### PR TITLE
fix(cicd): prevent runner-side expansion in symlink deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -866,19 +866,30 @@ jobs:
       - name: Update active deploy root symlink
         run: |
           echo "::group::Updating active deploy root"
-          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << EOF
+          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << 'EOF'
             set -euo pipefail
+            ACTIVE_PATH="${{ env.DEPLOY_ACTIVE_PATH }}"
+            TARGET_PATH="${{ env.DEPLOY_PATH }}"
             # Legacy migration: ln -sfn does NOT replace an existing real directory.
             # In that case it creates a nested link and test -L fails.
-            if [ -e "${{ env.DEPLOY_ACTIVE_PATH }}" ] && [ ! -L "${{ env.DEPLOY_ACTIVE_PATH }}" ]; then
-              LEGACY_BACKUP="${{ env.DEPLOY_ACTIVE_PATH }}.legacy-$(date -u +%Y%m%dT%H%M%SZ)"
-              echo "::warning::Detected legacy non-symlink active root: ${{ env.DEPLOY_ACTIVE_PATH }}; moving to $LEGACY_BACKUP"
-              mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"
+            if [ -e "$ACTIVE_PATH" ] && [ ! -L "$ACTIVE_PATH" ]; then
+              LEGACY_BACKUP="${ACTIVE_PATH}.legacy-$(date -u +%Y%m%dT%H%M%SZ)"
+              echo "::warning::Detected legacy non-symlink active root: $ACTIVE_PATH; moving to $LEGACY_BACKUP"
+              mv "$ACTIVE_PATH" "$LEGACY_BACKUP"
             fi
-            ln -sfn "${{ env.DEPLOY_PATH }}" "${{ env.DEPLOY_ACTIVE_PATH }}"
-            test -L "${{ env.DEPLOY_ACTIVE_PATH }}"
-            test "$(readlink "${{ env.DEPLOY_ACTIVE_PATH }}")" = "${{ env.DEPLOY_PATH }}"
-            ls -ld "${{ env.DEPLOY_ACTIVE_PATH }}"
+            ln -sfn "$TARGET_PATH" "$ACTIVE_PATH"
+            if [ ! -L "$ACTIVE_PATH" ]; then
+              echo "::error::Active deploy root is not a symlink after update: $ACTIVE_PATH"
+              ls -ld "$ACTIVE_PATH" || true
+              exit 1
+            fi
+            RESOLVED_TARGET="$(readlink "$ACTIVE_PATH")"
+            if [ "$RESOLVED_TARGET" != "$TARGET_PATH" ]; then
+              echo "::error::Active deploy root points to unexpected target: $RESOLVED_TARGET (expected $TARGET_PATH)"
+              ls -ld "$ACTIVE_PATH" || true
+              exit 1
+            fi
+            ls -ld "$ACTIVE_PATH"
           EOF
           echo "::notice::Active deploy root -> ${{ env.DEPLOY_PATH }}"
           echo "::endgroup::"

--- a/.github/workflows/uat-gate.yml
+++ b/.github/workflows/uat-gate.yml
@@ -302,19 +302,30 @@ jobs:
       - name: Update active deploy root symlink
         run: |
           echo "::group::Updating active deploy root"
-          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << EOF
+          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << 'EOF'
             set -euo pipefail
+            ACTIVE_PATH="${{ env.DEPLOY_ACTIVE_PATH }}"
+            TARGET_PATH="${{ env.DEPLOY_PATH }}"
             # Legacy migration: ln -sfn does NOT replace an existing real directory.
             # In that case it creates a nested link and test -L fails.
-            if [ -e "${{ env.DEPLOY_ACTIVE_PATH }}" ] && [ ! -L "${{ env.DEPLOY_ACTIVE_PATH }}" ]; then
-              LEGACY_BACKUP="${{ env.DEPLOY_ACTIVE_PATH }}.legacy-$(date -u +%Y%m%dT%H%M%SZ)"
-              echo "::warning::Detected legacy non-symlink active root: ${{ env.DEPLOY_ACTIVE_PATH }}; moving to $LEGACY_BACKUP"
-              mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"
+            if [ -e "$ACTIVE_PATH" ] && [ ! -L "$ACTIVE_PATH" ]; then
+              LEGACY_BACKUP="${ACTIVE_PATH}.legacy-$(date -u +%Y%m%dT%H%M%SZ)"
+              echo "::warning::Detected legacy non-symlink active root: $ACTIVE_PATH; moving to $LEGACY_BACKUP"
+              mv "$ACTIVE_PATH" "$LEGACY_BACKUP"
             fi
