### PR TITLE
Add git session and RCA guards to commit/push hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,8 +3,16 @@
 # GitOps-compliant: Non-blocking, adds metadata only
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+GUARD_SCRIPT="$PROJECT_ROOT/scripts/git-session-guard.sh"
 SESSION_FILE="$PROJECT_ROOT/SESSION_SUMMARY.md"
 LOG_FILE="$PROJECT_ROOT/.tmp/sessions/precommit.log"
+
+# Enforce branch/worktree session consistency before commit.
+if [[ -x "$GUARD_SCRIPT" ]]; then
+    if ! "$GUARD_SCRIPT" --check --hook pre-commit; then
+        exit 1
+    fi
+fi
 
 # Create log directory if needed
 mkdir -p "$(dirname "$LOG_FILE")"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Pre-push: block pushes on session drift or incomplete RCA protocol.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+SESSION_GUARD="$PROJECT_ROOT/scripts/git-session-guard.sh"
+RCA_GUARD="$PROJECT_ROOT/scripts/rca-completion-check.sh"
+
+if [[ -x "$SESSION_GUARD" ]]; then
+  "$SESSION_GUARD" --check --hook pre-push
+fi
+
+if [[ -x "$RCA_GUARD" ]]; then
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    if [[ -z "${local_ref:-}" ]]; then
+      continue
+    fi
+
+    # Deleting remote refs should not trigger RCA checks.
+    if [[ "${local_sha}" =~ ^0+$ ]]; then
+      continue
+    fi
+
+    if [[ "${remote_sha}" =~ ^0+$ ]]; then
+      "$RCA_GUARD" --check --range "${local_sha}" --hook pre-push
+    elif ! git cat-file -e "${remote_sha}^{commit}" 2>/dev/null; then
+      "$RCA_GUARD" --check --range "${local_sha}" --hook pre-push
+    else
+      "$RCA_GUARD" --check --range "${remote_sha}..${local_sha}" --hook pre-push
+    fi
+  done
+fi
+
+exit 0

--- a/scripts/git-session-guard.sh
+++ b/scripts/git-session-guard.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/git-session-guard.sh [--check] [--hook <name>]
+  scripts/git-session-guard.sh --refresh
+  scripts/git-session-guard.sh --status
+
+Description:
+  Guard against accidental branch/worktree drift across parallel sessions.
+  State is stored in the repository git dir and validated by git hooks.
+EOF
+}
+
+action="check"
+hook_name=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      action="check"
+      shift
+      ;;
+    --refresh)
+      action="refresh"
+      shift
+      ;;
+    --status)
+      action="status"
+      shift
+      ;;
+    --hook)
+      hook_name="${2:-}"
+      if [[ -z "${hook_name}" ]]; then
+        echo "[git-session-guard] --hook requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[git-session-guard] Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "[git-session-guard] Not inside a git repository; skipping."
+  exit 0
+fi
+
+state_file="$(git rev-parse --git-path session-guard.state)"
+
+current_branch="$(git symbolic-ref --short -q HEAD || true)"
+current_worktree="$(cd "${git_root}" && pwd -P)"
+now_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+expected_branch=""
+expected_worktree=""
+created_at=""
+updated_at=""
+
+load_state() {
+  if [[ ! -f "${state_file}" ]]; then
+    return 1
+  fi
+
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      expected_branch) expected_branch="${value}" ;;
+      expected_worktree) expected_worktree="${value}" ;;
+      created_at) created_at="${value}" ;;
+      updated_at) updated_at="${value}" ;;
+    esac
+  done < "${state_file}"
+
+  return 0
+}
+
+write_state() {
+  local created="$1"
+  cat > "${state_file}" <<EOF
+expected_branch=${current_branch}
+expected_worktree=${current_worktree}
+created_at=${created}
+updated_at=${now_utc}
+EOF
+}
+
+fail_guard() {
+  local reason="$1"
+  if [[ -n "${hook_name}" ]]; then
+    echo "[git-session-guard] ${hook_name} blocked: ${reason}" >&2
+  else
+    echo "[git-session-guard] ${reason}" >&2
+  fi
+
+  echo "[git-session-guard] current: branch='${current_branch:-DETACHED}', worktree='${current_worktree}'" >&2
+  echo "[git-session-guard] expected: branch='${expected_branch:-<unset>}', worktree='${expected_worktree:-<unset>}'" >&2
+  echo "[git-session-guard] If this switch is intentional, run: scripts/git-session-guard.sh --refresh" >&2
+  exit 1
+}
+
+if [[ "${action}" == "refresh" ]]; then
+  if [[ -z "${current_branch}" ]]; then
+    echo "[git-session-guard] Cannot refresh while HEAD is detached." >&2
+    exit 1
+  fi
+
+  if load_state; then
+    write_state "${created_at:-${now_utc}}"
+    echo "[git-session-guard] Refreshed: ${current_branch} @ ${current_worktree}"
+  else
+    write_state "${now_utc}"
+    echo "[git-session-guard] Initialized: ${current_branch} @ ${current_worktree}"
+  fi
+  exit 0
+fi
+
+if [[ "${action}" == "status" ]]; then
+  if ! load_state; then
+    echo "[git-session-guard] No guard state yet. Run: scripts/git-session-guard.sh --refresh"
+    exit 0
+  fi
+
+  echo "state_file=${state_file}"
+  echo "expected_branch=${expected_branch}"
+  echo "expected_worktree=${expected_worktree}"
+  echo "created_at=${created_at}"
+  echo "updated_at=${updated_at}"
+  echo "current_branch=${current_branch:-DETACHED}"
+  echo "current_worktree=${current_worktree}"
+
+  if [[ -z "${current_branch}" ]]; then
+    echo "status=detached_head"
+    exit 1
+  fi
+
+  if [[ "${current_branch}" != "${expected_branch}" || "${current_worktree}" != "${expected_worktree}" ]]; then
+    echo "status=drift"
+    exit 1
+  fi
+
+  echo "status=ok"
+  exit 0
+fi
+
+# action=check
+if [[ -z "${current_branch}" ]]; then
+  fail_guard "Detached HEAD is not allowed for guarded sessions."
+fi
+
+if ! load_state; then
+  write_state "${now_utc}"
+  echo "[git-session-guard] Initialized guard state for '${current_branch}'."
+  exit 0
+fi
+
+if [[ -z "${expected_branch}" || -z "${expected_worktree}" ]]; then
+  fail_guard "Corrupted guard state."
+fi
+
+if [[ "${current_branch}" != "${expected_branch}" ]]; then
+  fail_guard "Branch drift detected."
+fi
+
+if [[ "${current_worktree}" != "${expected_worktree}" ]]; then
+  fail_guard "Worktree drift detected."
+fi
+
+exit 0

