### PR TITLE
fix(ci): grant issue permissions for GitOps alert workflows

### DIFF
--- a/.github/workflows/gitops-drift-detection.yml
+++ b/.github/workflows/gitops-drift-detection.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   SSH_HOST: ainetic.tech
   SSH_USER: root

--- a/.github/workflows/gitops-metrics.yml
+++ b/.github/workflows/gitops-metrics.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   SSH_HOST: ainetic.tech
   SSH_USER: root


### PR DESCRIPTION
## What
- add explicit GitHub token permissions to GitOps workflows
- set `issues: write` so alert issue creation does not fail with `Resource not accessible by integration`

## Why
Scheduled/workflow-dispatch drift/metrics jobs may need to create issues. Without explicit permissions, issue+label API calls can fail.

## Validation
- YAML parse check passed for both workflows
- change is limited to workflow permissions block
