### PR TITLE
fix: restore Moltis official Docker latest channel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,9 @@ on:
           - production
           - staging
       version:
-        description: 'Moltis image version (leave blank to use tracked git version, e.g. v0.10.18)'
+        description: 'Moltis image version (leave blank to use tracked git version, typically latest per official Docker docs)'
         required: false
-        default: 'v0.10.18'
+        default: 'latest'
         type: string
       rollback:
         description: 'Rollback to previous version'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
   # MOLTIS - Main Application
   # ========================================================================
   moltis:
-    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-v0.10.18}
+    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-latest}
     container_name: moltis
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ x-logging: &logging
 # ============================================================================
 services:
   moltis:
-    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-v0.10.18}
+    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-latest}
     container_name: moltis
     restart: unless-stopped
     # SECURITY: privileged mode required for Docker-in-Docker sandbox execution

--- a/docs/GIT-TOPOLOGY-REGISTRY.md
+++ b/docs/GIT-TOPOLOGY-REGISTRY.md
@@ -18,6 +18,7 @@
 | `moltinger-ewde-codex-advisory-rollout` | `feat/moltinger-ewde-codex-advisory-rollout` | `sibling-worktree` | Needs decision |
 | `moltinger-jb6-gpt54-primary` | `feat/moltinger-jb6-gpt54-primary` | `sibling-worktree` | Active sibling worktree for the GPT-5.4 primary provider-chain task. |
 | `moltinger-main-merge.hsq6oh` | `main` | `sibling-worktree` | Needs decision |
+| `moltinger-moltis-official-docker-update-v0-10-18` | `fix/moltis-official-docker-latest-channel` | `sibling-worktree` | Needs decision |
 | `moltinger-pr35` | `tmp-pr35-fix` | `sibling-worktree` | Needs decision |
 | `moltinger-pr38` | `tmp-pr38-verify` | `sibling-worktree` | Needs decision |
 | `moltinger-pr39` | `tmp-pr39-fix` | `sibling-worktree` | Needs decision |
@@ -29,7 +30,6 @@
 | `moltinger-z8m-2-moltis-skills-subagents-abilities-expansion` | `feat/moltinger-z8m-2-moltis-skills-subagents-abilities-expansion` | `sibling-worktree` | Needs decision |
 | `moltinger-z8m-3-moltis-git-container-update` | `feat/moltinger-z8m-3-moltis-git-container-update` | `sibling-worktree` | Needs decision |
 | `moltinger-z8m-4-moltis-post-update-error-remediation` | `feat/moltinger-z8m-4-moltis-post-update-error-remediation` | `sibling-worktree` | Needs decision |
-| `moltis-official-docker-update-v0-10-18` | `feat/moltis-official-docker-update-v0-10-18` | `sibling-worktree` | Needs decision |
 | `primary-feature-008` | `008-codex-update-advisor` | `dedicated-feature-worktree` | Needs decision |
 | `primary-feature-009` | `009-codex-update-delivery-ux` | `dedicated-feature-worktree` | Needs decision |
 | `primary-feature-012` | `012-codex-upstream-watcher` | `dedicated-feature-worktree` | Needs decision |
@@ -64,9 +64,9 @@
 | `feat/moltinger-z8m-2-moltis-skills-subagents-abilities-expansion` | `none` | Needs decision |
 | `feat/moltinger-z8m-3-moltis-git-container-update` | `origin/feat/moltinger-z8m-3-moltis-git-container-update` | Needs decision |
 | `feat/moltinger-z8m-4-moltis-post-update-error-remediation` | `origin/feat/moltinger-z8m-4-moltis-post-update-error-remediation` | Needs decision |
-| `feat/moltis-official-docker-update-v0-10-18` | `origin/feat/moltis-official-docker-update-v0-10-18` | Needs decision |
 | `fix/beads-recovery-audit-localization` | `origin/fix/beads-recovery-audit-localization` | Needs decision |
-| `fix/beads-root-fallback-hardening` | `none` | Needs decision |
+| `fix/beads-root-fallback-hardening` | `origin/fix/beads-root-fallback-hardening` | Needs decision |
+| `fix/moltis-official-docker-latest-channel` | `origin/main` | Needs decision |
 | `tmp-pr35-fix` | `gone` | Tracking ref is gone; needs decision |
 | `tmp-pr38-verify` | `origin/015-clawdiy-smoke-mount-resolution` | Needs decision |
 | `tmp-pr39-fix` | `origin/012-codex-upstream-watcher` | Needs decision |
@@ -99,6 +99,7 @@
 | `codex/webhook-main-backfill` | `origin/codex/webhook-main-backfill` | Needs decision |
 | `codex/webhook-moltinger` | `origin/codex/webhook-moltinger` | Valuable but broad operational branch; extract selectively. |
 | `feat/molt-2-codex-update-monitor-new` | `origin/feat/molt-2-codex-update-monitor-new` | Needs decision |
