### PR TITLE
docs(rca): add Moltis 0.10.18 stabilization RCA and refresh lessons

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-03-14
-**Total Lessons**: 29
+**Generated**: 2026-03-20
+**Total Lessons**: 31
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (8 lessons)
+#### P1 (9 lessons)
+- [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
 - [Clawdiy deploy treated transient OpenClaw startup unhealthy as a hard latest-upgrade failure](../docs/rca/2026-03-14-clawdiy-latest-startup-warmup-was-treated-as-hard-failure.md)
 - [Clawdiy upgrade to official Docker latest regressed live health and required baseline rollback](../docs/rca/2026-03-14-clawdiy-latest-channel-regressed-live-health.md)
@@ -38,7 +39,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### P3 (7 lessons)
+#### P3 (8 lessons)
+- [Codex monitor threshold coupled to tomllib availability](../docs/rca/2026-03-15-codex-monitor-threshold-coupled-to-tomllib.md)
 - [False GitHub Auth Failure During Codex Push](../docs/rca/2026-03-08-codex-github-auth-false-failure.md)
 - [Ложные error-сигналы в успешных GitHub workflow](../docs/rca/2026-03-07-workflow-alert-severity-mismatch.md)
 - [2026-03-06-browser-compat-speckit-desync](../docs/rca/2026-03-06-browser-compat-speckit-desync.md)
@@ -54,7 +56,9 @@
 ### By Category
 
 
-#### cicd (7 lessons)
+#### cicd (9 lessons)
+- [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
+- [Codex monitor threshold coupled to tomllib availability](../docs/rca/2026-03-15-codex-monitor-threshold-coupled-to-tomllib.md)
 - [Clawdiy deploy treated transient OpenClaw startup unhealthy as a hard latest-upgrade failure](../docs/rca/2026-03-14-clawdiy-latest-startup-warmup-was-treated-as-hard-failure.md)
 - [Clawdiy upgrade to official Docker latest regressed live health and required baseline rollback](../docs/rca/2026-03-14-clawdiy-latest-channel-regressed-live-health.md)
 - [Deploy Clawdiy блокировался на dirty checkout без auditable repair path](../docs/rca/2026-03-14-clawdiy-deploy-missing-gitops-repair-path.md)
@@ -99,10 +103,10 @@
 - `process` (9 lessons)
 - `lessons` (9 lessons)
 - `clawdiy` (8 lessons)
+- `gitops` (7 lessons)
 - `openclaw` (6 lessons)
-- `gitops` (6 lessons)
+- `github-actions` (6 lessons)
 - `rca` (5 lessons)
-- `github-actions` (5 lessons)
 - `docker` (5 lessons)
 - `deploy` (5 lessons)
 - `topology-registry` (4 lessons)
@@ -114,10 +118,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 29 |
-| Critical (P0/P1) | 9 |
+| Total Lessons | 31 |
+| Critical (P0/P1) | 10 |
 | Categories | 5 |
-| Unique Tags | 74 |
+| Unique Tags | 80 |
 
 ---
 

--- a/docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md
+++ b/docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md
@@ -1,0 +1,86 @@
+---
+title: "Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [moltis, ghcr, github-actions, gitops, deploy-gate, rollback]
+root_cause: "Deploy contract pinned a non-pullable GHCR tag (`v0.10.18`) and workflow allowed production-host path ambiguity via dispatch input semantics, so upgrade intent was not durable"
+---
+
+# RCA: Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** Production оставался на `0.9.10`; обновление до целевой версии не закреплялось и легко деградировало в повторяемый не-upgrade path.  
+**Контекст:** Завершение стабилизации Moltis update contract и production deploy path после incident chain из `2026-03-13`.
+
+## Ошибка
+
+Обновление Moltis до `0.10.18` не закреплялось как GitOps-гарантированный итог:
+
+1. tracked pin использовал `v0.10.18`, но GHCR pullable tag для релиза был `0.10.18` (без `v`);
+2. deploy workflow допускал семантику input `environment=staging` при фактическом деплое на production host;
+3. существовал риск повторного "ложного" rollout path из соседних веток/worktree через неоднозначный dispatch-контракт.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему production не закреплялся на новой версии Moltis? | Потому что deploy пытался работать с неверным image tag-контрактом и неоднозначным environment gating | `docker manifest inspect ghcr.io/moltis-org/moltis:v0.10.18` не pullable; workflow до фикса имел `staging` option при deploy на тот же host |
+| 2 | Почему tag-контракт оказался неверным? | Release tag (`v0.10.18`) был напрямую принят за GHCR tag | Официальный артефакт: `docs/research/moltis-official-version-update-channel-2026-03-20.md`; проверка registry показала pullable `0.10.18` |
+| 3 | Почему deploy-gate пропускал неоднозначный path? | Контроль "только main/tag" зависел от runtime `TARGET_ENV`, а не от однозначной production-only dispatch модели | `.github/workflows/deploy.yml` до фикса имел input `environment` с `staging`; preflight/repair guard основывались на `TARGET_ENV` |
+| 4 | Почему это давало риск повторного отката/незакрепления? | Любой повторный dispatch с нестрогим env contract мог уходить в неправильный operational path и мешать deterministic rollout | История incident chain + повторяющийся drift/repair контур из RCA `2026-03-13` |
+| 5 | Почему дефект не ловился заранее как policy violation? | Отсутствовали жёсткие static-проверки на формат GHCR tag, запрет `latest`, запрет dispatch override-версии и production-only dispatch | `tests/static/test_config_validation.sh` до доработки не покрывал весь набор guardrail-проверок |
+
+## Корневая причина
+
+Корневая причина двойная:
+
+1. **Неверный артефакт-контракт версии**: release tag и GHCR tag были смешаны.
+2. **Недостаточно жёсткий deploy contract**: workflow оставлял неоднозначность target semantics для production deploy.
+
+## Принятые меры
+
+1. **Немедленное исправление (version contract):**
+   - `docker-compose.yml` и `docker-compose.prod.yml` закреплены на `ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-0.10.18}`.
+   - `scripts/moltis-version.sh` теперь:
+     - запрещает `latest`,
+     - запрещает префикс `v`,
+     - принимает только semver-like GHCR tag (`0.10.18` и semver suffix-паттерны).
+2. **Немедленное исправление (deploy gate contract):**
+   - `workflow_dispatch.environment` ограничен только `production`;
+   - удалён ad-hoc `version` override из deploy workflow;
+   - добавлен hard block при `TARGET_ENV != production`;
+   - production deploy разрешён только с `main` или matching tag;
+   - запрещён `MOLTIS_VERSION` override в серверном `.env`.
+3. **Немедленное исправление (test guardrails):**
+   - расширены static тесты для проверки:
+     - GHCR tag без `v`,
+     - отсутствия `latest` default,
+     - production-only dispatch,
+     - отсутствия ручного `version` input.
+4. **Документация и официальный артефакт:**
+   - добавлен исследовательский документ по официальному update channel:
+     - `docs/research/moltis-official-version-update-channel-2026-03-20.md`;
+   - обновлён индекс `docs/research/README.md`;
+   - обновлены runbook/version docs для нового контракта.
+
+## Подтверждение устранения
+
+- PR с фиксом: `#72` (merged в `main`, merge commit `5b4a186638d8e8e9ab156c08e28e83cb6a530a95`)
+- Production deploy run (успешно): `23321428031`
+- Runtime факт на сервере:
+  - `docker inspect moltis` => `ghcr.io/moltis-org/moltis:0.10.18`
+  - container health => `healthy`
+  - `https://moltis.ainetic.tech/health` => `200`
+  - `http://localhost:13131/health` => `200`
+  - `/opt/moltinger` checkout => `main@5b4a186...`, без `.env` override `MOLTIS_VERSION`.
+
+## Уроки
+
+1. **Для Moltis нельзя использовать `latest` как tracked default**: обновления должны идти через явный pinned GHCR tag в git.
+2. **Release tag (`vX.Y.Z`) и GHCR runtime tag (`X.Y.Z`) нужно верифицировать как разные артефакты** перед pin/update.
+3. **Production deploy contract должен быть однозначным и неизбыточным**: без staging-ветвлений и без version override в dispatch.
+4. **Rollback должен оставаться только recovery-path** (по health-failure/manual rollback), а не побочным эффектом нестрогого deploy flow.
+5. **Static CI guards должны проверять policy-контракт, а не только синтаксис**, иначе drift semantics замечается слишком поздно.
+


### PR DESCRIPTION
## Summary
- add RCA for Moltis upgrade stabilization (0.10.18) with evidence and 5-why path
- capture deploy gate hardening outcomes and production verification evidence
- rebuild docs/LESSONS-LEARNED.md to include the new incident lessons

## Validation
- ./scripts/build-lessons-index.sh
- ./scripts/query-lessons.sh --tag moltis
