### PR TITLE
fix(deploy): prevent tracked rollout failures on legacy container conflicts

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 43
+**Total Lessons**: 44
 
 ---
 
@@ -14,8 +14,9 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (14 lessons)
+#### P1 (15 lessons)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
+- [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
 - [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
 - [Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline](../docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md)
@@ -68,8 +69,9 @@
 ### By Category
 
 
-#### cicd (18 lessons)
+#### cicd (19 lessons)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
+- [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
 - [Test Suite gate failed because CI runner missed sqlite3 dependency for component_codex_session_path_repair](../docs/rca/2026-03-20-test-suite-gate-failed-on-missing-sqlite3-dependency.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
@@ -124,16 +126,16 @@
 
 ### Popular Tags
 
-- `gitops` (12 lessons)
+- `gitops` (13 lessons)
 - `github-actions` (12 lessons)
+- `deploy` (10 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
-- `deploy` (9 lessons)
 - `clawdiy` (8 lessons)
 - `rca` (7 lessons)
+- `cicd` (7 lessons)
 - `openclaw` (6 lessons)
-- `cicd` (6 lessons)
-- `telegram` (5 lessons)
+- `moltis` (6 lessons)
 
 
 ---
@@ -142,10 +144,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 43 |
-| Critical (P0/P1) | 15 |
+| Total Lessons | 44 |
+| Critical (P0/P1) | 16 |
 | Categories | 5 |
-| Unique Tags | 104 |
+| Unique Tags | 105 |
 
 ---
 

--- a/docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md
+++ b/docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md
@@ -1,0 +1,65 @@
+---
+title: "Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [cicd, deploy, docker-compose, gitops, moltis, production]
+root_cause: "Remote host kept legacy container /prometheus from a different compose project, while tracked deploy expected to create managed /prometheus; deploy.sh exited before JSON result, masking the real conflict"
+---
+
+# RCA: Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** production deploy run `23358681257` завершился `failure`; rollout прервался на control-plane этапе до финальной verification.
+
+## Ошибка
+
+Падение в run `23358681257` (workflow `Deploy Moltis`, step `Run tracked Moltis deploy control plane`):
+
+- Docker вернул конфликт имени контейнера:
+  - `Error response from daemon: Conflict. The container name "/prometheus" is already in use ...`
+- После этого tracked wrapper вернул fallback-ошибку:
+  - `run-tracked-moltis-deploy.sh received non-JSON output from deploy.sh`
+
+## Анализ 5 Почему
+
+| Уровень | Почему | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему deploy завершился `failure`? | `deploy.sh --json moltis deploy` завершился ошибкой при `docker compose up` | run `23358681257`, failed step log |
+| 2 | Почему `docker compose up` упал? | На хосте уже существовал контейнер `/prometheus` | лог ошибки Docker conflict |
+| 3 | Почему существующий `/prometheus` конфликтовал с tracked stack? | Контейнер имел другой compose project label (`ainetic`), а текущий deploy работает с `COMPOSE_PROJECT_NAME=moltinger` и тем же `container_name` | `docker inspect prometheus`: project=`ainetic` |
+| 4 | Почему legacy контейнер не был устранён до rollout? | В `deploy.sh` не было шага нормализации/очистки container-name конфликтов перед `compose up` | код `scripts/deploy.sh` до фикса |
+| 5 | Почему первичная причина была замаскирована generic-ошибкой? | Wrapper ожидал валидный JSON от `deploy.sh`, но при раннем `set -e` exit JSON не формировался | `scripts/run-tracked-moltis-deploy.sh` до фикса |
+
+## Корневая причина
+
+Два связанных дефекта:
+
+1. На сервере остался legacy контейнер `/prometheus` из другого compose project (`ainetic`), который конфликтовал с managed rollout по фиксированному `container_name`.
+2. При раннем падении `deploy.sh` JSON-контракт не соблюдался, и wrapper выдавал непрозрачную ошибку non-JSON вместо явной причины.
+
+## Принятые меры
+
+1. В `scripts/deploy.sh` добавлен guard `resolve_container_name_conflicts`:
+   - проверяет managed container names для target;
+   - находит контейнеры с тем же именем, но с project label, отличным от ожидаемого `COMPOSE_PROJECT_NAME`;
+   - принудительно удаляет конфликтный legacy контейнер до `compose up`.
+2. В `scripts/run-tracked-moltis-deploy.sh` добавлена явная проверка JSON-контракта:
+   - если `deploy.sh` завершился без валидного JSON, возвращается точный failure message с exit code.
+3. Добавлены статические регрессионные проверки:
+   - `static_deploy_script_cleans_legacy_container_name_conflicts_before_rollout`
+   - `static_tracked_deploy_detects_missing_json_contract_from_deploy_sh`
+
+## Проверка после исправлений
+
+| Проверка | Результат | Evidence |
+|----------|-----------|----------|
+| `bash tests/static/test_config_validation.sh` | pass | 89/89 |
+| Guard очистки legacy conflict | pass | static test `static_deploy_script_cleans_legacy_container_name_conflicts_before_rollout` |
+| Guard JSON envelope | pass | static test `static_tracked_deploy_detects_missing_json_contract_from_deploy_sh` |
+
+## Уроки
+
+1. Для production-хоста с долгой историей деплоев нельзя предполагать отсутствие legacy контейнеров с фиксированными именами; перед rollout нужна явная нормализация managed surface.
+2. Для CI orchestration JSON-контракт должен быть fail-closed: даже при ранних авариях ошибка обязана быть диагностичной и привязанной к root cause, а не к generic parse failure.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -552,6 +552,76 @@ ensure_required_networks() {
     done
 }
 
+managed_container_names_for_target() {
+    case "$TARGET" in
+        moltis)
+            echo "moltis"
+            echo "watchtower"
+            echo "cadvisor"
+            echo "prometheus"
+            echo "alertmanager"
+            echo "ollama-fallback"
+            ;;
+        clawdiy)
+            echo "clawdiy"
+            ;;
+        *)
+            ;;
+    esac
+}
+
+log_json_stderr() {
+    local level="$1"
+    shift
+
+    if [[ "$OUTPUT_JSON" == "true" ]]; then
+        echo "[$level] $*" >&2
+    else
+        case "$level" in
+            INFO) log_info "$@" ;;
+            WARN) log_warn "$@" ;;
+            ERROR) log_error "$@" ;;
+            *) log_info "$@" ;;
+        esac
+    fi
+}
+
+resolve_container_name_conflicts() {
+    local expected_project="${COMPOSE_PROJECT_NAME:-}"
+    local container_name container_id container_project container_service
+
+    if [[ -z "$expected_project" ]]; then
+        return 0
+    fi
+
+    while IFS= read -r container_name; do
+        [[ -n "$container_name" ]] || continue
+
+        container_id="$(docker ps -aq --filter "name=^/${container_name}$" | head -1 || true)"
+        [[ -n "$container_id" ]] || continue
+
+        container_project="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$container_id" 2>/dev/null || true)"
+        container_service="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$container_id" 2>/dev/null || true)"
+
+        if [[ -n "$container_project" && "$container_project" == "$expected_project" ]]; then
+            continue
+        fi
+
+        log_json_stderr WARN "Removing legacy/conflicting container '$container_name' (id=$container_id project=${container_project:-none} service=${container_service:-none}) before deploy"
+        if [[ "$OUTPUT_JSON" == "true" ]]; then
+            if ! docker rm -f "$container_id" 1>&2; then
+                log_error "Failed to remove conflicting container: $container_name ($container_id)"
+                exit 1
+            fi
+        else
+            if ! docker rm -f "$container_id"; then
+                log_error "Failed to remove conflicting container: $container_name ($container_id)"
+                exit 1
+            fi
+        fi
+    done < <(managed_container_names_for_target)
+}
+
 ensure_clawdiy_runtime_paths() {
     local required_paths=(
         "$PROJECT_ROOT/data/clawdiy"
@@ -880,6 +950,7 @@ check_prerequisites() {
     fi
 
     ensure_required_networks
+    resolve_container_name_conflicts
     log_success "Prerequisites check passed for target $TARGET"
 }
 

--- a/scripts/run-tracked-moltis-deploy.sh
+++ b/scripts/run-tracked-moltis-deploy.sh
@@ -381,6 +381,15 @@ DEPLOY_OUTPUT="$(
 DEPLOY_EXIT=$?
 set -e
 
+if ! jq empty >/dev/null 2>&1 <<<"$DEPLOY_OUTPUT"; then
+    if [[ "$DEPLOY_EXIT" -ne 0 ]]; then
+        emit_failure_json "deploy.sh exited with code $DEPLOY_EXIT before returning JSON; inspect workflow stderr for root cause"
+    else
+        emit_failure_json "deploy.sh returned non-JSON output despite --json contract"
+    fi
+    exit 1
+fi
+
 DEPLOY_STATUS="$(jq -r '.status // empty' <<<"$DEPLOY_OUTPUT" 2>/dev/null || true)"
 DEPLOY_HEALTH="$(jq -r '.details.health // empty' <<<"$DEPLOY_OUTPUT" 2>/dev/null || true)"
 ROLLBACK_VERIFIED=false

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -309,6 +309,25 @@ PY
         test_fail "Tracked deploy script must propagate CI context and skip interactive GitOps confirmation when invoking deploy.sh over remote SSH orchestration"
     fi
 
+    test_start "static_tracked_deploy_detects_missing_json_contract_from_deploy_sh"
+    if [[ -f "$TRACKED_DEPLOY_SCRIPT" ]] && \
+       rg -Fq "deploy.sh exited with code \$DEPLOY_EXIT before returning JSON" "$TRACKED_DEPLOY_SCRIPT" && \
+       rg -Fq "jq empty >/dev/null 2>&1 <<<\"\$DEPLOY_OUTPUT\"" "$TRACKED_DEPLOY_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Tracked deploy script must fail with an explicit error when deploy.sh exits before returning JSON"
+    fi
+
+    test_start "static_deploy_script_cleans_legacy_container_name_conflicts_before_rollout"
+    if [[ -f "$DEPLOY_SCRIPT" ]] && \
+       rg -Fq 'resolve_container_name_conflicts' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'docker rm -f "$container_id"' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'echo "prometheus"' "$DEPLOY_SCRIPT"; then
+        test_pass
+    else
+        test_fail "deploy.sh must clean conflicting legacy container names (including prometheus) before compose up to keep tracked deploy idempotent"
+    fi
+
     test_start "static_deploy_workflow_uses_shared_host_automation_entrypoint"
     if rg -q 'apply-moltis-host-automation\.sh' "$DEPLOY_WORKFLOW" && \
        ! rg -q 'Install cron jobs' "$DEPLOY_WORKFLOW" && \


### PR DESCRIPTION
## Summary
- add a deploy-time guard that removes legacy/conflicting managed container names (including prometheus) when they belong to a different compose project
- make tracked remote deploy fail with an explicit JSON-envelope error when deploy.sh exits before returning JSON
- add static regression checks and RCA/lessons updates for run 23358681257

## Validation
- bash tests/static/test_config_validation.sh

## RCA
- docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md