### PR TITLE
fix(telegram): make monitors opt-in and eliminate default chat noise

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 37
+**Total Lessons**: 38
 
 ---
 
@@ -28,8 +28,9 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (14 lessons)
+#### P2 (15 lessons)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
+- [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
 - [Moltis update proposal workflow failed with workflow-file issue due to forbidden secrets context in step if](../docs/rca/2026-03-20-moltis-update-proposal-workflow-file-issue-on-secrets-context.md)
 - [Deploy Clawdiy блокировался на dirty checkout без auditable repair path](../docs/rca/2026-03-14-clawdiy-deploy-missing-gitops-repair-path.md)
 - [CI preflight ошибочно требовал materialized Clawdiy runtime home до deploy/render шага](../docs/rca/2026-03-14-clawdiy-ci-preflight-materialization-assumption.md)
@@ -86,7 +87,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (11 lessons)
+#### process (12 lessons)
+- [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
 - [CI preflight ошибочно требовал materialized Clawdiy runtime home до deploy/render шага](../docs/rca/2026-03-14-clawdiy-ci-preflight-materialization-assumption.md)
 - [Официальный мастер настройки Clawdiy не мог завершить OAuth из-за неверного контракта домашнего каталога OpenClaw](../docs/rca/2026-03-13-clawdiy-official-wizard-runtime-home-contract-mismatch.md)
@@ -115,7 +117,7 @@
 - `github-actions` (11 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
-- `gitops` (8 lessons)
+- `gitops` (9 lessons)
 - `clawdiy` (8 lessons)
 - `deploy` (7 lessons)
 - `rca` (6 lessons)
@@ -130,10 +132,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 37 |
+| Total Lessons | 38 |
 | Critical (P0/P1) | 13 |
 | Categories | 5 |
-| Unique Tags | 90 |
+| Unique Tags | 92 |
 
 ---
 

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -45,21 +45,31 @@ curl -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
 ./scripts/telegram-webhook-monitor.sh --json
 
 # Server-side cron (GitOps): scripts/cron.d/moltis-telegram-webhook-monitor
-# CI schedule: .github/workflows/telegram-webhook-monitor.yml
+# Контракт по умолчанию: пассивный check (без sendMessage probe, пока не задан TELEGRAM_TEST_USER)
+# .github/workflows/telegram-webhook-monitor.yml запускается вручную (workflow_dispatch)
+```
+
+### Канонический post-deploy UAT (без постоянного спама)
+
+```bash
+gh workflow run telegram-e2e-on-demand.yml \
+  -f message='/status' \
+  -f operator_intent='post_deploy_verification'
 ```
 
 ### Standalone Telegram CLI (без Moltis)
 
 ```bash
-# User-level UAT probe (главный режим)
+# User-level UAT probe (MTProto, opt-in)
 ./scripts/telegram-user-monitor.sh --env-file .env
+# Cron для этого probe выключен по умолчанию: scripts/cron.d/moltis-telegram-user-monitor
 
 # Альтернатива без API_HASH: Telegram Web
 ./scripts/setup-telegram-web-user-monitor.sh --project-dir /opt/moltinger-active
 node scripts/telegram-web-user-login.mjs --state /opt/moltinger-active/data/.telegram-web-state.json
 TELEGRAM_WEB_PROBE_PROFILE=echo_ping TELEGRAM_WEB_MESSAGE=test2 ./scripts/telegram-web-user-monitor.sh
 
-# Primary scheduler (systemd timer)
+# Legacy scheduler (systemd timer, держать выключенным вне диагностики)
 systemctl enable --now moltis-telegram-web-user-monitor.timer
 
 # Поднять webhook endpoint (Traefik + echo)

--- a/docs/TELEGRAM-USER-MONITOR.md
+++ b/docs/TELEGRAM-USER-MONITOR.md
@@ -7,7 +7,7 @@
 - `scripts/telegram-user-send.py` — ручная отправка как пользователь (MTProto)
 - `scripts/telegram-user-probe.py` — одноразовый probe + валидация ответа
 - `scripts/telegram-user-monitor.sh` — обёртка для cron/systemd
-- `scripts/cron.d/moltis-telegram-user-monitor` — периодический запуск каждые 10 минут
+- `scripts/cron.d/moltis-telegram-user-monitor` — opt-in cron (по умолчанию выключен)
 
 ## Обязательные переменные
 
@@ -48,8 +48,25 @@ Cron-файл:
 scripts/cron.d/moltis-telegram-user-monitor
 ```
 
+По умолчанию cron-строка в этом файле закомментирована, чтобы не создавать лишний Telegram-шум в production.
+Включайте только на ограниченный период диагностики.
+
+Чтобы временно включить:
+
+1. Раскомментировать строку `*/10 ... telegram-user-monitor.sh` в `scripts/cron.d/moltis-telegram-user-monitor`
+2. Задеплоить через GitOps
+3. После диагностики вернуть строку обратно в комментарий
+
 Лог:
 
 ```bash
 /var/log/moltis/telegram-user-monitor.log
+```
+
+Для регулярной пост-деплой проверки используйте on-demand workflow:
+
+```bash
+gh workflow run telegram-e2e-on-demand.yml \
+  -f message='/status' \
+  -f operator_intent='post_deploy_verification'
 ```

--- a/docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md
+++ b/docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md
@@ -1,0 +1,74 @@
+---
+title: "Telegram monitor generated unsolicited user-facing traffic by default"
+date: 2026-03-20
+severity: P2
+category: process
+tags: [telegram, uat, monitor, cron, gitops, signal-noise]
+root_cause: "Two periodic monitor lanes were effectively active-by-default in production, while webhook probe logic auto-selected a chat target from allowlist, turning health checks into unsolicited user-visible messages"
+---
+
+# RCA: Telegram monitor generated unsolicited user-facing traffic by default
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** Production получал регулярные служебные Telegram-сообщения от monitor-процедур, что засоряло пользовательский чат и ухудшало операторский сигнал.
+
+## Ошибка
+
+В контуре мониторинга одновременно действовали:
+
+1. cron для `telegram-user-monitor` (MTProto) каждые 10 минут;
+2. cron для `telegram-webhook-monitor` каждые 15 минут;
+3. fallback в `telegram-webhook-monitor.sh`, который при пустом `TELEGRAM_TEST_USER` брал первый ID из `TELEGRAM_ALLOWED_USERS`.
+
+Итог: даже без явного намерения оператора health-check мог отправлять реальные сообщения в пользовательский чат.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему появлялись лишние сообщения в Telegram? | Потому что мониторинг периодически отправлял probe-сообщения в production чат. | `/etc/cron.d/moltis-telegram-user-monitor`, `/etc/cron.d/moltis-telegram-webhook-monitor` на сервере; `scripts/telegram-webhook-monitor.sh` вызывал `sendMessage`. |
+| 2 | Почему probe выбирал реального пользователя автоматически? | При пустом `TELEGRAM_TEST_USER` скрипт подставлял первый `TELEGRAM_ALLOWED_USERS`. | До фикса: `TELEGRAM_TEST_USER="${TELEGRAM_ALLOWED_USERS%%,*}"` в `scripts/telegram-webhook-monitor.sh`. |
+| 3 | Почему это было включено постоянно, а не только для диагностики? | Cron-шаблон MTProto lane содержал активную строку по умолчанию, а webhook lane требовал test user. | `scripts/cron.d/moltis-telegram-user-monitor` и `scripts/cron.d/moltis-telegram-webhook-monitor` до фикса. |
+| 4 | Почему это не ловилось как контрактная ошибка? | Не было статических guard-тестов на «opt-in only» мониторинг и запрет auto-fallback для test user. | `tests/static/test_config_validation.sh` не проверял эти условия до фикса. |
+| 5 | Почему это важно для rollout-качества? | Шум в чате маскирует реальные UAT-сигналы и раздражает пользователя, что снижает доверие к post-deploy верификации. | Операторская обратная связь + runbook contract про manual on-demand UAT. |
+
+## Корневая причина
+
+Контракт между «health monitoring» и «user-facing Telegram traffic» не был fail-closed: активные по умолчанию cron-задачи и fallback выбора chat-id фактически превращали мониторинг в регулярные пользовательские уведомления.
+
+## Принятые меры
+
+1. `scripts/telegram-webhook-monitor.sh`
+   - удалён fallback `TELEGRAM_ALLOWED_USERS -> TELEGRAM_TEST_USER`;
+   - `TELEGRAM_REQUIRE_TEST_USER` переведён в default `false`;
+   - добавлен `TELEGRAM_PROBE_DISABLE_NOTIFICATION` (default `true`);
+   - добавлены поля `send_probe_attempted` и `probe_skipped_reason` в JSON отчёт.
+2. `scripts/cron.d/moltis-telegram-webhook-monitor`
+   - default `TELEGRAM_REQUIRE_TEST_USER=false`;
+   - добавлен default `TELEGRAM_PROBE_DISABLE_NOTIFICATION=true`;
+   - зафиксирован opt-in характер active probe.
+3. `scripts/cron.d/moltis-telegram-user-monitor`
+   - cron-строка закомментирована (disabled by default, opt-in only).
+4. `tests/static/test_config_validation.sh`
+   - добавлены guard-тесты на:
+     - отсутствие auto-fallback по allowlist;
+     - passive defaults для webhook cron;
+     - disabled-by-default MTProto cron.
+5. Документация
+   - обновлены `docs/TELEGRAM-USER-MONITOR.md` и `docs/QUICK-REFERENCE.md` под contract «manual authoritative UAT + opt-in periodic monitors».
+
+## Подтверждение устранения
+
+- Локально:
+  - `bash tests/static/test_config_validation.sh` — pass
+  - `bash -n scripts/telegram-webhook-monitor.sh` — pass
+- Контракт по коду:
+  - webhook-monitor больше не выбирает chat-id из allowlist автоматически;
+  - MTProto cron не запускается, пока оператор явно не раскомментирует строку.
+
+## Уроки
+
+1. Любой мониторинг, который может отправлять сообщения пользователю, должен быть `opt-in` по умолчанию.
+2. Health-check и user-facing notifications должны быть разделены контрактно, а не только документированы.
+3. Анти-шум правила должны быть зафиксированы static-guard тестами, иначе настройка быстро деградирует в соседних ветках.

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -148,5 +148,6 @@ Current rollback contract:
 
 ## References
 
+- [research/moltis-official-version-update-channel-2026-03-20.md](research/moltis-official-version-update-channel-2026-03-20.md)
 - [deployment-strategy.md](deployment-strategy.md)
 - [disaster-recovery.md](disaster-recovery.md)

--- a/scripts/cron.d/moltis-telegram-user-monitor
+++ b/scripts/cron.d/moltis-telegram-user-monitor
@@ -18,5 +18,6 @@ TELEGRAM_MONITOR_POLL_INTERVAL=2
 TELEGRAM_MONITOR_MIN_REPLY_LEN=2
 TELEGRAM_SESSION=/opt/moltinger-active/data/.telegram-user
 
-# Every 10 minutes run user-level monitor and append JSON report.
-*/10 * * * * root mkdir -p /var/log/moltis && /opt/moltinger-active/scripts/telegram-user-monitor.sh >> /var/log/moltis/telegram-user-monitor.log 2>&1
+# Disabled by default to avoid unsolicited user-facing Telegram traffic.
+# Enable only for short-lived diagnostics windows.
+# */10 * * * * root mkdir -p /var/log/moltis && /opt/moltinger-active/scripts/telegram-user-monitor.sh >> /var/log/moltis/telegram-user-monitor.log 2>&1

--- a/scripts/cron.d/moltis-telegram-webhook-monitor
+++ b/scripts/cron.d/moltis-telegram-webhook-monitor
@@ -8,14 +8,17 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-# Force webhook mode for production quality gate.
+# Keep webhook readiness checks enabled.
+# Probe message stays passive-by-default (no required chat target).
 TELEGRAM_REQUIRE_WEBHOOK=true
 TELEGRAM_REQUIRE_HTTPS_WEBHOOK=true
-TELEGRAM_REQUIRE_TEST_USER=true
+TELEGRAM_REQUIRE_TEST_USER=false
+TELEGRAM_PROBE_DISABLE_NOTIFICATION=true
 TELEGRAM_MAX_PENDING_UPDATES=3
 MONITOR_VALIDATE_PREVIEW=true
 MOLTIS_BASE_URL=http://localhost:13131
 MOLTIS_ENV_FILE=/opt/moltinger-active/.env
 
 # Every 15 minutes run monitor and append JSON report.
+# Active sendMessage probe runs only when TELEGRAM_TEST_USER is set explicitly.
 */15 * * * * root mkdir -p /var/log/moltis && /opt/moltinger-active/scripts/telegram-webhook-monitor.sh --json >> /var/log/moltis/telegram-webhook-monitor.log 2>&1

--- a/scripts/telegram-webhook-monitor.sh
+++ b/scripts/telegram-webhook-monitor.sh
@@ -25,11 +25,11 @@ Environment:
   MOLTIS_BASE_URL                  Moltis base URL (default: http://localhost:13131)
   MOLTIS_PASSWORD                  Auth password for Moltis UI/API (optional for preview checks)
   TELEGRAM_BOT_TOKEN               Telegram bot token (required)
-  TELEGRAM_ALLOWED_USERS           Comma-separated Telegram user IDs (optional)
-  TELEGRAM_TEST_USER               Telegram user ID for probe message (optional)
+  TELEGRAM_TEST_USER               Telegram user ID for probe message (optional; no auto-fallback)
   TELEGRAM_REQUIRE_WEBHOOK         true|false (default: true)
   TELEGRAM_REQUIRE_HTTPS_WEBHOOK   true|false (default: true)
-  TELEGRAM_REQUIRE_TEST_USER       true|false (default: true)
+  TELEGRAM_REQUIRE_TEST_USER       true|false (default: false)
+  TELEGRAM_PROBE_DISABLE_NOTIFICATION true|false (default: true)
   TELEGRAM_MAX_PENDING_UPDATES     Non-negative integer (default: 3)
   TELEGRAM_TIMEOUT_SECONDS         HTTP timeout in seconds (default: 20)
   MONITOR_VALIDATE_PREVIEW         true|false (default: true)
@@ -95,7 +95,8 @@ MOLTIS_ENV_FILE="${MOLTIS_ENV_FILE:-$PROJECT_ROOT/.env}"
 MOLTIS_BASE_URL="${MOLTIS_BASE_URL:-http://localhost:13131}"
 TELEGRAM_REQUIRE_WEBHOOK="${TELEGRAM_REQUIRE_WEBHOOK:-true}"
 TELEGRAM_REQUIRE_HTTPS_WEBHOOK="${TELEGRAM_REQUIRE_HTTPS_WEBHOOK:-true}"
-TELEGRAM_REQUIRE_TEST_USER="${TELEGRAM_REQUIRE_TEST_USER:-true}"
+TELEGRAM_REQUIRE_TEST_USER="${TELEGRAM_REQUIRE_TEST_USER:-false}"
+TELEGRAM_PROBE_DISABLE_NOTIFICATION="${TELEGRAM_PROBE_DISABLE_NOTIFICATION:-true}"
 TELEGRAM_MAX_PENDING_UPDATES="${TELEGRAM_MAX_PENDING_UPDATES:-3}"
 TELEGRAM_TIMEOUT_SECONDS="${TELEGRAM_TIMEOUT_SECONDS:-20}"
 MONITOR_VALIDATE_PREVIEW="${MONITOR_VALIDATE_PREVIEW:-true}"
@@ -111,12 +112,7 @@ fi
 
 TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
 MOLTIS_PASSWORD="${MOLTIS_PASSWORD:-}"
-TELEGRAM_ALLOWED_USERS="${TELEGRAM_ALLOWED_USERS:-}"
 TELEGRAM_TEST_USER="${TELEGRAM_TEST_USER:-}"
-
-if [[ -z "$TELEGRAM_TEST_USER" && -n "$TELEGRAM_ALLOWED_USERS" ]]; then
-    TELEGRAM_TEST_USER="${TELEGRAM_ALLOWED_USERS%%,*}"
-fi
 
 if ! [[ "$TELEGRAM_MAX_PENDING_UPDATES" =~ ^[0-9]+$ ]]; then
     add_failure "TELEGRAM_MAX_PENDING_UPDATES must be a non-negative integer"
@@ -141,7 +137,9 @@ telegram_ok=false
 webhook_configured=false
 webhook_https=false
 send_probe_ok=false
+send_probe_attempted=false
 preview_clean=true
+probe_skipped_reason=""
 
 bot_username=""
 bot_id=""
@@ -209,16 +207,27 @@ fi
 
 if [[ -z "$TELEGRAM_TEST_USER" ]]; then
     if is_true "$TELEGRAM_REQUIRE_TEST_USER"; then
-        add_failure "TELEGRAM_TEST_USER not set (and TELEGRAM_ALLOWED_USERS is empty)"
+        add_failure "TELEGRAM_TEST_USER not set"
     else
-        add_warning "TELEGRAM_TEST_USER not set: probe message skipped"
+        probe_skipped_reason="test_user_not_configured"
     fi
 else
     if ! [[ "$TELEGRAM_TEST_USER" =~ ^[0-9]+$ ]]; then
         add_failure "TELEGRAM_TEST_USER must be numeric"
     elif [[ "$telegram_ok" == "true" ]]; then
+        send_probe_attempted=true
+        probe_disable_notification=false
+        if is_true "$TELEGRAM_PROBE_DISABLE_NOTIFICATION"; then
+            probe_disable_notification=true
+        fi
         probe_text="[monitor] telegram/webhook probe $(timestamp_utc)"
-        probe_payload="$(jq -cn --arg chat_id "$TELEGRAM_TEST_USER" --arg text "$probe_text" '{chat_id:$chat_id,text:$text}')"
+        probe_payload="$(
+            jq -cn \
+                --arg chat_id "$TELEGRAM_TEST_USER" \
+                --arg text "$probe_text" \
+                --argjson disable_notification "$probe_disable_notification" \
+                '{chat_id:$chat_id,text:$text,disable_notification:$disable_notification}'
+        )"
         probe_resp="$(telegram_api "sendMessage" "$probe_payload" || true)"
 
         if ! echo "$probe_resp" | jq -e '.' >/dev/null 2>&1; then
@@ -320,11 +329,13 @@ report_json="$(
         --arg inbound_mode "$inbound_mode" \
         --arg telegram_preview "$telegram_preview" \
         --arg probe_message_id "$probe_message_id" \
+        --arg probe_skipped_reason "$probe_skipped_reason" \
         --argjson pending_updates "${pending_updates:-0}" \
         --argjson telegram_ok "$telegram_ok" \
         --argjson webhook_configured "$webhook_configured" \
         --argjson webhook_https "$webhook_https" \
         --argjson send_probe_ok "$send_probe_ok" \
+        --argjson send_probe_attempted "$send_probe_attempted" \
         --argjson preview_clean "$preview_clean" \
         --argjson failures "$failures_json" \
         --argjson warnings "$warnings_json" \
@@ -336,6 +347,7 @@ report_json="$(
                 webhook_configured: $webhook_configured,
                 webhook_https: $webhook_https,
                 pending_updates: $pending_updates,
+                send_probe_attempted: $send_probe_attempted,
                 send_probe_ok: $send_probe_ok,
                 preview_clean: $preview_clean
             },
@@ -345,6 +357,7 @@ report_json="$(
                 webhook_url: $webhook_url,
                 inbound_mode: $inbound_mode,
                 probe_message_id: $probe_message_id,
+                probe_skipped_reason: $probe_skipped_reason,
                 telegram_preview: $telegram_preview
             },
             failures: $failures,

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -24,6 +24,9 @@ DEPLOY_SCRIPT="$PROJECT_ROOT/scripts/deploy.sh"
 BACKUP_SCRIPT="$PROJECT_ROOT/scripts/backup-moltis-enhanced.sh"
 MOLTIS_VERSION_HELPER="$PROJECT_ROOT/scripts/moltis-version.sh"
 MOLTIS_VERSION_SCRIPT="$PROJECT_ROOT/scripts/moltis-version.sh"
+TELEGRAM_WEBHOOK_MONITOR_SCRIPT="$PROJECT_ROOT/scripts/telegram-webhook-monitor.sh"
+TELEGRAM_WEBHOOK_MONITOR_CRON="$PROJECT_ROOT/scripts/cron.d/moltis-telegram-webhook-monitor"
+TELEGRAM_USER_MONITOR_CRON="$PROJECT_ROOT/scripts/cron.d/moltis-telegram-user-monitor"
 
 validate_toml() {
     local file_path="$1"
@@ -123,6 +126,31 @@ PY
         test_pass
     else
         test_fail "Moltis version helper must exist, validate compose alignment, and forbid latest as the tracked default"
+    fi
+
+    test_start "static_telegram_webhook_monitor_never_falls_back_to_allowed_users"
+    if rg -Fq 'TELEGRAM_REQUIRE_TEST_USER="${TELEGRAM_REQUIRE_TEST_USER:-false}"' "$TELEGRAM_WEBHOOK_MONITOR_SCRIPT" && \
+       rg -Fq 'TELEGRAM_PROBE_DISABLE_NOTIFICATION="${TELEGRAM_PROBE_DISABLE_NOTIFICATION:-true}"' "$TELEGRAM_WEBHOOK_MONITOR_SCRIPT" && \
+       ! rg -Fq 'TELEGRAM_TEST_USER="${TELEGRAM_ALLOWED_USERS%%,*}"' "$TELEGRAM_WEBHOOK_MONITOR_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Webhook monitor must not infer TELEGRAM_TEST_USER from allowlist and should keep probe notification policy explicit"
+    fi
+
+    test_start "static_telegram_webhook_cron_defaults_to_passive_probe_mode"
+    if rg -q '^TELEGRAM_REQUIRE_TEST_USER=false$' "$TELEGRAM_WEBHOOK_MONITOR_CRON" && \
+       rg -q '^TELEGRAM_PROBE_DISABLE_NOTIFICATION=true$' "$TELEGRAM_WEBHOOK_MONITOR_CRON"; then
+        test_pass
+    else
+        test_fail "Webhook cron defaults must keep active Telegram probe opt-in and quiet"
+    fi
+
+    test_start "static_telegram_user_monitor_cron_is_disabled_by_default"
+    if rg -q '^# \*/10 .*telegram-user-monitor\.sh' "$TELEGRAM_USER_MONITOR_CRON" && \
+       ! rg -q '^\*/10 .*telegram-user-monitor\.sh' "$TELEGRAM_USER_MONITOR_CRON"; then
+        test_pass
+    else
+        test_fail "MTProto user-monitor cron should be opt-in and disabled by default to avoid unsolicited chat noise"
     fi
 
     test_start "static_config_has_no_hardcoded_secrets"


### PR DESCRIPTION
## Что изменено
- Убран auto-fallback TELEGRAM_ALLOWED_USERS -> TELEGRAM_TEST_USER в scripts/telegram-webhook-monitor.sh
- Webhook cron переведен в passive-by-default (TELEGRAM_REQUIRE_TEST_USER=false, TELEGRAM_PROBE_DISABLE_NOTIFICATION=true)
- MTProto user-monitor cron отключен по умолчанию (opt-in)
- Добавлены static-guard проверки на anti-noise контракт
- Обновлены runbook/quick-reference + добавлен RCA и обновлен lessons index

## Проверки
- bash -n scripts/telegram-webhook-monitor.sh
- bash -n tests/static/test_config_validation.sh
- bash tests/static/test_config_validation.sh (73/73)

## Цель
Закрепить контракт: регулярные мониторинги не должны засорять пользовательский Telegram-чат, а authoritative UAT остается ручным on-demand.