-            ln -sfn "${{ env.DEPLOY_PATH }}" "${{ env.DEPLOY_ACTIVE_PATH }}"
-            test -L "${{ env.DEPLOY_ACTIVE_PATH }}"
-            test "$(readlink "${{ env.DEPLOY_ACTIVE_PATH }}")" = "${{ env.DEPLOY_PATH }}"
-            ls -ld "${{ env.DEPLOY_ACTIVE_PATH }}"
+            ln -sfn "$TARGET_PATH" "$ACTIVE_PATH"
+            if [ ! -L "$ACTIVE_PATH" ]; then
+              echo "::error::Active deploy root is not a symlink after update: $ACTIVE_PATH"
+              ls -ld "$ACTIVE_PATH" || true
+              exit 1
+            fi
+            RESOLVED_TARGET="$(readlink "$ACTIVE_PATH")"
+            if [ "$RESOLVED_TARGET" != "$TARGET_PATH" ]; then
+              echo "::error::Active deploy root points to unexpected target: $RESOLVED_TARGET (expected $TARGET_PATH)"
+              ls -ld "$ACTIVE_PATH" || true
+              exit 1
+            fi
+            ls -ld "$ACTIVE_PATH"
           EOF
           echo "::notice::Active deploy root -> ${{ env.DEPLOY_PATH }}"
           echo "::endgroup::"

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 34
+**Total Lessons**: 36
 
 ---
 
