### PR TITLE
fix(cicd): harden active-root symlink migration in UAT deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy Moltis
 
 # Prevent parallel remote mutations on production target.
-# This lock must stay shared with deploy-clawdiy.yml and uat-gate.yml deploy job.
+# This lock must stay shared with uat-gate.yml deploy job.
 concurrency:
   group: prod-remote-ainetic-tech-opt-moltinger
   cancel-in-progress: false
@@ -867,10 +867,18 @@ jobs:
         run: |
           echo "::group::Updating active deploy root"
           ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << EOF
-            set -e
+            set -euo pipefail
+            # Legacy migration: ln -sfn does NOT replace an existing real directory.
+            # In that case it creates a nested link and test -L fails.
+            if [ -e "${{ env.DEPLOY_ACTIVE_PATH }}" ] && [ ! -L "${{ env.DEPLOY_ACTIVE_PATH }}" ]; then
+              LEGACY_BACKUP="${{ env.DEPLOY_ACTIVE_PATH }}.legacy-$(date -u +%Y%m%dT%H%M%SZ)"
+              echo "::warning::Detected legacy non-symlink active root: ${{ env.DEPLOY_ACTIVE_PATH }}; moving to $LEGACY_BACKUP"
+              mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"
+            fi
             ln -sfn "${{ env.DEPLOY_PATH }}" "${{ env.DEPLOY_ACTIVE_PATH }}"
             test -L "${{ env.DEPLOY_ACTIVE_PATH }}"
             test "$(readlink "${{ env.DEPLOY_ACTIVE_PATH }}")" = "${{ env.DEPLOY_PATH }}"
+            ls -ld "${{ env.DEPLOY_ACTIVE_PATH }}"
           EOF
           echo "::notice::Active deploy root -> ${{ env.DEPLOY_PATH }}"
           echo "::endgroup::"

--- a/.github/workflows/uat-gate.yml
+++ b/.github/workflows/uat-gate.yml
@@ -299,6 +299,26 @@ jobs:
           echo "Configuration synced successfully (docker-compose.yml + docker-compose.prod.yml + config/ + scripts/)"
           echo "::endgroup::"
 
+      - name: Update active deploy root symlink
+        run: |
+          echo "::group::Updating active deploy root"
+          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << EOF
+            set -euo pipefail
+            # Legacy migration: ln -sfn does NOT replace an existing real directory.
+            # In that case it creates a nested link and test -L fails.
+            if [ -e "${{ env.DEPLOY_ACTIVE_PATH }}" ] && [ ! -L "${{ env.DEPLOY_ACTIVE_PATH }}" ]; then
+              LEGACY_BACKUP="${{ env.DEPLOY_ACTIVE_PATH }}.legacy-$(date -u +%Y%m%dT%H%M%SZ)"
+              echo "::warning::Detected legacy non-symlink active root: ${{ env.DEPLOY_ACTIVE_PATH }}; moving to $LEGACY_BACKUP"
+              mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"
+            fi
+            ln -sfn "${{ env.DEPLOY_PATH }}" "${{ env.DEPLOY_ACTIVE_PATH }}"
+            test -L "${{ env.DEPLOY_ACTIVE_PATH }}"
+            test "$(readlink "${{ env.DEPLOY_ACTIVE_PATH }}")" = "${{ env.DEPLOY_PATH }}"
+            ls -ld "${{ env.DEPLOY_ACTIVE_PATH }}"
+          EOF
+          echo "::notice::Active deploy root -> ${{ env.DEPLOY_PATH }}"
+          echo "::endgroup::"
+
       - name: Generate .env from Secrets
         run: |
           echo "::group::Generating .env file from GitHub Secrets"

