### PR TITLE
fix(deploy): resolve legacy container conflict when project name env is unset

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -591,7 +591,7 @@ resolve_container_name_conflicts() {
     local container_name container_id container_project container_service
 
     if [[ -z "$expected_project" ]]; then
-        return 0
+        expected_project="$(basename "$PROJECT_ROOT")"
     fi
 
     while IFS= read -r container_name; do

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -328,6 +328,7 @@ PY
     test_start "static_deploy_script_cleans_legacy_container_name_conflicts_before_rollout"
     if [[ -f "$DEPLOY_SCRIPT" ]] && \
        rg -Fq 'resolve_container_name_conflicts' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'expected_project="$(basename "$PROJECT_ROOT")"' "$DEPLOY_SCRIPT" && \
        rg -Fq 'docker rm -f "$container_id"' "$DEPLOY_SCRIPT" && \
        rg -Fq 'echo "prometheus"' "$DEPLOY_SCRIPT"; then
         test_pass


### PR DESCRIPTION
Fixes tracked deploy cleanup path so legacy container-name conflicts are removed even when COMPOSE_PROJECT_NAME is absent in remote deploy context.\n\nValidation: bash tests/static/test_config_validation.sh (90/90 pass).\n\nRCA context: deploy run 23359828438 failed on /prometheus conflict because conflict cleanup returned early without fallback project derivation.