@@ -14,8 +14,10 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (9 lessons)
+#### P1 (11 lessons)
+- [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
 - [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
+- [Deploy collision and active-root symlink guard](../docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
 - [Clawdiy deploy treated transient OpenClaw startup unhealthy as a hard latest-upgrade failure](../docs/rca/2026-03-14-clawdiy-latest-startup-warmup-was-treated-as-hard-failure.md)
 - [Clawdiy upgrade to official Docker latest regressed live health and required baseline rollback](../docs/rca/2026-03-14-clawdiy-latest-channel-regressed-live-health.md)
@@ -59,11 +61,13 @@
 ### By Category
 
 
-#### cicd (12 lessons)
+#### cicd (14 lessons)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
 - [Test Suite gate failed because CI runner missed sqlite3 dependency for component_codex_session_path_repair](../docs/rca/2026-03-20-test-suite-gate-failed-on-missing-sqlite3-dependency.md)
+- [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
 - [Moltis update proposal workflow failed with workflow-file issue due to forbidden secrets context in step if](../docs/rca/2026-03-20-moltis-update-proposal-workflow-file-issue-on-secrets-context.md)
 - [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
+- [Deploy collision and active-root symlink guard](../docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md)
 - [Codex monitor threshold coupled to tomllib availability](../docs/rca/2026-03-15-codex-monitor-threshold-coupled-to-tomllib.md)
 - [Clawdiy deploy treated transient OpenClaw startup unhealthy as a hard latest-upgrade failure](../docs/rca/2026-03-14-clawdiy-latest-startup-warmup-was-treated-as-hard-failure.md)
 - [Clawdiy upgrade to official Docker latest regressed live health and required baseline rollback](../docs/rca/2026-03-14-clawdiy-latest-channel-regressed-live-health.md)
@@ -106,15 +110,15 @@
 
 ### Popular Tags
 
+- `github-actions` (11 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
-- `github-actions` (9 lessons)
+- `gitops` (8 lessons)
 - `clawdiy` (8 lessons)
-- `gitops` (7 lessons)
+- `deploy` (7 lessons)
+- `rca` (6 lessons)
 - `openclaw` (6 lessons)
-- `rca` (5 lessons)
 - `docker` (5 lessons)
-- `deploy` (5 lessons)
 - `topology-registry` (4 lessons)
 
 
@@ -124,10 +128,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 34 |
-| Critical (P0/P1) | 10 |
+| Total Lessons | 36 |
+| Critical (P0/P1) | 12 |
 | Categories | 5 |
-| Unique Tags | 86 |
+| Unique Tags | 88 |
 
 ---
 

--- a/docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md
+++ b/docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md
@@ -1,0 +1,63 @@
+---
+title: "SSH heredoc runner-side expansion in deploy workflow"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [deploy, github-actions, ssh, heredoc, rca]
+root_cause: "Unquoted heredoc in remote ssh step allowed runner-side shell expansion of remote variables and command substitutions."
+---
+
+# RCA: SSH heredoc runner-side expansion in deploy workflow
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** Production deploy падал на шаге `Update active deploy root symlink` при корректном состоянии сервера.
+
+## Ошибка
+
+Симптомы:
+
+- `Deploy Moltis` run `23341975775` завершился `failure`.
+- Падение на шаге `Update active deploy root symlink`.
+- На сервере при этом ` /opt/moltinger-active -> /opt/moltinger` уже был корректным symlink, то есть состояние target было валидным, но job все равно завершался с exit code `1`.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему шаг `Update active deploy root symlink` падал? | Команда завершалась `exit code 1` без диагностического сообщения из remote-скрипта. | GitHub Actions log run `23341975775`, job `67897873911` |
+| 2 | Почему не было remote-диагностики при падении? | Ошибка происходила на runner во время подготовки heredoc, до полного корректного исполнения remote-блока. | Репродукция локально: `bash -euxo pipefail` + `ssh << EOF` |
+| 3 | Почему runner исполнял часть remote-скрипта локально? | Использовался неэкранированный heredoc `<< EOF`; локальный shell разворачивал `$LEGACY_BACKUP` и `$(...)`. | Фрагмент workflow шага symlink update |
+| 4 | Почему это приводило к `exit 1`? | При `set -u` локальная подстановка `$LEGACY_BACKUP` вызывала `unbound variable`, прерывая шаг. | Репродукция: `bash: line 1: LEGACY_BACKUP: unbound variable` |
+| 5 | Почему это попало в production pipeline? | Не было policy и unit-guard теста на quoted heredoc именно для remote symlink-шагов. | Отсутствие проверки `<< 'EOF'` в `tests/unit/test_deploy_workflow_guards.sh` |
+
+## Корневая причина
+
+В production deploy-пайплайне remote ssh-блок был оформлен неэкранированным heredoc (`<< EOF`), из-за чего shell runner-а локально разворачивал remote-переменные и command substitution.  
+Это процессная ошибка в шаблоне workflow, а не проблема серверного состояния.
+
+## Принятые меры
+
+1. **Немедленное исправление:**  
+   Переведены symlink-шаги в `deploy.yml` и `uat-gate.yml` на quoted heredoc: `<< 'EOF'`.
+2. **Hardening:**  
+   Добавлены явные проверки с диагностикой:
+   - active path после обновления обязан быть symlink;
+   - target symlink обязан совпадать с `${{ env.DEPLOY_PATH }}`.
+3. **Предотвращение:**  
+   Добавлен regression test в `tests/unit/test_deploy_workflow_guards.sh`, который валидирует quoted heredoc в symlink-шагах обоих workflow.
+4. **Документация:**  
+   Добавлено правило в `docs/rules/github-actions-remote-ssh-heredoc-quoting.md`.
+
+## Связанные обновления
+
+- [x] Новый файл правила создан (`docs/rules/github-actions-remote-ssh-heredoc-quoting.md`)
+- [ ] Краткая ссылка добавлена в CLAUDE.md
+- [ ] Новые навыки созданы
+- [x] Тесты добавлены
+
+## Уроки
+
+1. **Remote ssh steps в GitHub Actions должны использовать quoted heredoc** — для удаленного скрипта применять `<< 'EOF'`, иначе shell runner-а может выполнить подстановки локально.
+2. **Нельзя полагаться на “тихие” `test` без контекста** — при проверках symlink добавлять явные сообщения об ошибке и текущем состоянии пути.
+3. **Workflow-политики должны быть тестируемыми** — heredoc quoting и критичные deploy-инварианты обязаны иметь unit-guard.

--- a/docs/rules/github-actions-remote-ssh-heredoc-quoting.md
+++ b/docs/rules/github-actions-remote-ssh-heredoc-quoting.md
@@ -1,0 +1,34 @@
+# Rule: Quote SSH Heredocs in GitHub Actions
+
+## Problem
+
+In GitHub Actions, `ssh ... << EOF` allows local runner shell expansion inside the heredoc body.  
+This can execute command substitutions or variable expansion locally instead of on the remote host and break production deploy steps.
+
+## Mandatory Rule
+
+For remote scripts executed via SSH in workflows, use **quoted heredoc**:
+
+```bash
+ssh user@host << 'EOF'
+  set -euo pipefail
+  # remote-only logic
+EOF
+```
+
+Do **not** use unquoted heredoc (`<< EOF`) for remote execution blocks containing shell variables or command substitutions.
+
+## If local interpolation is required
+
+Pass values explicitly as command arguments or environment variables, and still keep remote body quoted:
+
+```bash
+ssh user@host "VERSION=$VERSION bash -se" << 'EOF'
+  docker pull "image:${VERSION}"
+EOF
+```
+
+## Verification
+
+1. Critical deploy steps must include explicit state checks and readable error messages.
+2. Add/maintain unit guards for workflow invariants (`tests/unit/test_deploy_workflow_guards.sh`).

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -61,12 +61,12 @@ test_active_root_symlink_step_handles_legacy_directory() {
     local uat_guard=false
 
     if grep -Fq "Detected legacy non-symlink active root" "$DEPLOY_WORKFLOW" && \
-       grep -Fq 'mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"' "$DEPLOY_WORKFLOW"; then
+       grep -Fq 'mv "$ACTIVE_PATH" "$LEGACY_BACKUP"' "$DEPLOY_WORKFLOW"; then
         deploy_guard=true
     fi
 
     if grep -Fq "Detected legacy non-symlink active root" "$UAT_WORKFLOW" && \
-       grep -Fq 'mv "${{ env.DEPLOY_ACTIVE_PATH }}" "$LEGACY_BACKUP"' "$UAT_WORKFLOW"; then
+       grep -Fq 'mv "$ACTIVE_PATH" "$LEGACY_BACKUP"' "$UAT_WORKFLOW"; then
         uat_guard=true
     fi
 
@@ -75,6 +75,56 @@ test_active_root_symlink_step_handles_legacy_directory() {
     else
         test_fail "Legacy directory migration guard missing in deploy.yml and/or uat-gate.yml"
     fi
+}
+
+workflow_symlink_step_uses_quoted_heredoc() {
+    local workflow_file="$1"
+    local in_step=false
+    local saw_quoted=false
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]name:[[:space:]]Update[[:space:]]active[[:space:]]deploy[[:space:]]root[[:space:]]symlink[[:space:]]*$ ]]; then
+            in_step=true
+            continue
+        fi
+
+        if [[ "$in_step" == "true" && "$line" =~ ^[[:space:]]*-[[:space:]]name:[[:space:]] ]]; then
+            break
+        fi
+
+        if [[ "$in_step" == "true" ]]; then
+            if [[ "$line" == *"<< 'EOF'"* ]]; then
+                saw_quoted=true
+            fi
+
+            if [[ "$line" == *"<< EOF"* ]]; then
+                return 1
+            fi
+        fi
+    done < "$workflow_file"
+
+    [[ "$in_step" == "true" && "$saw_quoted" == "true" ]]
+}
+
+test_active_root_symlink_step_uses_quoted_heredoc() {
+    test_start "Symlink update should use quoted heredoc to avoid runner-side expansion"
+
+    if [[ ! -f "$DEPLOY_WORKFLOW" || ! -f "$UAT_WORKFLOW" ]]; then
+        test_skip "Workflow files missing for heredoc quoting guard check"
+        return
+    fi
+
+    if ! workflow_symlink_step_uses_quoted_heredoc "$DEPLOY_WORKFLOW"; then
+        test_fail "deploy.yml symlink update step must use << 'EOF' (quoted heredoc)"
+        return
+    fi
+
+    if ! workflow_symlink_step_uses_quoted_heredoc "$UAT_WORKFLOW"; then
+        test_fail "uat-gate.yml symlink update step must use << 'EOF' (quoted heredoc)"
+        return
+    fi
+
+    test_pass
 }
 
 run_all_tests() {
@@ -91,6 +141,7 @@ run_all_tests() {
     test_deploy_workflow_uses_shared_production_lock
     test_uat_deploy_job_uses_shared_production_lock
     test_active_root_symlink_step_handles_legacy_directory
+    test_active_root_symlink_step_uses_quoted_heredoc
 
     generate_report
 }


### PR DESCRIPTION
## Problem
Production deploy failed at `Update active deploy root symlink` even when server symlink state was valid.

## Root cause
The step used unquoted heredoc (`<< EOF`) for remote SSH execution. Runner-side shell expanded remote variables/command substitutions, causing local failure (e.g. unbound variable) and intermittent opaque exit code 1.

## Changes
- Switched symlink update SSH blocks to quoted heredoc (`<< 'EOF'`) in:
  - `.github/workflows/deploy.yml`
  - `.github/workflows/uat-gate.yml`
- Hardened symlink checks with explicit diagnostics (type + target mismatch paths).
- Added workflow guard regression test to enforce quoted heredoc for symlink step.
- Added RCA and rule docs; refreshed lessons index.

## Validation
- `bash tests/unit/test_deploy_workflow_guards.sh`
- `./tests/run.sh --lane static --json`
- `./tests/run.sh --lane component --json`
