### PR TITLE
fix(ci): make GitOps drift issue creation resilient + RCA

### DIFF
--- a/.github/workflows/gitops-drift-detection.yml
+++ b/.github/workflows/gitops-drift-detection.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   SSH_HOST: ainetic.tech
   SSH_USER: root
@@ -103,12 +107,18 @@ jobs:
       - name: Create issue on drift
         if: steps.drift.outputs.drift_found == 'true'
         run: |
-          # Check for existing open drift issue to prevent duplicates
-          EXISTING=$(gh issue list --repo ${{ github.repository }} --label drift --state open --limit 1 --json number 2>/dev/null || echo "[]")
+          # Check for existing open drift issue to prevent duplicates.
+          # Search by title to avoid hard dependency on labels.
+          EXISTING_NUMBER=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --state open \
+            --search "GitOps Drift Detected in:title" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || true)
 
-          if [ "$EXISTING" != "[]" ] && [ -n "$EXISTING" ]; then
-            echo "::warning::Open drift issue already exists. Skipping issue creation."
-            echo "Existing issue: $EXISTING"
+          if [ -n "$EXISTING_NUMBER" ]; then
+            echo "::warning::Open drift issue #$EXISTING_NUMBER already exists. Skipping issue creation."
             exit 0
           fi
 
@@ -140,11 +150,33 @@ jobs:
           *Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)*
           "
 
-          gh issue create \
+          # Create issue in non-blocking mode.
+          set +e
+          ISSUE_URL=$(gh issue create \
             --repo ${{ github.repository }} \
             --title "🔍 GitOps Drift Detected - $(date -u +%Y-%m-%d)" \
-            --body "$ISSUE_BODY" \
-            --label "gitops,drift,automation"
+            --body "$ISSUE_BODY" 2>/tmp/gh-issue-create.err)
+          CREATE_EXIT=$?
+          set -e
+
+          if [ $CREATE_EXIT -ne 0 ] || [ -z "$ISSUE_URL" ]; then
+            echo "::warning::Could not create drift issue (non-blocking)."
+            if [ -s /tmp/gh-issue-create.err ]; then
+              echo "::warning::$(tail -n 1 /tmp/gh-issue-create.err)"
+            fi
+            exit 0
+          fi
+
+          ISSUE_NUMBER="${ISSUE_URL##*/}"
+          if ! gh issue edit "$ISSUE_NUMBER" \
+            --repo ${{ github.repository }} \
+            --add-label "gitops" \
+            --add-label "drift" \
+            --add-label "automation" >/dev/null 2>&1; then
+            echo "::warning::Issue created without labels (labels missing or token lacks permissions)."
+          fi
+
+          echo "::notice::Drift issue created: $ISSUE_URL"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-07
-**Total Lessons**: 7
+**Total Lessons**: 8
 
 ---
 
@@ -10,6 +10,9 @@
 
 ### By Severity
 
+
+#### P2 (1 lessons)
+- [Повторяющиеся падения GitHub Actions workflow (Drift + Deploy)](../docs/rca/2026-03-07-github-workflows-recurring-failures.md)
 
 #### P3 (4 lessons)
 - [2026-03-03-sample-enhanced-rca](../docs/rca/2026-03-03-sample-enhanced-rca.md)
@@ -23,6 +26,9 @@
 
 ### By Category
 
+
+#### cicd (1 lessons)
+- [Повторяющиеся падения GitHub Actions workflow (Drift + Deploy)](../docs/rca/2026-03-07-github-workflows-recurring-failures.md)
 
 #### generic (4 lessons)
 - [2026-03-03-sample-enhanced-rca](../docs/rca/2026-03-03-sample-enhanced-rca.md)
@@ -67,9 +73,9 @@
 - `recurring-issue` (1 lessons)
 - `protocol` (1 lessons)
 - `process` (1 lessons)
+- `permissions` (1 lessons)
 - `instructions` (1 lessons)
-- `file-deletion` (1 lessons)
-- `false` (1 lessons)
+- `gitops` (1 lessons)
 
 
 ---
@@ -78,10 +84,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 7 |
+| Total Lessons | 8 |
 | Critical (P0/P1) | 0 |
-| Categories | 4 |
-| Unique Tags | 11 |
+| Categories | 5 |
+| Unique Tags | 16 |
 
 ---
 

