### PR TITLE
fix: hard-block tag deploys that are not current main HEAD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,8 +92,17 @@ jobs:
           fi
 
           if [ "$REPAIR_REQUESTED" = true ] && [ "$TARGET_ENV" = "production" ] && [ "${{ github.ref_name }}" != "main" ] && [ "${{ github.ref_type }}" != "tag" ]; then
-            echo "::error::repair_server_checkout is only allowed for production deploys from main or a matching release tag."
+            echo "::error::repair_server_checkout is only allowed for production deploys from main or release tags that point to current origin/main HEAD."
             exit 1
+          fi
+
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            git fetch --no-tags --depth=1 origin main
+            MAIN_HEAD="$(git rev-parse origin/main)"
+            if [ "$MAIN_HEAD" != "${{ github.sha }}" ]; then
+              echo "::error::Production tag deploy is blocked: tag must point to current origin/main HEAD ($MAIN_HEAD), got ${{ github.sha }}."
+              exit 1
+            fi
           fi
 
           # Function to compare files
@@ -367,6 +376,15 @@ jobs:
           if [ "${{ github.ref_name }}" != "main" ] && [ "${{ github.ref_type }}" != "tag" ]; then
             echo "::error::Production deploys must run from main. Current ref: ${{ github.ref_name }}"
             exit 1
+          fi
+
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            git fetch --no-tags --depth=1 origin main
+            MAIN_HEAD="$(git rev-parse origin/main)"
+            if [ "$MAIN_HEAD" != "${{ github.sha }}" ]; then
+              echo "::error::Production tag deploy is blocked: tag must point to current origin/main HEAD ($MAIN_HEAD), got ${{ github.sha }}."
+              exit 1
+            fi
           fi
 
           if [ "$TARGET_ENV" = "production" ] && [ "${{ github.ref_type }}" = "tag" ] && [ "${{ steps.version.outputs.version }}" != "$TRACKED_VERSION" ]; then

--- a/docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md
+++ b/docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md
@@ -51,7 +51,7 @@ root_cause: "Deploy contract pinned a non-pullable GHCR tag (`v0.10.18`) and wor
    - `workflow_dispatch.environment` ограничен только `production`;
    - удалён ad-hoc `version` override из deploy workflow;
    - добавлен hard block при `TARGET_ENV != production`;
-   - production deploy разрешён только с `main` или matching tag;
+   - production deploy разрешён только с `main`; tag-triggered deploy допускается только если tag SHA совпадает с текущим `origin/main` HEAD;
    - запрещён `MOLTIS_VERSION` override в серверном `.env`.
 3. **Немедленное исправление (test guardrails):**
    - расширены static тесты для проверки:
@@ -83,4 +83,3 @@ root_cause: "Deploy contract pinned a non-pullable GHCR tag (`v0.10.18`) and wor
 3. **Production deploy contract должен быть однозначным и неизбыточным**: без staging-ветвлений и без version override в dispatch.
 4. **Rollback должен оставаться только recovery-path** (по health-failure/manual rollback), а не побочным эффектом нестрогого deploy flow.
 5. **Static CI guards должны проверять policy-контракт, а не только синтаксис**, иначе drift semantics замечается слишком поздно.
-

--- a/docs/runbooks/moltis-backup-safe-update.md
+++ b/docs/runbooks/moltis-backup-safe-update.md
@@ -113,6 +113,7 @@ GitHub Actions path:
 
 - `.github/workflows/deploy.yml`
 - `workflow_dispatch` target is production-only
+- release-tag deploy is allowed only when tag SHA matches current `origin/main` HEAD
 - manual version input defaults to blank and must equal tracked git version if provided
 - backup step must finish successfully
 - restore-readiness validation must finish successfully

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -83,6 +83,7 @@ BACKUP_FILE="$(cat data/moltis/.last-moltis-backup)"
 - validate restore readiness of that backup
 - deploy the git-tracked version only
 - allow only production target in workflow_dispatch
+- allow tag-triggered production deploy only when tag SHA equals current `origin/main` HEAD
 - keep manual version input blank by default (tracked git version is source of truth)
 - block deploy if restore readiness fails
 

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -239,10 +239,11 @@ PY
        ! rg -q ' - staging' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        ! rg -q '^[[:space:]]+version:[[:space:]]*$' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        rg -q 'supports production target only' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
-       rg -q 'Production deploys must run from main' "$PROJECT_ROOT/.github/workflows/deploy.yml"; then
+       rg -q 'Production deploys must run from main' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
+       rg -q 'tag must point to current origin/main HEAD' "$PROJECT_ROOT/.github/workflows/deploy.yml"; then
         test_pass
     else
-        test_fail "Deploy workflow must resolve tracked Moltis version, remove ad-hoc version input, forbid staging bypass, and block feature-branch production deploys"
+        test_fail "Deploy workflow must resolve tracked Moltis version, remove ad-hoc version input, forbid staging bypass, and block non-main tag deploys"
     fi
 
     test_start "static_deploy_surfaces_post_upgrade_protocol_skew_as_operator_signal"
@@ -353,10 +354,11 @@ PY
     test_start "static_deploy_uses_tracked_moltis_version_and_blocks_feature_prod_deploys"
     if rg -q 'scripts/moltis-version\.sh version' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        rg -q 'Production deploys must run from main' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
+       rg -q 'tag must point to current origin/main HEAD' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        rg -q 'Production tag deploy version must match tracked Moltis version' "$PROJECT_ROOT/.github/workflows/deploy.yml"; then
         test_pass
     else
-        test_fail "Deploy workflow must resolve the tracked Moltis version and block feature-branch production deploys"
+        test_fail "Deploy workflow must resolve the tracked Moltis version, block feature-branch deploys, and reject tags that do not point to current main HEAD"
     fi
 
     test_start "static_deploy_surfaces_post_upgrade_protocol_skew_as_operator_signal"


### PR DESCRIPTION
## Что исправлено
- Добавлен hard guard в `Deploy Moltis` для `ref_type=tag`: прод-деплой разрешён только если tag SHA совпадает с текущим `origin/main` HEAD.
- Guard добавлен в оба критичных места workflow:
  - `gitops-compliance` (чтобы не выполнять mutation-steps для невалидного tag-run)
  - `preflight` (финальный production gate)
- Обновлены policy/docs:
  - `docs/version-update.md`
  - `docs/runbooks/moltis-backup-safe-update.md`
  - RCA `docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md`
- Расширены static guard tests (`tests/static/test_config_validation.sh`).

## Зачем
Закрывает residual rollback path: запуск продового deploy с release-tag, указывающего не на текущий `main` (старый commit/параллельный worktree).

## Проверки
- `bash tests/static/test_config_validation.sh` (70/70)
- `bash tests/unit/test_deploy_workflow_guards.sh` (4/4)
