### PR TITLE
fix(ci): align deploy smoke host-rule check with templated domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1098,11 +1098,14 @@ jobs:
             # Test 5: GitOps - verify docker-compose.prod.yml has correct Traefik labels
             echo "Test 5: GitOps configuration check..."
             cd ${{ env.DEPLOY_PATH }}
-            if grep -q 'traefik.http.routers.moltis.rule=Host(`moltis.ainetic.tech`)' docker-compose.prod.yml; then
-              echo "GitOps: Traefik Host rule correct (moltis.ainetic.tech)"
+            if grep -qE 'traefik\.http\.routers\.moltis\.rule=Host\(`(\$\{MOLTIS_DOMAIN(:-[^}]*)?\}|moltis\.ainetic\.tech)`\)' docker-compose.prod.yml; then
+              echo "GitOps: Traefik Host rule check passed (literal or MOLTIS_DOMAIN template)"
             else
               echo "::error::GitOps violation: Traefik Host rule mismatch in docker-compose.prod.yml"
-              echo "Expected: Host(\`moltis.ainetic.tech\`)"
+              echo "Expected one of:"
+              echo "  - Host(\`moltis.ainetic.tech\`)"
+              echo "  - Host(\`\${MOLTIS_DOMAIN:-moltis.ainetic.tech}\`)"
+              echo "  - Host(\`\${MOLTIS_DOMAIN}\`)"
               echo "Found in file:"
               grep "traefik.http.routers.moltis.rule" docker-compose.prod.yml || echo "(not found)"
               exit 1


### PR DESCRIPTION
## Summary
- fixes false negative in deploy smoke test (Post-deployment Verification)
- accepts both literal host rule and templated `${MOLTIS_DOMAIN...}` form in `docker-compose.prod.yml`

## Why
Latest main deployment failed smoke test despite successful deploy because the check expected only literal `Host(`moltis.ainetic.tech`)` while the file uses a templated host rule.

## Validation
- YAML parse: `.github/workflows/deploy.yml`