--- a/docs/rca/2026-03-07-github-workflows-recurring-failures.md
+++ b/docs/rca/2026-03-07-github-workflows-recurring-failures.md
@@ -1,0 +1,102 @@
+---
+title: "Повторяющиеся падения GitHub Actions workflow (Drift + Deploy)"
+date: 2026-03-07
+severity: P2
+category: cicd
+tags: [github-actions, gitops, drift-detection, deploy, permissions]
+root_cause: "Хрупкие проверки и зависимость от labels/permissions без graceful fallback приводили к ложным падениям workflow"
+---
+
+# RCA: Повторяющиеся падения GitHub Actions workflow (Drift + Deploy)
+
+**Дата:** 2026-03-07
+**Статус:** Resolved
+**Влияние:** Среднее; шумные false-positive падения CI/CD и потеря доверия к алертам
+**Контекст:** Анализ инцидентов из GitHub Actions email alerts и стабилизация workflow без усложнения пайплайна
+
+## Context
+
+| Field | Value |
+|-------|-------|
+| Timestamp | 2026-03-07T07:19:57Z |
+| PWD | /Users/rl/.codex/worktrees/27e8/moltinger |
+| Shell | /bin/zsh |
+| Git Branch | codex/better-deploy |
+| Git Commit | e412200 |
+| Git Status | modified (workflow files + RCA report) |
+| Docker Version | Docker version 29.2.1, build a5c7197 |
+| Disk Usage | 5% used on `/` |
+| Memory | macOS vm_stat collected |
+| Error Type | cicd |
+
+## Error Classification (Chain-of-Thought)
+
+| Field | Value |
+|-------|-------|
+| Error Type | process/config |
+| Confidence | high |
+| Context Quality | sufficient |
+
+### Hypotheses
+
+| # | Hypothesis | Confidence |
+|---|------------|------------|
+| H1 | Workflow падал из-за недостаточных permissions при работе с GitHub Issues labels | 85% |
+| H2 | Smoke-check в deploy слишком жёстко проверял только один формат Traefik rule | 90% |
+| H3 | Частота ошибок увеличивалась из-за отсутствия non-blocking fallback для вторичных операций (issue labels) | 75% |
+
+## Ошибка
+
+Наблюдались повторяющиеся ошибки в GitHub Actions:
+
+1. `GitOps Drift Detection` run `22793973357` (2026-03-07T06:37:37Z) падал на шаге `Create issue on drift` с ошибкой:
+   - `error fetching labels: GraphQL: Resource not accessible by integration (repository.labels)`
+2. `Deploy Moltis` run `22793996452` (2026-03-07T06:39:12Z) падал на шаге `Run smoke tests`:
+   - проверка ожидала только `Host(\`moltis.ainetic.tech\`)`,
+   - но в `docker-compose.prod.yml` фактически использовался templated вариант `Host(\`${MOLTIS_DOMAIN:-moltis.ainetic.tech}\`)`.
+
+## Анализ 5 Почему (with Evidence)
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему workflow падали часто? | Из-за hard-fail на вторичных/хрупких проверках | Runs `22793973357`, `22793996452` завершились `failure` |
+| 2 | Почему `GitOps Drift Detection` падал при создании issue? | Использовалась label-зависимая операция без гарантированных прав и fallback | Лог: `Resource not accessible by integration (repository.labels)` |
+| 3 | Почему `Deploy Moltis` падал при успешном фактическом деплое? | Smoke test проверял только один строковый вариант Host rule | Лог run `22793996452`: expected static rule, found templated rule |
+| 4 | Почему такие проверки дошли в `main`? | Проверки workflow ориентированы на "строгое соответствие", но без допусков на эквивалентные конфигурации и без graceful degradation | В `deploy.yml` был один `grep`; в `gitops-drift-detection.yml` не было non-blocking path |
+| 5 | Почему ошибка стала повторяющейся? | Не было унифицированного паттерна "critical vs non-critical step" в GitHub Actions | Повторяющиеся alert-падения при том, что суть drift detection/health уже была отработана |
+
+## Корневая причина
+
+В workflow отсутствовал системный шаблон надежности: операции уведомления (issue/labels) и проверка конфигурации использовали brittle правила и hard-fail без учета эквивалентных конфигураций и ограничений `GITHUB_TOKEN`.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| □ Actionable? | yes | Исправляется правками workflow |
+| □ Systemic? | yes | Паттерн применим к нескольким pipeline |
+| □ Preventable? | yes | Через least-privilege permissions + graceful fallback + tolerant checks |
+
+## Принятые меры
+
+1. **Немедленное исправление:** В `gitops-drift-detection.yml` добавлены `permissions` и non-blocking логика создания issue (без hard dependency на labels).
+2. **Предотвращение:** В `deploy.yml` smoke-check Traefik Host rule теперь принимает оба валидных формата: static и templated.
+3. **Документация:** Создан этот RCA-отчёт; уроки добавлены в индекс lessons.
+
+## Связанные обновления
+
+- [X] RCA-отчёт создан в `docs/rca/`
+- [X] Раздел `## Уроки` добавлен
+- [X] Индекс уроков пересобран (`./scripts/build-lessons-index.sh`)
+- [ ] Новый файл правила создан (не требовалось)
+- [ ] Ссылка в CLAUDE.md добавлена (не требовалось)
+
+## Уроки
+
+1. **Не завязывать алертинг на labels как обязательный путь** — issue creation должна деградировать в warning, а не валить job.
+2. **Smoke-тесты должны проверять семантику, а не единственную строку** — эквивалентные конфиги (static/templated) должны считаться валидными.
+3. **Разделять критичные и некритичные шаги CI/CD** — failure должен означать реальный инцидент, а не проблему оформления уведомления.
+
+---
+
+*Создано по протоколу RCA (5 Why) для инцидентов GitHub Actions runs `22793973357` и `22793996452`.*


### PR DESCRIPTION
## Summary
- harden `GitOps Drift Detection` issue creation path (non-blocking, dedupe by title, explicit permissions)
- keep drift signal while avoiding hard-fail on issue-label edge cases
- add RCA report and lessons index update for recurring workflow failures

## Validation
- local YAML parse OK for updated workflows
- manual run on branch succeeded: `22794633702`
- after operational sync, main drift check passed: `22794925363`

## Notes
- repository labels (`gitops`, `drift`, `automation`, `slo-breach`, `alert`) were created to support workflow labeling