--- a/scripts/rca-completion-check.sh
+++ b/scripts/rca-completion-check.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/rca-completion-check.sh --check [--range <git-range>] [--hook <name>]
+
+Description:
+  Blocks incomplete RCA protocol pushes.
+  If commits include RCA reports (docs/rca/YYYY-MM-DD-*.md), they must also include
+  instruction updates (AGENTS.md, CLAUDE.md, or docs/rules/*.md).
+EOF
+}
+
+action="check"
+range_arg=""
+hook_name=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      action="check"
+      shift
+      ;;
+    --range)
+      range_arg="${2:-}"
+      if [[ -z "${range_arg}" ]]; then
+        echo "[rca-completion-check] --range requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --hook)
+      hook_name="${2:-}"
+      if [[ -z "${hook_name}" ]]; then
+        echo "[rca-completion-check] --hook requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[rca-completion-check] Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${action}" != "check" ]]; then
+  echo "[rca-completion-check] Unsupported action: ${action}" >&2
+  exit 2
+fi
+
+if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "[rca-completion-check] Not inside a git repository; skipping."
+  exit 0
+fi
+
+cd "${git_root}"
+
+range_to_check="${range_arg}"
+if [[ -z "${range_to_check}" ]]; then
+  if git rev-parse --verify --quiet '@{upstream}' >/dev/null; then
+    range_to_check='@{upstream}..HEAD'
+  else
+    range_to_check='HEAD'
+  fi
+fi
+
+collect_files() {
+  local range="$1"
+  if [[ "${range}" == *".."* ]]; then
+    git diff --name-only "${range}"
+  else
+    git show --name-only --pretty='format:' "${range}"
+  fi
+}
+
+changed_files="$(collect_files "${range_to_check}" | sed '/^$/d' | sort -u)"
+if [[ -z "${changed_files}" ]]; then
+  exit 0
+fi
+
+rca_files="$(printf '%s\n' "${changed_files}" | grep -E '^docs/rca/[0-9]{4}-[0-9]{2}-[0-9]{2}-.*\.md$' || true)"
+if [[ -z "${rca_files}" ]]; then
+  exit 0
+fi
+
+instruction_files="$(printf '%s\n' "${changed_files}" | grep -E '^(AGENTS\.md|CLAUDE\.md|docs/rules/.+\.md)$' || true)"
+if [[ -n "${instruction_files}" ]]; then
+  echo "[rca-completion-check] RCA protocol check passed for ${range_to_check}."
+  exit 0
+fi
+
+if [[ -n "${hook_name}" ]]; then
+  echo "[rca-completion-check] ${hook_name} blocked: incomplete RCA protocol." >&2
+else
+  echo "[rca-completion-check] Incomplete RCA protocol." >&2
+fi
+echo "[rca-completion-check] Range: ${range_to_check}" >&2
+echo "[rca-completion-check] RCA files detected:" >&2
+while IFS= read -r rca_file; do
+  [[ -n "${rca_file}" ]] || continue
+  echo "  - ${rca_file}" >&2
+done <<< "${rca_files}"
+echo "[rca-completion-check] Required additional changes: AGENTS.md, CLAUDE.md, or docs/rules/*.md" >&2
+echo "[rca-completion-check] Add instruction updates, then retry push." >&2
+exit 1

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -2,7 +2,7 @@
 # Setup Git Hooks for Session Management
 # Run once after cloning repo or when hooks are updated
 
-set -e
+set -euo pipefail
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo '.')"
 HOOKS_DIR="$PROJECT_ROOT/.githooks"
@@ -19,8 +19,16 @@ cat > "$HOOKS_DIR/pre-commit" << 'EOF'
 # GitOps-compliant: Non-blocking, adds metadata only
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-SESSION_FILE="$PROJECT_ROOT/SESSION_STATE.md"
+GUARD_SCRIPT="$PROJECT_ROOT/scripts/git-session-guard.sh"
+SESSION_FILE="$PROJECT_ROOT/SESSION_SUMMARY.md"
 LOG_FILE="$PROJECT_ROOT/.tmp/sessions/precommit.log"
+
+# Enforce branch/worktree session consistency before commit.
+if [[ -x "$GUARD_SCRIPT" ]]; then
+    if ! "$GUARD_SCRIPT" --check --hook pre-commit; then
+        exit 1
+    fi
+fi
 
 # Create log directory if needed
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -34,9 +42,9 @@ DATE=$(date +%Y-%m-%d)
 COMMIT_MSG=$(head -1 "$PROJECT_ROOT/.git/COMMIT_EDITMSG" 2>/dev/null || echo "commit")
 COMMIT_SHORT=$(echo "$COMMIT_MSG" | head -c 60)
 
-# Skip if SESSION_STATE.md is in this commit (avoid loop)
-if git diff --cached --name-only | grep -q "SESSION_STATE.md"; then
-    echo "📝 SESSION_STATE.md in commit, skipping pre-commit update"
+# Skip if SESSION_SUMMARY.md is in this commit (avoid loop)
+if git diff --cached --name-only | grep -q "SESSION_SUMMARY.md"; then
+    echo "📝 SESSION_SUMMARY.md in commit, skipping pre-commit update"
     exit 0
 fi
 
@@ -49,11 +57,53 @@ EOF
 
 chmod +x "$HOOKS_DIR/pre-commit"
 
+# Create pre-push hook
+cat > "$HOOKS_DIR/pre-push" << 'EOF'
+#!/bin/bash
+# Pre-push: block pushes on session drift or incomplete RCA protocol.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+SESSION_GUARD="$PROJECT_ROOT/scripts/git-session-guard.sh"
+RCA_GUARD="$PROJECT_ROOT/scripts/rca-completion-check.sh"
+
+if [[ -x "$SESSION_GUARD" ]]; then
+  "$SESSION_GUARD" --check --hook pre-push
+fi
+
+if [[ -x "$RCA_GUARD" ]]; then
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    if [[ -z "${local_ref:-}" ]]; then
+      continue
+    fi
+
+    # Deleting remote refs should not trigger RCA checks.
+    if [[ "${local_sha}" =~ ^0+$ ]]; then
+      continue
+    fi
+
+    if [[ "${remote_sha}" =~ ^0+$ ]]; then
+      "$RCA_GUARD" --check --range "${local_sha}" --hook pre-push
+    elif ! git cat-file -e "${remote_sha}^{commit}" 2>/dev/null; then
+      "$RCA_GUARD" --check --range "${local_sha}" --hook pre-push
+    else
+      "$RCA_GUARD" --check --range "${remote_sha}..${local_sha}" --hook pre-push
+    fi
+  done
+fi
+
+exit 0
+EOF
+
+chmod +x "$HOOKS_DIR/pre-push"
+
 # Configure git to use .githooks
 git config core.hooksPath "$HOOKS_DIR"
 
 echo "✅ Git hooks configured:"
-echo "   - pre-commit: Session state logging"
+echo "   - pre-commit: Session logging + session guard"
+echo "   - pre-push: Session guard + RCA completion guard"
 echo ""
 echo "📁 Hooks location: $HOOKS_DIR"
 echo "⚙️  Git core.hooksPath: $(git config core.hooksPath)"


### PR DESCRIPTION
Summary
- enforce the new git-session-guard from pre-commit and pre-push to block drift and detached HEADs
- add a pre-push hook wiring RCA completion checks and update setup script so hooks and messages reference SESSION_SUMMARY.md instead of SESSION_STATE.md
- introduce scripts/git-session-guard.sh and scripts/rca-completion-check.sh along with hook scaffolding

Testing
- Not run (not requested)