### PR TITLE
fix(deploy): block tracked Moltis downgrade regressions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -402,6 +402,52 @@ jobs:
 
           echo "::notice::All preflight checks passed"
 
+      - name: Setup SSH for version regression guard
+        if: steps.validate.outputs.should_deploy == 'true'
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add host to known hosts for version regression guard
+        if: steps.validate.outputs.should_deploy == 'true'
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H ${{ env.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Prevent tracked version regressions against running production baseline
+        if: steps.validate.outputs.should_deploy == 'true'
+        run: |
+          set -euo pipefail
+
+          TRACKED_VERSION="${{ steps.version.outputs.version }}"
+          REMOTE_IMAGE="$(ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} "docker inspect --format='{{.Config.Image}}' ${{ env.CONTAINER_NAME }} 2>/dev/null || true")"
+
+          if [[ -z "$REMOTE_IMAGE" ]]; then
+            echo "::notice::No running Moltis container detected on server; skipping version regression guard."
+            exit 0
+          fi
+
+          if [[ "$REMOTE_IMAGE" != "${{ env.MOLTIS_IMAGE }}:"* ]]; then
+            echo "::warning::Running image '$REMOTE_IMAGE' is outside tracked Moltis image namespace; skipping version regression guard."
+            exit 0
+          fi
+
+          REMOTE_VERSION="${REMOTE_IMAGE##*:}"
+
+          if [[ ! "$REMOTE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z._-]+)?$ ]]; then
+            echo "::warning::Running Moltis image uses non-semver tag '$REMOTE_VERSION'; skipping version regression guard."
+            exit 0
+          fi
+
+          NEWEST="$(printf '%s\n%s\n' "$REMOTE_VERSION" "$TRACKED_VERSION" | sort -V | tail -n1)"
+          if [[ "$NEWEST" != "$TRACKED_VERSION" && "$REMOTE_VERSION" != "$TRACKED_VERSION" ]]; then
+            echo "::error::Tracked Moltis version regression detected: running=$REMOTE_VERSION tracked=$TRACKED_VERSION"
+            echo "::error::Production downgrade via tracked git version is blocked. Use explicit rollback flow instead."
+            exit 1
+          fi
+
+          echo "::notice::Version regression guard passed: running=$REMOTE_VERSION tracked=$TRACKED_VERSION"
+
       - name: Run preflight validation script
         id: preflight
         if: steps.validate.outputs.should_deploy == 'true'

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 39
+**Total Lessons**: 40
 
 ---
 
@@ -14,9 +14,10 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (12 lessons)
+#### P1 (13 lessons)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
 - [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
+- [Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline](../docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md)
 - [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
 - [Deploy collision and active-root symlink guard](../docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
@@ -64,12 +65,13 @@
 ### By Category
 
 
-#### cicd (15 lessons)
+#### cicd (16 lessons)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
 - [Test Suite gate failed because CI runner missed sqlite3 dependency for component_codex_session_path_repair](../docs/rca/2026-03-20-test-suite-gate-failed-on-missing-sqlite3-dependency.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
 - [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
 - [Moltis update proposal workflow failed with workflow-file issue due to forbidden secrets context in step if](../docs/rca/2026-03-20-moltis-update-proposal-workflow-file-issue-on-secrets-context.md)
+- [Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline](../docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md)
 - [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
 - [Deploy collision and active-root symlink guard](../docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md)
 - [Codex monitor threshold coupled to tomllib availability](../docs/rca/2026-03-15-codex-monitor-threshold-coupled-to-tomllib.md)
@@ -116,12 +118,12 @@
 
 ### Popular Tags
 
+- `gitops` (11 lessons)
 - `github-actions` (11 lessons)
-- `gitops` (10 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
+- `deploy` (8 lessons)
 - `clawdiy` (8 lessons)
-- `deploy` (7 lessons)
 - `rca` (6 lessons)
 - `openclaw` (6 lessons)
 - `telegram` (5 lessons)
@@ -134,10 +136,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 39 |
-| Critical (P0/P1) | 13 |
+| Total Lessons | 40 |
+| Critical (P0/P1) | 14 |
 | Categories | 5 |
-| Unique Tags | 95 |
+| Unique Tags | 98 |
 
 ---
 

--- a/docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md
+++ b/docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md
@@ -1,0 +1,61 @@
+---
+title: "Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [moltis, deploy, gitops, versioning, regression-guard, rollback-safety]
+root_cause: "Preflight validated tracked version format and branch source, but did not compare tracked git version with currently running production baseline, so stale main state could trigger an unintended downgrade rollout"
+---
+
+# RCA: Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** Высокий риск повторного незаметного downgrade при merge stale-ветки в `main` и обычном production deploy.
+
+## Ошибка
+
+После стабилизации прода на `0.10.18` был выявлен незакрытый путь:
+
+- deploy использует tracked версию из `main` (это корректно),
+- но до фикса не было preflight-проверки, что tracked версия не ниже уже работающей на сервере.
+
+В результате stale merge в `main` потенциально мог инициировать downgrade через стандартный workflow, без явного rollback-сценария.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему downgrade мог пройти через обычный deploy? | Потому что workflow не сравнивал tracked git версию с текущей running version на сервере. | `.github/workflows/deploy.yml` до фикса: отсутствовал compare gate `running vs tracked`. |
+| 2 | Почему это не ловили текущие проверки? | Проверки валидировали формат/version-source (`main`, tag->main, pinned semver), но не semantic monotonicity. | `scripts/moltis-version.sh`, static tests до фикса. |
+| 3 | Почему это опасно именно после стабилизации на `0.10.18`? | Любой stale merge в `main` с более старым tag мог запустить “легальный” deploy и вернуть старую версию. | Deploy trigger: `push` на `main`; tracked version из compose. |
+| 4 | Почему rollback-механизм не решал эту проблему? | Rollback — это recovery path, а не защита от неверного normal rollout. | Политика runbook: rollback должен быть осознанным recovery, не побочным эффектом deploy. |
+| 5 | Почему риск был системным? | Контракт не фиксировал правило “normal deploy не имеет права понижать версию относительно текущего baseline”. | Отсутствовал explicit anti-regression gate в CI/CD и static-guard. |
+
+## Корневая причина
+
+В production deploy-контракте отсутствовал fail-closed anti-regression gate для сравнения tracked git версии и текущего running baseline на сервере.
+
+## Принятые меры
+
+1. `.github/workflows/deploy.yml`:
+   - добавлен preflight шаг `Prevent tracked version regressions against running production baseline`;
+   - если running semver-tag выше tracked semver-tag, deploy блокируется;
+   - сообщение явно направляет в explicit rollback flow.
+2. `tests/static/test_config_validation.sh`:
+   - добавлен guard `static_deploy_blocks_tracked_version_regression_against_running_baseline`.
+3. Документация:
+   - `docs/version-update.md` обновлён: tracked-version downgrade через normal deploy запрещён;
+   - `docs/runbooks/moltis-backup-safe-update.md` обновлён: downgrade только через явный rollback path.
+
+## Подтверждение устранения
+
+- `bash tests/static/test_config_validation.sh` — pass.
+- В `deploy.yml` присутствует anti-regression preflight gate.
+- Runtime baseline остаётся `0.10.18`, deploy по `main` продолжает работать.
+
+## Уроки
+
+1. Pinned version и semver-валидность недостаточны без monotonicity guard относительно текущего production baseline.
+2. Rollback должен оставаться отдельным recovery-контуром и не подменяться обычным deploy.
+3. Любой production version contract должен иметь static test на anti-regression поведение.

--- a/docs/runbooks/moltis-backup-safe-update.md
+++ b/docs/runbooks/moltis-backup-safe-update.md
@@ -33,6 +33,7 @@ Operational policy in this repository:
 - Do not pull or restart a new Moltis image without a fresh pre-update backup.
 - Do not continue rollout if restore-check fails for that fresh backup.
 - Do not treat "previous image exists" as sufficient rollback evidence by itself.
+- Do not downgrade tracked version through normal deploy flow; use explicit rollback path.
 
 ## Required Evidence
 
@@ -115,6 +116,7 @@ GitHub Actions path:
 - `workflow_dispatch` target is production-only
 - release-tag deploy is allowed only when tag SHA matches current `origin/main` HEAD
 - manual version input defaults to blank and must equal tracked git version if provided
+- tracked version regression versus currently running semver image is blocked
 - backup step must finish successfully
 - restore-readiness validation must finish successfully
 - only then may the new Moltis image be pulled and started

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -43,6 +43,7 @@ Forbidden:
 - `sed -i` edits on the server
 - ad-hoc image pulls without a matching pre-update backup
 - rollout when restore-check has not passed for the same backup
+- tracked-version downgrades through `main` deploy path (use explicit rollback flow instead)
 
 Current tracked-helper contract in this branch:
 
@@ -85,6 +86,7 @@ BACKUP_FILE="$(cat data/moltis/.last-moltis-backup)"
 - allow only production target in workflow_dispatch
 - allow tag-triggered production deploy only when tag SHA equals current `origin/main` HEAD
 - keep manual version input blank by default (tracked git version is source of truth)
+- block deploy when tracked git version is lower than the currently running semver-tagged Moltis image
 - block deploy if restore readiness fails
 
 `.github/workflows/uat-gate.yml` is expected to:

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -275,6 +275,15 @@ PY
         test_fail "Deploy workflow must resolve tracked Moltis version, remove ad-hoc version input, forbid staging bypass, and block non-main tag deploys"
     fi
 
+    test_start "static_deploy_blocks_tracked_version_regression_against_running_baseline"
+    if rg -q 'Prevent tracked version regressions against running production baseline' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
+       rg -q 'Tracked Moltis version regression detected' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
+       rg -q 'sort -V' "$PROJECT_ROOT/.github/workflows/deploy.yml"; then
+        test_pass
+    else
+        test_fail "Deploy workflow must block tracked version regressions when running production Moltis version is newer"
+    fi
+
     test_start "static_deploy_surfaces_post_upgrade_protocol_skew_as_operator_signal"
     if rg -q 'Check post-upgrade web protocol skew' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \
        rg -q 'stale browser tabs' "$PROJECT_ROOT/.github/workflows/deploy.yml" && \


### PR DESCRIPTION
## Summary\n- add preflight guard in Deploy Moltis workflow to block tracked version regressions against the currently running production baseline\n- keep rollback as an explicit recovery path instead of allowing implicit downgrades via stale tracked compose version\n- add static contract test and docs/runbook updates\n- record RCA and rebuild lessons index\n\n## Validation\n- bash tests/static/test_config_validation.sh\n- bash scripts/moltis-version.sh assert-tracked\n\n## Why\nThis closes the remaining gap where a stale merge into main could trigger a production downgrade even though tracked version format and GitOps branch gates were already enforced.