### PR TITLE
fix(ci): stabilize GitOps Metrics workflow SSH metrics collection

### DIFF
--- a/.github/workflows/gitops-metrics.yml
+++ b/.github/workflows/gitops-metrics.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   SSH_HOST: ainetic.tech
   SSH_USER: root


### PR DESCRIPTION
Replacement for closed PR #3.

This respins the useful part on a fresh branch from main and carries only the GitHub Actions workflow fix in `.github/workflows/gitops-metrics.yml`, without `.beads/issues.jsonl` noise.