### PR TITLE
fix(deploy): unblock tracked Moltis rollout by propagating CI context

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 42
+**Total Lessons**: 43
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (13 lessons)
+#### P1 (14 lessons)
+- [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
 - [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
 - [Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline](../docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md)
@@ -67,7 +68,8 @@
 ### By Category
 
 
-#### cicd (17 lessons)
+#### cicd (18 lessons)
+- [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
 - [Test Suite gate failed because CI runner missed sqlite3 dependency for component_codex_session_path_repair](../docs/rca/2026-03-20-test-suite-gate-failed-on-missing-sqlite3-dependency.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
@@ -122,16 +124,16 @@
 
 ### Popular Tags
 
+- `gitops` (12 lessons)
 - `github-actions` (12 lessons)
-- `gitops` (11 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
-- `deploy` (8 lessons)
+- `deploy` (9 lessons)
 - `clawdiy` (8 lessons)
 - `rca` (7 lessons)
 - `openclaw` (6 lessons)
+- `cicd` (6 lessons)
 - `telegram` (5 lessons)
-- `git-worktree` (5 lessons)
 
 
 ---
@@ -140,10 +142,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 42 |
-| Critical (P0/P1) | 14 |
+| Total Lessons | 43 |
+| Critical (P0/P1) | 15 |
 | Categories | 5 |
-| Unique Tags | 102 |
+| Unique Tags | 104 |
 
 ---
 

--- a/docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md
+++ b/docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md
@@ -1,0 +1,58 @@
+---
+title: "Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [cicd, deploy, gitops, guardrails, moltis, production]
+root_cause: "Remote tracked deploy wrapper did not propagate CI context to deploy.sh, so manual-confirmation guard aborted rollout inside GitHub Actions"
+---
+
+# RCA: Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** production deploy pipeline завершался `failure`, несмотря на успешные preflight/GitOps/backup шаги; финальный rollout до Moltis control-plane прерывался до старта контейнерного обновления.
+
+## Ошибка
+
+Падение в run `23357425657` (workflow `Deploy Moltis`, job `Deploy to Production`, step `Run tracked Moltis deploy control plane`):
+
+- лог показывал `GitOps Compliance Warning` как для ручного запуска;
+- затем `Operation cancelled`;
+- job завершался `##[error]Tracked deploy control plane failed`.
+
+## Анализ 5 Почему
+
+| Уровень | Почему | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему deploy pipeline падал на финальном шаге? | `deploy.sh` возвращал non-zero в tracked control-plane | run `23357425657`, failed step `Run tracked Moltis deploy control plane` |
+| 2 | Почему `deploy.sh` возвращал non-zero? | Срабатывал `gitops_confirm_manual` и отменял выполнение | лог: `GitOps Compliance Warning` + `Operation cancelled` |
+| 3 | Почему guard считал запуск ручным, хотя запуск был из GitHub Actions? | На удалённом хосте внутри `run-tracked-moltis-deploy.sh` не было CI-маркеров (`GITHUB_ACTIONS`, `GITHUB_RUN_ID`) | `scripts/gitops-guards.sh` -> `gitops_is_ci`, remote call path |
+| 4 | Почему CI-маркеры отсутствовали на remote hop? | Wrapper вызывал `deploy.sh --json moltis deploy` без проброса окружения для CI guard контракта | `scripts/run-tracked-moltis-deploy.sh` до фикса |
+| 5 | Почему дефект попал в main? | Не было статического контракта, проверяющего что tracked remote entrypoint запускает `deploy.sh` в non-interactive CI mode | отсутствие соответствующего static test до фикса |
+
+## Корневая причина
+
+В shared remote entrypoint (`run-tracked-moltis-deploy.sh`) не был явно зафиксирован CI/non-interactive execution contract при вызове `deploy.sh`.  
+Из-за этого GitOps manual-confirmation guard работал как в интерактивной сессии и отменял rollout в рамках CI/CD.
+
+## Принятые меры
+
+1. В `scripts/run-tracked-moltis-deploy.sh` добавлен явный проброс CI-контекста и non-interactive флага при вызове `deploy.sh`:
+   - `GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}`
+   - `GITHUB_RUN_ID=${GITHUB_RUN_ID:-$WORKFLOW_RUN}`
+   - `GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}`
+   - `GITOPS_CONFIRM_SKIP=true`
+2. Добавлен static guard `static_tracked_deploy_propagates_ci_context_for_noninteractive_guarded_deploy` в `tests/static/test_config_validation.sh`.
+
+## Проверка после исправлений
+
+| Проверка | Результат | Evidence |
+|----------|-----------|----------|
+| `bash tests/static/test_config_validation.sh` | pass | 83/83 |
+| Новый static guard для remote tracked deploy | pass | `static_tracked_deploy_propagates_ci_context_for_noninteractive_guarded_deploy` |
+
+## Уроки
+
+1. Любой SSH-hop из CI в remote script обязан явно восстанавливать execution context (CI/non-interactive), а не полагаться на implicit env inheritance.
+2. Guardrails должны иметь тест-контракт на boundary "workflow -> SSH wrapper -> remote script", иначе production-breakage проявляется только в live deploy run.

--- a/scripts/run-tracked-moltis-deploy.sh
+++ b/scripts/run-tracked-moltis-deploy.sh
@@ -370,7 +370,14 @@ validate_tracked_contract
 
 log_info "Running tracked Moltis deploy via scripts/deploy.sh"
 set +e
-DEPLOY_OUTPUT="$("$DEPLOY_PATH/scripts/deploy.sh" --json moltis deploy)"
+DEPLOY_OUTPUT="$(
+    env \
+        GITHUB_ACTIONS="${GITHUB_ACTIONS:-true}" \
+        GITHUB_RUN_ID="${GITHUB_RUN_ID:-$WORKFLOW_RUN}" \
+        GITHUB_RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}" \
+        GITOPS_CONFIRM_SKIP=true \
+        "$DEPLOY_PATH/scripts/deploy.sh" --json moltis deploy
+)"
 DEPLOY_EXIT=$?
 set -e
 

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -298,6 +298,17 @@ PY
         test_fail "Workflows must stay aligned with the tracked deploy JSON contract they parse"
     fi
 
+    test_start "static_tracked_deploy_propagates_ci_context_for_noninteractive_guarded_deploy"
+    if [[ -f "$TRACKED_DEPLOY_SCRIPT" ]] && \
+       rg -Fq 'GITHUB_ACTIONS="${GITHUB_ACTIONS:-true}"' "$TRACKED_DEPLOY_SCRIPT" && \
+       rg -Fq 'GITHUB_RUN_ID="${GITHUB_RUN_ID:-$WORKFLOW_RUN}"' "$TRACKED_DEPLOY_SCRIPT" && \
+       rg -Fq 'GITOPS_CONFIRM_SKIP=true' "$TRACKED_DEPLOY_SCRIPT" && \
+       rg -Fq '"$DEPLOY_PATH/scripts/deploy.sh" --json moltis deploy' "$TRACKED_DEPLOY_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Tracked deploy script must propagate CI context and skip interactive GitOps confirmation when invoking deploy.sh over remote SSH orchestration"
+    fi
+
     test_start "static_deploy_workflow_uses_shared_host_automation_entrypoint"
     if rg -q 'apply-moltis-host-automation\.sh' "$DEPLOY_WORKFLOW" && \
        ! rg -q 'Install cron jobs' "$DEPLOY_WORKFLOW" && \


### PR DESCRIPTION
## Что исправлено
- `scripts/run-tracked-moltis-deploy.sh` теперь вызывает `deploy.sh` с явным CI-контекстом (`GITHUB_ACTIONS`, `GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`) и `GITOPS_CONFIRM_SKIP=true`.
- Добавлен статический контракт `static_tracked_deploy_propagates_ci_context_for_noninteractive_guarded_deploy`.
- Добавлен RCA: `docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md`.
- Обновлён `docs/LESSONS-LEARNED.md`.

## RCA (корень)
Deploy run `23357425657` падал в шаге `Run tracked Moltis deploy control plane`, потому что remote-hop терял CI env и `gitops_confirm_manual` трактовал запуск как ручной (`Operation cancelled`).

## Проверки
- `bash tests/static/test_config_validation.sh` (83/83 pass)