--- a/docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md
+++ b/docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md
@@ -1,0 +1,75 @@
+---
+title: "Deploy collision and active-root symlink guard"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [deploy, github-actions, concurrency, symlink, gitops]
+root_cause: "Branch-scoped deploy concurrency plus fragile ln -sfn symlink update logic without legacy directory migration."
+---
+
+# RCA: Deploy collision and active-root symlink guard
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** Production deploy мог падать на шаге `Update active deploy root symlink`, а параллельные deploy-пайплайны могли конфликтовать на одном сервере.
+
+## Ошибка
+
+Симптомы:
+
+- `Deploy Moltis` run `23339680970` завершился `failure`.
+- Падение на шаге `Update active deploy root symlink`.
+- Пользователь зафиксировал системный риск столкновений при параллельных deploy в разных ветках.
+
+Дополнительные факты:
+
+- В `deploy.yml` использовался branch-scoped lock: `group: deploy-${{ github.ref }}`.
+- В `uat-gate.yml` у production deploy-джобы не было общего lock с `deploy.yml`.
+- Шаг symlink-обновления использовал `ln -sfn` + `test -L`, что ломается при legacy-состоянии, когда target path уже real directory.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему падал шаг обновления active-root? | Проверка `test -L /opt/moltinger-active` возвращала ошибку. | `deploy.yml` шаг `Update active deploy root symlink` |
+| 2 | Почему `test -L` мог возвращать ошибку после `ln -sfn`? | `ln -sfn` не заменяет existing real directory; создаёт nested symlink внутри директории. | Локальная репродукция: `ln -sfn <target> <existing_dir>` + `[ -L <existing_dir> ] -> false` |
+| 3 | Почему такой legacy-сценарий не был покрыт? | В workflow не было миграции non-symlink path в backup перед созданием symlink. | Отсутствие guard-блока `if [ -e ... ] && [ ! -L ... ]` |
+| 4 | Почему конфликт проявлялся как системный риск, а не единичный сбой? | Параллельные production deploy могли менять одно и то же remote state без единого lock. | `deploy.yml` имел lock по branch (`deploy-${{ github.ref }}`), а `uat-gate.yml` не имел shared production lock |
+| 5 | Почему это допустили в процессе? | Не была закреплена инварианта "single writer" для production target + не было unit-guard теста на workflow lock policy. | Отсутствовали тесты на shared lock group и на legacy symlink migration guard |
+
+## Корневая причина
+
+Система деплоя не обеспечивала инварианту "один writer на production target" и предполагала, что `/opt/moltinger-active` всегда уже symlink.  
+Это комбинация двух причин:
+
+1. Неправильная гранулярность concurrency (branch-scoped вместо target-scoped).
+2. Хрупкая логика `ln -sfn` без миграции legacy directory-состояния.
+
+## Принятые меры
+
+1. **Немедленное исправление:**  
+   В `deploy.yml` добавлен shared production lock:
+   `group: prod-remote-ainetic-tech-opt-moltinger`.
+2. **Предотвращение:**  
+   В `uat-gate.yml` deploy-джобе добавлен тот же lock group, чтобы все mutating deploy paths serializовались.
+3. **Hardening symlink шага:**  
+   В `deploy.yml` и `uat-gate.yml` добавлена legacy migration логика: если active path существует и не symlink, он переносится в timestamp backup, затем создаётся корректный symlink.
+4. **Regression guard:**  
+   Добавлен unit test `tests/unit/test_deploy_workflow_guards.sh`, который проверяет:
+   - shared production lock group в workflow,
+   - отсутствие branch-scoped deploy group в `deploy.yml`,
+   - наличие legacy migration guard для active-root symlink.
+
+## Связанные обновления
+
+- [x] Новый файл правила создан (`docs/rules/production-deploy-single-writer.md`)
+- [ ] Краткая ссылка добавлена в CLAUDE.md
+- [ ] Новые навыки созданы
+- [x] Тесты добавлены
+
+## Уроки
+
+1. **Single writer для production обязателен** — concurrency group должен быть target-scoped (host/path), а не branch-scoped.
+2. **`ln -sfn` не мигрирует real directory** — перед symlink update нужен explicit guard на legacy path type.
+3. **Workflow policy должна быть тестируемой** — lock policy и migration guards нужно фиксировать unit-тестами, иначе регрессии возвращаются.
+