+| `feat/moltis-official-docker-update-v0-10-18` | `origin/feat/moltis-official-docker-update-v0-10-18` | Needs decision |
 | `feat/openclaw-control-plane` | `none` | Needs decision |
 | `test/rca-guard-uat-20260307-0004` | `none` | Local-only test branch. |
 | `test/rca-guard-uat-20260307-0015` | `gone` | Local-only stale test branch with gone upstream. |
@@ -131,8 +132,8 @@
 | `origin/feat/moltinger-z8m-1-moltis-backup-rollback-baseline` | Needs decision |
 | `origin/feat/moltinger-z8m-3-moltis-git-container-update` | Needs decision |
 | `origin/feat/moltinger-z8m-4-moltis-post-update-error-remediation` | Needs decision |
-| `origin/feat/moltis-official-docker-update-v0-10-18` | Needs decision |
 | `origin/fix/beads-recovery-audit-localization` | Needs decision |
+| `origin/fix/beads-root-fallback-hardening` | Needs decision |
 
 ## Reviewed Intent Awaiting Reconciliation
 

--- a/scripts/moltis-version.sh
+++ b/scripts/moltis-version.sh
@@ -15,7 +15,7 @@ Commands:
   version         Print the tracked Moltis version from compose files
   image           Print the tracked Moltis image reference from compose files
   assert-tracked  Fail unless docker-compose.yml and docker-compose.prod.yml
-                  resolve to the same pinned Moltis image (not latest)
+                  resolve to the same git-managed Moltis image reference
 EOF
 }
 
@@ -77,10 +77,6 @@ assert_tracked_contract() {
         return 1
     fi
 
-    if [[ "$version" == "latest" ]]; then
-        echo "Tracked Moltis version must be pinned in git; 'latest' is forbidden" >&2
-        return 1
-    fi
 }
 
 main() {

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -91,13 +91,13 @@ run_static_config_validation_tests() {
         test_pass
     fi
 
-    test_start "static_moltis_version_contract_is_pinned"
+    test_start "static_moltis_version_contract_matches_official_docker_channel"
     if [[ -x "$MOLTIS_VERSION_SCRIPT" ]] && \
        "$MOLTIS_VERSION_SCRIPT" assert-tracked && \
-       [[ "$("$MOLTIS_VERSION_SCRIPT" version)" != "latest" ]]; then
+       [[ "$("$MOLTIS_VERSION_SCRIPT" version)" == "latest" ]]; then
         test_pass
     else
-        test_fail "Tracked Moltis version must be pinned in git and validated by scripts/moltis-version.sh"
+        test_fail "Tracked Moltis version must match the official Docker channel in git and be validated by scripts/moltis-version.sh"
     fi
 
     test_start "static_fixture_disables_openai_for_pr_gate"
@@ -149,10 +149,10 @@ run_static_config_validation_tests() {
     if rg -q 'scripts/moltis-version\.sh version' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        rg -q 'Production deploys must run from main' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        rg -q 'Production workflow_dispatch must use tracked Moltis version' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
-       ! rg -q "default: 'latest'" "$PROJECT_ROOT/.github/workflows/deploy.yml"; then
+       rg -q "default: 'latest'" "$PROJECT_ROOT/.github/workflows/deploy.yml"; then
         test_pass
     else
-        test_fail "Deploy workflow must resolve a tracked Moltis version and block feature-branch production deploys"
+        test_fail "Deploy workflow must resolve the tracked Moltis version, stay on the official latest channel, and block feature-branch production deploys"
     fi
 
     test_start "static_clawdiy_workflow_exists"


### PR DESCRIPTION
## Summary\n- restore ghcr.io/moltis-org/moltis:latest as the tracked Docker channel from official Moltis docs\n- keep production deploys blocked outside main and tied to the tracked git-managed channel\n- update static validation to assert the official latest channel instead of a nonexistent release tag\n\n## Validation\n- scripts/moltis-version.sh version\n- scripts/moltis-version.sh assert-tracked\n- bash -n scripts/moltis-version.sh\n- env MOLTIS_PASSWORD=placeholder TELEGRAM_BOT_TOKEN=placeholder TAVILY_API_KEY=placeholder GLM_API_KEY=placeholder MOLTIS_DOMAIN=moltis.ainetic.tech docker compose -f docker-compose.prod.yml config --quiet\n- env MOLTIS_PASSWORD=placeholder TELEGRAM_BOT_TOKEN=placeholder TAVILY_API_KEY=placeholder GLM_API_KEY=placeholder MOLTIS_DOMAIN=moltis.ainetic.tech tests/static/test_config_validation.sh\n\n## Incident note\nPrevious production rollout from main failed at `Pull new image` because `ghcr.io/moltis-org/moltis:v0.10.18` was not available in GHCR. This patch aligns the repo back with the official Docker docs channel.