### PR TITLE
fix(beads): add filesystem fallback for worktree detection

### DIFF
--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -90,9 +90,110 @@ beads_resolve_git() {
     git "$@"
 }
 
+beads_resolve_find_git_marker_root() {
+  local probe_path="${1:-$PWD}"
+  local cursor=""
+  local next_cursor=""
+
+  cursor="$(beads_resolve_normalize_path "${probe_path}")" || return 1
+  if [[ ! -d "${cursor}" ]]; then
+    cursor="$(dirname "${cursor}")"
+  fi
+
+  while [[ -n "${cursor}" ]]; do
+    if [[ -e "${cursor}/.git" ]]; then
+      printf '%s\n' "${cursor}"
+      return 0
+    fi
+
+    if [[ "${cursor}" == "/" ]]; then
+      break
+    fi
+
+    next_cursor="$(dirname "${cursor}")"
+    if [[ "${next_cursor}" == "${cursor}" ]]; then
+      break
+    fi
+    cursor="${next_cursor}"
+  done
+
+  return 1
+}
+
+beads_resolve_gitdir_path() {
+  local repo_root="$1"
+  local marker_path="${repo_root}/.git"
+  local gitdir_value=""
+
+  if [[ -d "${marker_path}" ]]; then
+    beads_resolve_normalize_path "${marker_path}"
+    return 0
+  fi
+
+  if [[ ! -f "${marker_path}" ]]; then
+    return 1
+  fi
+
+  gitdir_value="$(sed -n '1s/^gitdir: //p' "${marker_path}")"
+  [[ -n "${gitdir_value}" ]] || return 1
+
+  beads_resolve_normalize_path "${gitdir_value}" "${repo_root}"
+}
+
+beads_resolve_canonical_root_from_gitdir() {
+  local repo_root="$1"
+  local gitdir_path=""
+  local common_dir_rel=""
+  local common_dir=""
+
+  gitdir_path="$(beads_resolve_gitdir_path "${repo_root}")" || return 1
+
+  if [[ -d "${repo_root}/.git" ]]; then
+    printf '%s\n' "${repo_root}"
+    return 0
+  fi
+
+  if [[ -f "${gitdir_path}/commondir" ]]; then
+    common_dir_rel="$(<"${gitdir_path}/commondir")"
+    [[ -n "${common_dir_rel}" ]] || return 1
+    common_dir="$(beads_resolve_normalize_path "${common_dir_rel}" "${gitdir_path}")" || return 1
+  else
+    common_dir="${gitdir_path}"
+  fi
+
+  if [[ "$(basename "${common_dir}")" == ".git" ]]; then
+    (
+      cd "${common_dir}"
+      cd ..
+      pwd -P
+    )
+    return 0
+  fi
+
+  if [[ "$(basename "$(dirname "${common_dir}")")" == "worktrees" ]]; then
+    (
+      cd "${common_dir}"
+      cd ../..
+      cd ..
+      pwd -P
+    )
+    return 0
+  fi
+
+  return 1
+}
+
 beads_resolve_repo_root() {
   local probe_path="${1:-$PWD}"
-  beads_resolve_git -C "${probe_path}" rev-parse --show-toplevel 2>/dev/null || true
+  local repo_root=""
+
+  repo_root="$(beads_resolve_git -C "${probe_path}" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "${repo_root}" ]]; then
+    printf '%s\n' "${repo_root}"
+    return 0
+  fi
+
+  beads_resolve_find_git_marker_root "${probe_path}" || true
 }
 
 beads_resolve_canonical_root() {
@@ -101,7 +202,8 @@ beads_resolve_canonical_root() {
 
   common_dir="$(beads_resolve_git -C "${repo_root}" rev-parse --git-common-dir 2>/dev/null || true)"
   if [[ -z "${common_dir}" ]]; then
-    return 1
+    beads_resolve_canonical_root_from_gitdir "${repo_root}"
+    return $?
   fi
 
   (

--- a/tests/component/test_codex_cli_update_monitor.sh
+++ b/tests/component/test_codex_cli_update_monitor.sh
@@ -12,6 +12,7 @@ UPSTREAM_WATCHER_FIXTURE_DIR="$PROJECT_ROOT/tests/fixtures/codex-upstream-watche
 FAKE_BD_BIN_DIR=""
 FAKE_BD_STATE_DIR=""
 FAKE_BD_DB=""
+BROKEN_GIT_BIN_DIR=""
 
 setup_component_codex_update_monitor() {
     require_commands_or_skip jq python3 || return 2
@@ -59,6 +60,16 @@ case "$cmd" in
 esac
 EOF
     chmod +x "$FAKE_BD_BIN_DIR/bd"
+}
+
+setup_broken_git_fixture() {
+    BROKEN_GIT_BIN_DIR="$(secure_temp_dir broken-git-bin)"
+
+    cat > "$BROKEN_GIT_BIN_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$BROKEN_GIT_BIN_DIR/git"
 }
 
 seed_component_monitor_fixture_repo() {
@@ -277,11 +288,11 @@ run_component_codex_cli_update_monitor_tests() {
     worktree_path="$(canonicalize_fixture_path "$worktree_path")"
     seed_component_local_beads_foundation "$worktree_path"
     setup_fake_bd_fixture
-    export PATH="$FAKE_BD_BIN_DIR:$original_path"
+    setup_broken_git_fixture
     export FAKE_BD_STATE_DIR
     export FAKE_BD_CREATE_ID="moltinger-test-created"
     work_dir="$(secure_temp_dir codex-update-monitor)"
-    GIT_DIR="/no/such/git-dir" GIT_WORK_TREE="/no/such/git-work-tree" \
+    PATH="$FAKE_BD_BIN_DIR:$BROKEN_GIT_BIN_DIR:$original_path" \
         run_monitor_fixture_with_script "$worktree_path/scripts/codex-cli-update-monitor.sh" "0.110.0" "$work_dir" \
         --issue-action upsert
     report="$work_dir/report.json"
@@ -293,10 +304,10 @@ run_component_codex_cli_update_monitor_tests() {
     fixture_root="$(secure_temp_dir codex-update-monitor-fixture)"
     repo_dir="$(seed_component_monitor_fixture_repo "$fixture_root")"
     setup_fake_bd_fixture
-    export PATH="$FAKE_BD_BIN_DIR:$original_path"
+    setup_broken_git_fixture
     export FAKE_BD_STATE_DIR
     work_dir="$(secure_temp_dir codex-update-monitor)"
-    GIT_DIR="/no/such/git-dir" GIT_WORK_TREE="/no/such/git-work-tree" \
+    PATH="$FAKE_BD_BIN_DIR:$BROKEN_GIT_BIN_DIR:$original_path" \
         run_monitor_fixture_with_script "$repo_dir/scripts/codex-cli-update-monitor.sh" "0.110.0" "$work_dir" \
         --issue-action upsert
     report="$work_dir/report.json"


### PR DESCRIPTION
## Summary
- add a filesystem fallback in `scripts/beads-resolve-db.sh` so worktree ownership can still be resolved when `git rev-parse` is unavailable or broken in the caller environment
- keep the earlier `GIT_*` env sanitation and extend the resolver with `.git` marker and `commondir` discovery
- harden the monitor regression tests by forcing the implicit-upsert and canonical-root paths through a broken `git` binary, so CI exercises the fallback deterministically

## Why this follow-up exists
PR #67 sanitized ambient `GIT_*` variables, but `main` still failed the same two `component_codex_cli_update_monitor` cases in GitHub Actions. This patch adds a non-`git` fallback path so the resolver no longer depends solely on `git rev-parse` succeeding.

## Testing
- `bash -n scripts/beads-resolve-db.sh`
- `bash -n tests/component/test_codex_cli_update_monitor.sh`
- `bash tests/component/test_codex_cli_update_monitor.sh`
- `bash tests/component/test_codex_cli_update_advisor.sh`
- `bash tests/static/test_beads_worktree_ownership.sh`
- `bash tests/unit/test_bd_dispatch.sh`
- `TEST_REPORT_DIR=/tmp/monitor-run-canonical-fallback ./tests/run.sh --lane component --filter component_codex_cli_update_monitor --json`
- `docker run --rm -v "$PWD:/workspace" -w /workspace ubuntu:24.04 bash -lc 'set -euo pipefail; apt-get update -yqq; DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git jq python3 ripgrep ca-certificates >/dev/null; bash tests/component/test_codex_cli_update_monitor.sh'`