--- a/docs/rules/production-deploy-single-writer.md
+++ b/docs/rules/production-deploy-single-writer.md
@@ -1,0 +1,18 @@
+# Rule: Production Deploy Single Writer
+
+For remote production mutations on `ainetic.tech` (`/opt/moltinger*`), only one deploy writer is allowed at a time.
+
+Mandatory requirements:
+
+1. All production-mutating GitHub workflows must share one target-scoped concurrency group.
+2. Lock name must be stable and tied to remote target (host/path), not branch name.
+3. Any active-root symlink update must migrate legacy non-symlink paths before `ln -sfn`.
+
+Implementation baseline:
+
+- Lock group: `prod-remote-ainetic-tech-opt-moltinger`
+- Guard pattern:
+  - `if [ -e "$ACTIVE" ] && [ ! -L "$ACTIVE" ]; then mv "$ACTIVE" "$ACTIVE.legacy-<timestamp>"; fi`
+  - `ln -sfn "$TARGET" "$ACTIVE"`
+  - `test -L "$ACTIVE"` and `test "$(readlink "$ACTIVE")" = "$TARGET"`
+

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Deployment workflow guard tests
+# Prevents regressions in production locking and active-root migration logic.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+DEPLOY_WORKFLOW="$PROJECT_ROOT/.github/workflows/deploy.yml"
+UAT_WORKFLOW="$PROJECT_ROOT/.github/workflows/uat-gate.yml"
+EXPECTED_LOCK_GROUP="prod-remote-ainetic-tech-opt-moltinger"
+
+test_deploy_workflow_uses_shared_production_lock() {
+    test_start "Deploy workflow should use shared production concurrency group"
+
+    if [[ ! -f "$DEPLOY_WORKFLOW" ]]; then
+        test_skip "Missing workflow file: $DEPLOY_WORKFLOW"
+        return
+    fi
+
+    if ! grep -Fq "group: $EXPECTED_LOCK_GROUP" "$DEPLOY_WORKFLOW"; then
+        test_fail "Deploy workflow missing shared lock group: $EXPECTED_LOCK_GROUP"
+        return
+    fi
+
+    if grep -Fq 'group: deploy-${{ github.ref }}' "$DEPLOY_WORKFLOW"; then
+        test_fail "Deploy workflow still uses branch-scoped lock group"
+        return
+    fi
+
+    test_pass
+}
+
+test_uat_deploy_job_uses_shared_production_lock() {
+    test_start "UAT deploy job should use shared production concurrency group"
+
+    if [[ ! -f "$UAT_WORKFLOW" ]]; then
+        test_skip "Missing workflow file: $UAT_WORKFLOW"
+        return
+    fi
+
+    if ! grep -Fq "group: $EXPECTED_LOCK_GROUP" "$UAT_WORKFLOW"; then
+        test_fail "UAT deploy job missing shared lock group: $EXPECTED_LOCK_GROUP"
+        return
+    fi
+
+    test_pass
+}
+
+test_active_root_symlink_step_handles_legacy_directory() {
+    test_start "Symlink update should migrate legacy non-symlink active root"
+
+    if [[ ! -f "$DEPLOY_WORKFLOW" || ! -f "$UAT_WORKFLOW" ]]; then
+        test_skip "Workflow files missing for symlink migration guard check"
+        return
+    fi
+
+    local deploy_guard=false
+    local uat_guard=false
+
+    if grep -Fq "Detected legacy non-symlink active root" "$DEPLOY_WORKFLOW" && \
+       grep -Fq 'mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"' "$DEPLOY_WORKFLOW"; then
+        deploy_guard=true
+    fi
+
+    if grep -Fq "Detected legacy non-symlink active root" "$UAT_WORKFLOW" && \
+       grep -Fq 'mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"' "$UAT_WORKFLOW"; then
+        uat_guard=true
+    fi
+
+    if [[ "$deploy_guard" == "true" && "$uat_guard" == "true" ]]; then
+        test_pass
+    else
+        test_fail "Legacy directory migration guard missing in deploy.yml and/or uat-gate.yml"
+    fi
+}
+
+run_all_tests() {
+    start_timer
+
+    if [[ "$OUTPUT_JSON" != "true" ]]; then
+        echo ""
+        echo "========================================="
+        echo "  Deploy Workflow Guard Unit Tests"
+        echo "========================================="
+        echo ""
+    fi
+
+    test_deploy_workflow_uses_shared_production_lock
+    test_uat_deploy_job_uses_shared_production_lock
+    test_active_root_symlink_step_handles_legacy_directory
+
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_all_tests
+fi


### PR DESCRIPTION
## Summary\n- add legacy-safe active-root symlink migration step to UAT deploy job\n- keep shared production concurrency lock across deploy surfaces\n- add RCA and rule doc for single-writer production deploy policy\n- add unit guard test to prevent lock/symlink regression\n\n## Validation\n- ./tests/run.sh --lane static --json\n- ./tests/run.sh --lane component --json\n\n## Why\nRoot-cause fix for systemic deploy failures and parallel deploy collision risk: enforce single-writer semantics and make symlink update resilient when legacy directory exists.