### PR TITLE
docs(topology): refresh registry after main merge

### DIFF
--- a/docs/GIT-TOPOLOGY-REGISTRY.md
+++ b/docs/GIT-TOPOLOGY-REGISTRY.md
@@ -50,7 +50,7 @@
 | `011-worktree-handoff-hardening` | `origin/011-worktree-handoff-hardening` | Needs decision |
 | `012-codex-upstream-watcher` | `origin/012-codex-upstream-watcher` | Needs decision |
 | `012-codex-upstream-watcher-writable` | `origin/012-codex-upstream-watcher` | Needs decision |
-| `016-beads-local-db-ux` | `origin/016-beads-local-db-ux` | Needs decision |
+| `016-beads-local-db-ux` | `gone` | Tracking ref is gone; needs decision |
 | `016-clawdiy-restore-readiness-fix` | `origin/016-clawdiy-restore-readiness-fix` | Needs decision |
 | `016-worktree-skill-bug-fix` | `none` | Needs decision |
 | `codex/full-review` | `origin/codex/full-review` | Open parallel branch; separate worktree exists. |
@@ -103,14 +103,11 @@
 | `origin/008-codex-update-advisor` | Needs decision |
 | `origin/009-codex-update-delivery-ux` | Needs decision |
 | `origin/010-beads-recovery-batch` | Needs decision |
-| `origin/011-remote-uat-hardening` | Needs decision |
-| `origin/011-worktree-handoff-hardening` | Needs decision |
 | `origin/011-worktree-skill-extraction` | Needs decision |
 | `origin/012-codex-upstream-watcher` | Needs decision |
 | `origin/013-clawdiy-state-hardening` | Needs decision |
 | `origin/014-clawdiy-smoke-jq-fix` | Needs decision |
 | `origin/015-clawdiy-smoke-mount-resolution` | Needs decision |
-| `origin/016-beads-local-db-ux` | Needs decision |
 | `origin/codex/004-telegram-e2e-harness` | Source for future Telegram consolidation. |
 | `origin/codex/fix-bot` | Source for future Telegram consolidation. |
 | `origin/codex/webhook-moltinger` | Source for future Telegram consolidation. |


### PR DESCRIPTION
## Summary
- refresh the generated git topology registry after the original PR #37 landing
- drop remote branches that are now merged into main from the unmerged-remote section
- capture current tracking state for remaining local branches/worktrees

## Validation
- scripts/git-topology-registry.sh check
