### PR TITLE
fix(deploy): preserve JSON contract in tracked Moltis deploy by redirecting restore-check logs

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 46
+**Total Lessons**: 47
 
 ---
 
@@ -14,8 +14,9 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (17 lessons)
+#### P1 (18 lessons)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
+- [Tracked Moltis deploy failed because backup restore-check logs polluted deploy.sh JSON stdout contract](../docs/rca/2026-03-20-tracked-deploy-json-contract-broken-by-restore-check-stdout.md)
 - [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
 - [Telegram authoritative UAT could pass on provider/model resolution errors](../docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md)
 - [SSH heredoc runner-side expansion in deploy workflow](../docs/rca/2026-03-20-ssh-heredoc-runner-expansion-in-deploy.md)
@@ -71,8 +72,9 @@
 ### By Category
 
 
-#### cicd (21 lessons)
+#### cicd (22 lessons)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
+- [Tracked Moltis deploy failed because backup restore-check logs polluted deploy.sh JSON stdout contract](../docs/rca/2026-03-20-tracked-deploy-json-contract-broken-by-restore-check-stdout.md)
 - [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
 - [Test Suite gate failed because CI runner missed sqlite3 dependency for component_codex_session_path_repair](../docs/rca/2026-03-20-test-suite-gate-failed-on-missing-sqlite3-dependency.md)
@@ -131,12 +133,12 @@
 ### Popular Tags
 
 - `gitops` (15 lessons)
+- `deploy` (13 lessons)
 - `github-actions` (12 lessons)
-- `deploy` (12 lessons)
+- `cicd` (10 lessons)
 - `process` (9 lessons)
+- `moltis` (9 lessons)
 - `lessons` (9 lessons)
-- `cicd` (9 lessons)
-- `moltis` (8 lessons)
 - `clawdiy` (8 lessons)
 - `rca` (7 lessons)
 - `openclaw` (6 lessons)
@@ -148,10 +150,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 46 |
-| Critical (P0/P1) | 18 |
+| Total Lessons | 47 |
+| Critical (P0/P1) | 19 |
 | Categories | 5 |
-| Unique Tags | 106 |
+| Unique Tags | 109 |
 
 ---
 

--- a/docs/rca/2026-03-20-tracked-deploy-json-contract-broken-by-restore-check-stdout.md
+++ b/docs/rca/2026-03-20-tracked-deploy-json-contract-broken-by-restore-check-stdout.md
@@ -1,0 +1,59 @@
+---
+title: "Tracked Moltis deploy failed because backup restore-check logs polluted deploy.sh JSON stdout contract"
+date: 2026-03-20
+severity: P1
+category: cicd
+tags: [cicd, deploy, json-contract, backup, restore-check, moltis, production]
+root_cause: "In --json mode, deploy.sh executed backup restore-check with stdout attached, so informational logs preceded JSON payload; tracked deploy wrapper treated mixed output as non-JSON and failed despite successful rollout"
+---
+
+# RCA: Tracked Moltis deploy failed because backup restore-check logs polluted deploy.sh JSON stdout contract
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** production deploy run `23361033522` завершился `failure` в control-plane step, хотя Moltis контейнеры фактически перезапустились успешно.
+
+## Ошибка
+
+В run `23361033522` step `Run tracked Moltis deploy control plane` завершился с:
+
+- `deploy.sh returned non-JSON output despite --json contract`
+
+Симптомы:
+
+- Docker operations прошли успешно (`moltis`/`watchtower`/`ollama` были запущены).
+- wrapper отказался принимать результат из-за некорректного JSON envelope.
+
+## Анализ 5 Почему
+
+| Уровень | Почему | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему workflow пометил deploy как failed? | Wrapper `run-tracked-moltis-deploy.sh` не смог распарсить stdout `deploy.sh` как JSON | run `23361033522` failed log |
+| 2 | Почему stdout не был валидным JSON? | Перед JSON payload в stdout попали INFO-логи restore-check (`Verifying backup...`) | remote repro `/opt/moltinger/scripts/deploy.sh --json moltis deploy` |
+| 3 | Почему restore-check писал в stdout в JSON-режиме? | В `backup_current_state` команда `"$BACKUP_SCRIPT" restore-check "$backup_path"` вызывалась без перенаправления в stderr | `scripts/deploy.sh` до фикса |
+| 4 | Почему это ломает tracked control-plane? | Wrapper требует fail-closed contract: stdout должен быть единственным JSON объектом | `scripts/run-tracked-moltis-deploy.sh` (`jq empty` check) |
+| 5 | Почему дефект проявился только после предыдущего фикса? | Ранее deploy падал раньше (port/name conflicts); после устранения этих падений pipeline дошёл до restore-check и вскрыл новый контрактный дефект | последовательность run `23360516210` -> `23361033522` |
+
+## Корневая причина
+
+Нарушен stdout/stderr контракт `deploy.sh --json`: restore-check печатал операционные логи в stdout, из-за чего wrapper получал mixed output вместо чистого JSON.
+
+## Принятые меры
+
+1. В `scripts/deploy.sh` для `TARGET=moltis` в JSON-режиме restore-check принудительно уходит в stderr:
+   - `"$BACKUP_SCRIPT" restore-check "$backup_path" 1>&2`
+2. В статические проверки добавлен guard:
+   - `static_deploy_script_keeps_json_stdout_clean` теперь валидирует stderr-redirect restore-check.
+
+## Проверка после исправлений
+
+| Проверка | Результат | Evidence |
+|----------|-----------|----------|
+| `bash tests/static/test_config_validation.sh` | pass | 91/91 |
+| JSON stdout guard | pass | `static_deploy_script_keeps_json_stdout_clean` |
+| Remote dry verification of contract path | pass | stderr содержит restore logs, stdout остаётся JSON payload |
+
+## Уроки
+
+1. Для всех `--json` entrypoint-скриптов stdout должен быть зарезервирован только под machine-readable payload.
+2. Любые диагностические/операционные сообщения в JSON-режиме должны быть строго перенаправлены в stderr.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1046,7 +1046,11 @@ backup_current_state() {
             fi
 
             log_info "Running restore-readiness check for Moltis backup..."
-            "$BACKUP_SCRIPT" restore-check "$backup_path"
+            if [[ "$OUTPUT_JSON" == "true" ]]; then
+                "$BACKUP_SCRIPT" restore-check "$backup_path" 1>&2
+            else
+                "$BACKUP_SCRIPT" restore-check "$backup_path"
+            fi
             write_moltis_restore_check_evidence "$backup_path" >/dev/null
             log_success "Restore-readiness evidence recorded: $DEPLOY_RESTORE_CHECK_FILE"
         fi

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -755,11 +755,12 @@ PY
     test_start "static_deploy_script_keeps_json_stdout_clean"
     if rg -q 'docker compose "\$\{compose_args\[@\]\}" "\$\{args\[@\]\}" 1>&2' "$DEPLOY_SCRIPT" && \
        rg -q 'docker logs "\$container" --tail 80 >&2' "$DEPLOY_SCRIPT" && \
+       rg -q '"\$BACKUP_SCRIPT" restore-check "\$backup_path" 1>&2' "$DEPLOY_SCRIPT" && \
        rg -q 'if \[\[ "\$OUTPUT_JSON" != "true" \]\]; then' "$DEPLOY_SCRIPT" && \
        rg -q 'echo -n "\."' "$DEPLOY_SCRIPT"; then
         test_pass
     else
-        test_fail "deploy.sh must keep docker compose progress, docker logs, and wait dots out of JSON stdout"
+        test_fail "deploy.sh must keep restore-check logs, docker compose progress, docker logs, and wait dots out of JSON stdout"
     fi
 
     test_start "static_clawdiy_workflow_validates_auth_rendering_rules"


### PR DESCRIPTION
## Root cause
Deploy run 23361033522 failed even after successful container rollout because deploy.sh --json emitted restore-check INFO logs to stdout before JSON payload.

## Changes
- in scripts/deploy.sh, run backup restore-check with stdout redirected to stderr when OUTPUT_JSON=true
- extend static JSON cleanliness guard to enforce restore-check stderr redirect
- add RCA for this incident and rebuild lessons index

## Validation
- bash tests/static/test_config_validation.sh => 91/91 pass
- remote repro confirms stdout now reserved for JSON payload in --json mode