### PR TITLE
fix(beads): sanitize git env for resolver probes

### DIFF
--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -75,16 +75,31 @@ beads_resolve_normalize_path() {
   )
 }
 
+beads_resolve_git() {
+  env \
+    -u GIT_DIR \
+    -u GIT_WORK_TREE \
+    -u GIT_COMMON_DIR \
+    -u GIT_NAMESPACE \
+    -u GIT_INDEX_FILE \
+    -u GIT_OBJECT_DIRECTORY \
+    -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+    -u GIT_PREFIX \
+    -u GIT_CEILING_DIRECTORIES \
+    -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
+    git "$@"
+}
+
 beads_resolve_repo_root() {
   local probe_path="${1:-$PWD}"
-  git -C "${probe_path}" rev-parse --show-toplevel 2>/dev/null || true
+  beads_resolve_git -C "${probe_path}" rev-parse --show-toplevel 2>/dev/null || true
 }
 
 beads_resolve_canonical_root() {
   local repo_root="$1"
   local common_dir=""
 
-  common_dir="$(git -C "${repo_root}" rev-parse --git-common-dir 2>/dev/null || true)"
+  common_dir="$(beads_resolve_git -C "${repo_root}" rev-parse --git-common-dir 2>/dev/null || true)"
   if [[ -z "${common_dir}" ]]; then
     return 1
   fi

--- a/tests/component/test_codex_cli_update_monitor.sh
+++ b/tests/component/test_codex_cli_update_monitor.sh
@@ -281,7 +281,8 @@ run_component_codex_cli_update_monitor_tests() {
     export FAKE_BD_STATE_DIR
     export FAKE_BD_CREATE_ID="moltinger-test-created"
     work_dir="$(secure_temp_dir codex-update-monitor)"
-    run_monitor_fixture_with_script "$worktree_path/scripts/codex-cli-update-monitor.sh" "0.110.0" "$work_dir" \
+    GIT_DIR="/no/such/git-dir" GIT_WORK_TREE="/no/such/git-work-tree" \
+        run_monitor_fixture_with_script "$worktree_path/scripts/codex-cli-update-monitor.sh" "0.110.0" "$work_dir" \
         --issue-action upsert
     report="$work_dir/report.json"
     assert_eq "created" "$(jq -r '.issue_action.mode' "$report")" "Dedicated worktree upsert should still resolve a local tracker automatically"
@@ -295,7 +296,8 @@ run_component_codex_cli_update_monitor_tests() {
     export PATH="$FAKE_BD_BIN_DIR:$original_path"
     export FAKE_BD_STATE_DIR
     work_dir="$(secure_temp_dir codex-update-monitor)"
-    run_monitor_fixture_with_script "$repo_dir/scripts/codex-cli-update-monitor.sh" "0.110.0" "$work_dir" \
+    GIT_DIR="/no/such/git-dir" GIT_WORK_TREE="/no/such/git-work-tree" \
+        run_monitor_fixture_with_script "$repo_dir/scripts/codex-cli-update-monitor.sh" "0.110.0" "$work_dir" \
         --issue-action upsert
     report="$work_dir/report.json"
     assert_eq "skipped" "$(jq -r '.issue_action.mode' "$report")" "Canonical-root upsert should fail closed without an explicit DB target"


### PR DESCRIPTION
## Summary
- sanitize `beads-resolve-db.sh` git probes so ambient `GIT_*` variables cannot hijack fixture/worktree detection
- harden the monitor component regression checks by running the implicit upsert/canonical-root cases under poisoned `GIT_DIR` and `GIT_WORK_TREE`
- keep the hotfix scoped to the post-merge red `component_codex_cli_update_monitor` path

## Testing
- `bash -n scripts/beads-resolve-db.sh`
- `bash -n tests/component/test_codex_cli_update_monitor.sh`
- `bash tests/component/test_codex_cli_update_monitor.sh`
- `TEST_REPORT_DIR=/tmp/monitor-run-canonical-fixed ./tests/run.sh --lane component --filter component_codex_cli_update_monitor --json`
- `bash tests/component/test_codex_cli_update_advisor.sh`
- `bash tests/static/test_beads_worktree_ownership.sh`
- `bash tests/unit/test_bd_dispatch.sh`
