### PR TITLE
fix(telegram): align webhook monitor with production polling mode

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 38
+**Total Lessons**: 39
 
 ---
 
@@ -28,8 +28,9 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (15 lessons)
+#### P2 (16 lessons)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
+- [Telegram webhook monitor default expected webhook while production stayed in polling mode](../docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md)
 - [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
 - [Moltis update proposal workflow failed with workflow-file issue due to forbidden secrets context in step if](../docs/rca/2026-03-20-moltis-update-proposal-workflow-file-issue-on-secrets-context.md)
 - [Deploy Clawdiy блокировался на dirty checkout без auditable repair path](../docs/rca/2026-03-14-clawdiy-deploy-missing-gitops-repair-path.md)
@@ -87,7 +88,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (12 lessons)
+#### process (13 lessons)
+- [Telegram webhook monitor default expected webhook while production stayed in polling mode](../docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md)
 - [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
 - [CI preflight ошибочно требовал materialized Clawdiy runtime home до deploy/render шага](../docs/rca/2026-03-14-clawdiy-ci-preflight-materialization-assumption.md)
@@ -115,15 +117,15 @@
 ### Popular Tags
 
 - `github-actions` (11 lessons)
+- `gitops` (10 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
-- `gitops` (9 lessons)
 - `clawdiy` (8 lessons)
 - `deploy` (7 lessons)
 - `rca` (6 lessons)
 - `openclaw` (6 lessons)
+- `telegram` (5 lessons)
 - `docker` (5 lessons)
-- `topology-registry` (4 lessons)
 
 
 ---
@@ -132,10 +134,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 38 |
+| Total Lessons | 39 |
 | Critical (P0/P1) | 13 |
 | Categories | 5 |
-| Unique Tags | 92 |
+| Unique Tags | 95 |
 
 ---
 

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -45,7 +45,7 @@ curl -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
 ./scripts/telegram-webhook-monitor.sh --json
 
 # Server-side cron (GitOps): scripts/cron.d/moltis-telegram-webhook-monitor
-# Контракт по умолчанию: пассивный check (без sendMessage probe, пока не задан TELEGRAM_TEST_USER)
+# Контракт по умолчанию: polling-friendly + пассивный check (без sendMessage probe, пока не задан TELEGRAM_TEST_USER)
 # .github/workflows/telegram-webhook-monitor.yml запускается вручную (workflow_dispatch)
 ```
 

--- a/docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md
+++ b/docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md
@@ -1,0 +1,62 @@
+---
+title: "Telegram webhook monitor default expected webhook while production stayed in polling mode"
+date: 2026-03-20
+severity: P2
+category: process
+tags: [telegram, monitor, polling, webhook, contract-drift, gitops]
+root_cause: "Cron defaults for webhook monitor enforced TELEGRAM_REQUIRE_WEBHOOK=true despite documented production transport mode polling, producing permanent false-fail monitor verdicts"
+---
+
+# RCA: Telegram webhook monitor default expected webhook while production stayed in polling mode
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** Периодический монитор webhook в production стабильно возвращал `fail` даже при рабочем сервисе, потому что проверял неподходящий transport-контракт.
+
+## Ошибка
+
+После deploy `main` (run `23352151759`) ручной запуск:
+
+`/opt/moltinger-active/scripts/telegram-webhook-monitor.sh --json`
+
+давал:
+
+- `inbound_mode: polling`
+- `failures: Telegram webhook is not configured; inbound_mode expected webhook`
+
+При этом production-контракт у проекта для канала Telegram оставался `polling`.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему монитор давал `fail`? | Потому что требовал webhook-mode. | `/etc/cron.d/moltis-telegram-webhook-monitor`: `TELEGRAM_REQUIRE_WEBHOOK=true` до фикса. |
+| 2 | Почему это было неверно для production? | Production transport фактически работал в polling-mode. | Runtime report: `inbound_mode=polling`; runbook `docs/telegram-e2e-on-demand.md` фиксирует polling как текущий transport. |
+| 3 | Почему несоответствие не ловилось заранее? | Static-guard тест проверял только probe/noise параметры, но не `TELEGRAM_REQUIRE_WEBHOOK`. | `tests/static/test_config_validation.sh` до фикса. |
+| 4 | Почему это важно? | Постоянный ложный `fail` снижает доверие к мониторингу и маскирует реальные инциденты. | Операторская диагностика после merge/deploy anti-noise ветки. |
+| 5 | Почему drift закрепился? | Контракт monitor defaults не был явно привязан к текущему production transport mode. | Отсутствовал явный polling-friendly default в cron contract. |
+
+## Корневая причина
+
+Contract drift между cron default параметрами webhook-monitor и фактическим production transport mode (`polling`).
+
+## Принятые меры
+
+1. `scripts/cron.d/moltis-telegram-webhook-monitor`
+   - `TELEGRAM_REQUIRE_WEBHOOK` изменён на `false` по умолчанию;
+   - комментарий обновлён: webhook requirement включается только при осознанном cutover.
+2. `tests/static/test_config_validation.sh`
+   - static-guard теперь требует `TELEGRAM_REQUIRE_WEBHOOK=false` в webhook cron defaults.
+3. `docs/QUICK-REFERENCE.md`
+   - зафиксирован `polling-friendly` default для server-side monitor.
+
+## Подтверждение устранения
+
+- `bash tests/static/test_config_validation.sh` — pass (включая новый guard).
+- Ручной запуск monitor на сервере в default-contract больше не должен падать из-за transport mismatch.
+
+## Уроки
+
+1. Health-monitor defaults должны быть синхронизированы с фактическим production transport mode.
+2. Любой contract параметр monitor-кронов должен иметь static-guard в CI.
+3. Переход `polling -> webhook` должен оформляться как явный rollout-step, а не скрытый дефолт.

--- a/scripts/cron.d/moltis-telegram-webhook-monitor
+++ b/scripts/cron.d/moltis-telegram-webhook-monitor
@@ -8,9 +8,9 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-# Keep webhook readiness checks enabled.
-# Probe message stays passive-by-default (no required chat target).
-TELEGRAM_REQUIRE_WEBHOOK=true
+# Keep default monitor aligned with production polling mode.
+# If webhook cutover is enabled intentionally, set TELEGRAM_REQUIRE_WEBHOOK=true explicitly.
+TELEGRAM_REQUIRE_WEBHOOK=false
 TELEGRAM_REQUIRE_HTTPS_WEBHOOK=true
 TELEGRAM_REQUIRE_TEST_USER=false
 TELEGRAM_PROBE_DISABLE_NOTIFICATION=true

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -138,11 +138,12 @@ PY
     fi
 
     test_start "static_telegram_webhook_cron_defaults_to_passive_probe_mode"
-    if rg -q '^TELEGRAM_REQUIRE_TEST_USER=false$' "$TELEGRAM_WEBHOOK_MONITOR_CRON" && \
+    if rg -q '^TELEGRAM_REQUIRE_WEBHOOK=false$' "$TELEGRAM_WEBHOOK_MONITOR_CRON" && \
+       rg -q '^TELEGRAM_REQUIRE_TEST_USER=false$' "$TELEGRAM_WEBHOOK_MONITOR_CRON" && \
        rg -q '^TELEGRAM_PROBE_DISABLE_NOTIFICATION=true$' "$TELEGRAM_WEBHOOK_MONITOR_CRON"; then
         test_pass
     else
-        test_fail "Webhook cron defaults must keep active Telegram probe opt-in and quiet"
+        test_fail "Webhook cron defaults must stay polling-friendly and keep active Telegram probe opt-in + quiet"
     fi
 
     test_start "static_telegram_user_monitor_cron_is_disabled_by_default"


### PR DESCRIPTION
## Что исправлено
- Для server-side webhook monitor в cron default выставлен TELEGRAM_REQUIRE_WEBHOOK=false
- Контракт остался anti-noise: TELEGRAM_REQUIRE_TEST_USER=false и TELEGRAM_PROBE_DISABLE_NOTIFICATION=true
- Добавлен static-guard, чтобы cron default оставался polling-friendly
- Добавлен RCA и обновлен lessons index

## Почему
После deploy #81 ручной прогон monitor в production давал ложный fail из-за mismatch: runtime inbound_mode=polling, а cron требовал webhook.

## Проверки
- bash -n tests/static/test_config_validation.sh
- bash tests/static/test_config_validation.sh (73/73)
