### PR TITLE
fix(deploy): prevent Moltis rollout failures from monitoring port conflicts

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 45
+**Total Lessons**: 46
 
 ---
 
@@ -14,13 +14,14 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (16 lessons)
+#### P1 (17 lessons)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
 - [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
 - [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
 - [Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline](../docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md)
 - [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
+- [Moltis deploy blocked by unmanaged host-level Prometheus port conflict during full-stack compose up](../docs/rca/2026-03-20-moltis-deploy-blocked-by-unmanaged-prometheus-host-port-conflict.md)
 - [Push deploy blocked by GitOps drift from exec-bit mismatch on codex-cli-update-delivery.sh](../docs/rca/2026-03-20-gitops-drift-on-codex-delivery-script-exec-bit.md)
 - [Deploy collision and active-root symlink guard](../docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
@@ -70,7 +71,7 @@
 ### By Category
 
 
-#### cicd (20 lessons)
+#### cicd (21 lessons)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
 - [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
@@ -81,6 +82,7 @@
 - [Moltis update proposal failed on perl replacement ambiguity and GitHub PR permission assumption](../docs/rca/2026-03-20-moltis-update-proposal-perl-backreference-and-pr-permission-fallback.md)
 - [Deploy workflow allowed tracked-version regression risk against newer running Moltis baseline](../docs/rca/2026-03-20-moltis-tracked-version-regression-guard.md)
 - [Moltis stayed on 0.9.10 because pinned GHCR tag format was wrong and production deploy gate allowed bypass semantics](../docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md)
+- [Moltis deploy blocked by unmanaged host-level Prometheus port conflict during full-stack compose up](../docs/rca/2026-03-20-moltis-deploy-blocked-by-unmanaged-prometheus-host-port-conflict.md)
 - [Push deploy blocked by GitOps drift from exec-bit mismatch on codex-cli-update-delivery.sh](../docs/rca/2026-03-20-gitops-drift-on-codex-delivery-script-exec-bit.md)
 - [Deploy collision and active-root symlink guard](../docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md)
 - [Codex monitor threshold coupled to tomllib availability](../docs/rca/2026-03-15-codex-monitor-threshold-coupled-to-tomllib.md)
@@ -128,15 +130,15 @@
 
 ### Popular Tags
 
-- `gitops` (14 lessons)
+- `gitops` (15 lessons)
 - `github-actions` (12 lessons)
-- `deploy` (11 lessons)
+- `deploy` (12 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
+- `cicd` (9 lessons)
+- `moltis` (8 lessons)
 - `clawdiy` (8 lessons)
-- `cicd` (8 lessons)
 - `rca` (7 lessons)
-- `moltis` (7 lessons)
 - `openclaw` (6 lessons)
 
 
@@ -146,10 +148,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 45 |
-| Critical (P0/P1) | 17 |
+| Total Lessons | 46 |
+| Critical (P0/P1) | 18 |
 | Categories | 5 |
-| Unique Tags | 105 |
+| Unique Tags | 106 |
 
 ---
 

--- a/docs/rca/2026-03-20-moltis-deploy-blocked-by-unmanaged-prometheus-host-port-conflict.md
+++ b/docs/rca/2026-03-20-moltis-deploy-blocked-by-unmanaged-prometheus-host-port-conflict.md
@@ -1,0 +1,69 @@
+---
+title: "Moltis deploy blocked by unmanaged host-level Prometheus port conflict during full-stack compose up"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [cicd, deploy, docker-compose, gitops, moltis, production, monitoring]
+root_cause: "Moltis target deploy executed full-stack compose up (including monitoring services with host port 9090), while the server already had unmanaged system Prometheus bound to 9090; unrelated monitoring conflict blocked Moltis rollout"
+---
+
+# RCA: Moltis deploy blocked by unmanaged host-level Prometheus port conflict during full-stack compose up
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** production deploy run `23360516210` завершился `failure` в шаге `Run tracked Moltis deploy control plane`; Moltis upgrade pipeline снова прервался до post-deploy verification.
+
+## Ошибка
+
+Падение в run `23360516210` (workflow `Deploy Moltis`):
+
+- `docker compose up` внутри tracked deploy завершился ошибкой:
+  - `failed to bind host port for 0.0.0.0:9090 ... address already in use`
+- До этого container-name conflict был уже устранён (`Removing legacy/conflicting container 'prometheus' ...`), но новый конфликт возник именно на host port binding.
+
+Дополнительная проверка на сервере:
+
+- `ss -ltnp '( sport = :9090 )'` показал:
+  - `users:(("prometheus",pid=433564,...))`
+
+Это подтвердило, что порт `9090` занят не managed docker-контейнером Moltis stack, а внешним system-level процессом.
+
+## Анализ 5 Почему
+
+| Уровень | Почему | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему deploy упал? | Шаг tracked deploy получил `exit 1` от `deploy.sh` во время `docker compose up` | run `23360516210`, failed step logs |
+| 2 | Почему `docker compose up` завершился ошибкой? | Сервис `prometheus` не смог занять host port `9090` (`address already in use`) | stderr Docker в run logs |
+| 3 | Почему порт `9090` был занят? | На сервере уже работал unmanaged системный `prometheus` процесс | `ss -ltnp` на `ainetic.tech` |
+| 4 | Почему это блокировало именно Moltis update? | `moltis` target deploy поднимал весь compose stack, включая monitoring сервисы (`prometheus/alertmanager/cadvisor`) с host port bindings | `scripts/deploy.sh` до фикса: `compose_cmd normal up -d --remove-orphans` без service-scoping |
+| 5 | Почему это архитектурно опасно? | Unrelated observability surface становился hard blocker для обновления Moltis core, хотя rollback/update контракт должен зависеть только от Moltis и его обязательных sidecar'ов | поведение pipeline до фикса |
+
+## Корневая причина
+
+Deploy контракт для `target=moltis` был избыточно широким: вместо service-scoped rollout запускался полный compose stack с monitoring сервисами и внешними портами. В окружении с внешним/унаследованным Prometheus это приводило к host-port конфликту (`9090`) и срывало Moltis rollout.
+
+## Принятые меры
+
+1. `scripts/deploy.sh` переведён на service-scoped deploy для `target=moltis`:
+   - поднимаются только `moltis` + обязательные sidecar'ы (`watchtower`, `ollama`);
+   - monitoring stack (`cadvisor/prometheus/alertmanager`) исключён из критического пути Moltis rollout.
+2. Сужен scope legacy container conflict cleanup:
+   - проверяются/очищаются только managed контейнеры Moltis target (`moltis`, `watchtower`, `ollama-fallback`);
+   - больше не удаляются monitoring container names как часть Moltis deploy path.
+3. Добавлен статический контрактный тест:
+   - `static_deploy_script_scopes_moltis_rollout_to_core_and_sidecars`
+4. Обновлён существующий тест очистки конфликтов:
+   - закреплено, что cleanup не трогает monitoring names (`prometheus`) в Moltis target path.
+
+## Проверка после исправлений
+
+| Проверка | Результат | Evidence |
+|----------|-----------|----------|
+| `bash tests/static/test_config_validation.sh` | pass | 91/91 |
+| Scope deploy path | pass | `static_deploy_script_scopes_moltis_rollout_to_core_and_sidecars` |
+| Legacy conflict cleanup scope | pass | `static_deploy_script_cleans_legacy_container_name_conflicts_before_rollout` |
+
+## Уроки
+
+1. `target=moltis` не должен зависеть от успешного старта необязательных monitoring сервисов с host-level портами.
+2. В CI/CD для production rollout нужно отделять critical runtime surface от auxiliary observability surface, чтобы исключить ложные hard blockers обновлений.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -510,7 +510,9 @@ configure_target() {
             TARGET_NOTIFICATION_NAME="Moltis"
             TARGET_HEALTH_TIMEOUT="$HEALTH_CHECK_TIMEOUT"
             TARGET_REQUIRED_NETWORKS=("$TRAEFIK_NETWORK")
-            TARGET_AUXILIARY_SERVICES=("watchtower")
+            # Scope managed rollout to Moltis core + required sidecars only.
+            # Monitoring services must not block Moltis deploys due host-level port conflicts.
+            TARGET_AUXILIARY_SERVICES=("watchtower" "ollama")
             ;;
         clawdiy)
             TARGET_DISPLAY="Clawdiy"
@@ -557,9 +559,6 @@ managed_container_names_for_target() {
         moltis)
             echo "moltis"
             echo "watchtower"
-            echo "cadvisor"
-            echo "prometheus"
-            echo "alertmanager"
             echo "ollama-fallback"
             ;;
         clawdiy)
@@ -1081,7 +1080,15 @@ pull_images() {
 
 deploy_containers() {
     log_info "Deploying containers for target $TARGET..."
-    compose_cmd normal up -d --remove-orphans
+    local -a deploy_services=("$TARGET_SERVICE")
+    local service
+
+    for service in "${TARGET_AUXILIARY_SERVICES[@]}"; do
+        [[ -n "$service" ]] || continue
+        deploy_services+=("$service")
+    done
+
+    compose_cmd normal up -d --remove-orphans "${deploy_services[@]}"
     log_success "Containers deployed for target $TARGET"
 }
 

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -330,10 +330,20 @@ PY
        rg -Fq 'resolve_container_name_conflicts' "$DEPLOY_SCRIPT" && \
        rg -Fq 'expected_project="$(basename "$PROJECT_ROOT")"' "$DEPLOY_SCRIPT" && \
        rg -Fq 'docker rm -f "$container_id"' "$DEPLOY_SCRIPT" && \
-       rg -Fq 'echo "prometheus"' "$DEPLOY_SCRIPT"; then
+       rg -Fq 'echo "ollama-fallback"' "$DEPLOY_SCRIPT" && \
+       ! rg -Fq 'echo "prometheus"' "$DEPLOY_SCRIPT"; then
         test_pass
     else
-        test_fail "deploy.sh must clean conflicting legacy container names (including prometheus) before compose up to keep tracked deploy idempotent"
+        test_fail "deploy.sh must clean conflicting legacy containers for Moltis managed services only (without touching monitoring-stack container names)"
+    fi
+
+    test_start "static_deploy_script_scopes_moltis_rollout_to_core_and_sidecars"
+    if [[ -f "$DEPLOY_SCRIPT" ]] && \
+       rg -Fq 'TARGET_AUXILIARY_SERVICES=("watchtower" "ollama")' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'compose_cmd normal up -d --remove-orphans "${deploy_services[@]}"' "$DEPLOY_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Moltis deploy path must target only moltis + required sidecars so unrelated monitoring services cannot block tracked upgrades"
     fi
 
     test_start "static_deploy_workflow_uses_shared_host_automation_entrypoint"


### PR DESCRIPTION
## Root cause
Deploy run 23360516210 failed in tracked control-plane because deploy.sh started monitoring services and hit host port conflict on 9090 with unmanaged system Prometheus.

## Changes
- scope target=moltis rollout to core services only: moltis, watchtower, ollama
- narrow legacy conflict cleanup to Moltis managed container names only
- add static guard static_deploy_script_scopes_moltis_rollout_to_core_and_sidecars
- add RCA and rebuild lessons index

## Validation
- bash tests/static/test_config_validation.sh => 91/91 pass

## Expected outcome
Tracked Moltis upgrades no longer fail because unrelated monitoring-stack host port collisions.