### PR TITLE
fix(cicd): formalize manual compare URL contract for Moltis update proposal

### DIFF
--- a/.github/workflows/moltis-update-proposal.yml
+++ b/.github/workflows/moltis-update-proposal.yml
@@ -180,8 +180,8 @@ jobs:
               PR_MODE="pr_created"
             elif grep -qi 'not permitted to create or approve pull requests' <<<"$CREATE_OUTPUT"; then
               PR_URL="https://github.com/${GITHUB_REPOSITORY}/compare/main...${BRANCH}?expand=1"
-              PR_MODE="manual_pr_required_actions_permission"
-              echo "::notice::GitHub Actions token cannot create PR in this repository; using compare URL fallback"
+              PR_MODE="manual_compare_url"
+              echo "::notice::GitHub Actions token cannot create PR in this repository; using supported manual compare URL approval path"
             else
               echo "::error::Failed to create proposal PR: $CREATE_OUTPUT"
               exit "$CREATE_RC"
@@ -234,16 +234,29 @@ jobs:
           body: |
             Доступно обновление Moltis до версии ${{ steps.pr.outputs.candidate_version }}.
 
-            Для подтверждения откройте PR и выполните approve/merge:
+            Для подтверждения используйте ссылку ниже:
             ${{ steps.pr.outputs.pr_url }}
 
-            Если ссылка открывает compare-страницу вместо готового PR, нажмите "Create pull request", затем approve/merge.
+            Поддерживаются два штатных режима:
+            1) ссылка уже ведёт на готовый PR -> approve/merge;
+            2) ссылка ведёт на compare-страницу -> нажмите "Create pull request", затем approve/merge.
+
+            Compare URL mode является поддерживаемым контрактом (это не failure state).
 
             Это безопасный proposal workflow: деплой напрямую не запускался.
 
       - name: Proposal summary
         if: always()
         run: |
+          PR_MODE="${{ steps.pr.outputs.pr_mode || 'n/a' }}"
+          APPROVAL_MODE="auto_pr"
+          OPERATOR_ACTION="Review, approve, and merge the PR link."
+
+          if [[ "$PR_MODE" == "manual_compare_url" ]]; then
+            APPROVAL_MODE="manual_compare_url"
+            OPERATOR_ACTION="Open compare URL, click 'Create pull request', then approve and merge."
+          fi
+
           {
             echo "## Moltis Update Proposal"
             echo ""
@@ -256,9 +269,12 @@ jobs:
             echo "| Skip reason | \`${{ steps.version.outputs.skip_reason || 'n/a' }}\` |"
             echo "| Proposal branch | \`${{ steps.branch.outputs.branch || 'n/a' }}\` |"
             echo "| PR URL | ${{ steps.pr.outputs.pr_url || 'n/a' }} |"
-            echo "| PR mode | \`${{ steps.pr.outputs.pr_mode || 'n/a' }}\` |"
+            echo "| PR mode (raw) | \`$PR_MODE\` |"
+            echo "| Approval mode (contract) | \`$APPROVAL_MODE\` |"
+            echo "| Operator action | $OPERATOR_ACTION |"
             echo "| Email send | \`${{ steps.email.outputs.should_send || 'false' }}\` |"
             echo "| Email skip reason | \`${{ steps.email.outputs.reason || 'n/a' }}\` |"
             echo ""
+            echo "> Manual compare URL mode is a supported contract when Actions cannot create PRs."
             echo "> This workflow only prepares/updates a PR. It does not deploy to production."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-20
-**Total Lessons**: 47
+**Total Lessons**: 48
 
 ---
 
@@ -34,12 +34,13 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (18 lessons)
+#### P2 (19 lessons)
 - [Test Suite gate failed again because sqlite3 was installed on host runner but missing in test-runner container runtime](../docs/rca/2026-03-20-test-suite-gate-failed-on-sqlite3-runtime-context-mismatch.md)
 - [Telegram webhook monitor default expected webhook while production stayed in polling mode](../docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md)
 - [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
 - [Moltis update proposal workflow failed with workflow-file issue due to forbidden secrets context in step if](../docs/rca/2026-03-20-moltis-update-proposal-workflow-file-issue-on-secrets-context.md)
 - [Moltis update proposal failed on perl replacement ambiguity and GitHub PR permission assumption](../docs/rca/2026-03-20-moltis-update-proposal-perl-backreference-and-pr-permission-fallback.md)
+- [Moltis update proposal had contract drift: manual compare fallback existed in code but was not formalized as governance contract](../docs/rca/2026-03-20-moltis-update-proposal-manual-compare-contract-governance.md)
 - [Beads wrapper delegated into a sibling worktree wrapper and left stale JSONL export](../docs/rca/2026-03-20-beads-wrapper-path-pollution-caused-stale-jsonl-export.md)
 - [Deploy Clawdiy блокировался на dirty checkout без auditable repair path](../docs/rca/2026-03-14-clawdiy-deploy-missing-gitops-repair-path.md)
 - [CI preflight ошибочно требовал materialized Clawdiy runtime home до deploy/render шага](../docs/rca/2026-03-14-clawdiy-ci-preflight-materialization-assumption.md)
@@ -103,9 +104,10 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (13 lessons)
+#### process (14 lessons)
 - [Telegram webhook monitor default expected webhook while production stayed in polling mode](../docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md)
 - [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
+- [Moltis update proposal had contract drift: manual compare fallback existed in code but was not formalized as governance contract](../docs/rca/2026-03-20-moltis-update-proposal-manual-compare-contract-governance.md)
 - [Clawdiy lost gpt-5.4 as default model after redeploy because runtime wizard state was not captured in tracked config](../docs/rca/2026-03-14-clawdiy-runtime-model-state-was-not-in-gitops.md)
 - [CI preflight ошибочно требовал materialized Clawdiy runtime home до deploy/render шага](../docs/rca/2026-03-14-clawdiy-ci-preflight-materialization-assumption.md)
 - [Официальный мастер настройки Clawdiy не мог завершить OAuth из-за неверного контракта домашнего каталога OpenClaw](../docs/rca/2026-03-13-clawdiy-official-wizard-runtime-home-contract-mismatch.md)
@@ -133,9 +135,9 @@
 ### Popular Tags
 
 - `gitops` (15 lessons)
+- `github-actions` (13 lessons)
 - `deploy` (13 lessons)
-- `github-actions` (12 lessons)
-- `cicd` (10 lessons)
+- `cicd` (11 lessons)
 - `process` (9 lessons)
 - `moltis` (9 lessons)
 - `lessons` (9 lessons)
@@ -150,10 +152,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 47 |
+| Total Lessons | 48 |
 | Critical (P0/P1) | 19 |
 | Categories | 5 |
-| Unique Tags | 109 |
+| Unique Tags | 110 |
 
 ---
 

--- a/docs/rca/2026-03-20-moltis-update-proposal-manual-compare-contract-governance.md
+++ b/docs/rca/2026-03-20-moltis-update-proposal-manual-compare-contract-governance.md
@@ -1,0 +1,66 @@
+---
+title: "Moltis update proposal had contract drift: manual compare fallback existed in code but was not formalized as governance contract"
+date: 2026-03-20
+severity: P2
+category: process
+tags: [cicd, moltis-update, github-actions, governance, permissions, docs]
+root_cause: "Workflow already handled missing createPullRequest permission via compare URL, but docs/summary framed it as implicit fallback instead of explicit supported contract"
+---
+
+# RCA: Moltis update proposal had contract drift (manual compare URL path not formalized)
+
+**Дата:** 2026-03-20  
+**Статус:** Resolved  
+**Влияние:** issue `#87` оставался открытым из-за неоднозначного governance-контракта: не было ясно, нужно ли повышать GitHub permissions или закреплять manual compare URL path.
+
+## Ошибка
+
+Технический fallback уже работал:
+
+- при `createPullRequest` denial workflow не падал;
+- формировался compare URL и оператор мог создать PR вручную.
+
+Но contract-слой был неполным:
+
+- `docs/version-update.md` не фиксировал manual compare URL как постоянный supported path;
+- summary/email формулировки могли восприниматься как “degraded exception”, а не как штатный режим.
+
+## Анализ 5 Почему
+
+| Уровень | Почему | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему #87 оставался нерешённым? | Не был формально зафиксирован выбор между расширением permission и manual compare governance mode | issue `#87` body |
+| 2 | Почему появилась дилемма? | Код и документация разошлись по уровню явности контракта | `.github/workflows/moltis-update-proposal.yml` vs `docs/version-update.md` (до фикса) |
+| 3 | Почему документация не покрывала manual mode явно? | Фокус был на устранении hard-fail и восстановлении работоспособности pipeline | RCA `2026-03-20-moltis-update-proposal-perl-backreference-and-pr-permission-fallback.md` |
+| 4 | Почему этого недостаточно для governance? | Без явного policy operators трактуют compare URL как временный workaround | consilium review по #87 |
+| 5 | Почему важно закрыть именно policy-уровень? | Permissions в repo settings вне git-контракта; без doc contract можно повторно вернуться к хрупкому поведению | GitOps/least-privilege требования проекта |
+
+## Корневая причина
+
+Реальная проблема была не в отсутствии fallback-логики, а в contract drift: manual compare URL path был реализован технически, но не зафиксирован как официальный постоянный режим в документации и operator-facing summary.
+
+## Принятые меры
+
+1. Обновлён workflow `moltis-update-proposal`:
+   - fallback mode именован как `manual_compare_url`;
+   - summary показывает contract-level `Approval mode (contract)`;
+   - email формулирует compare URL как supported path (не failure state).
+2. Обновлён `docs/version-update.md`:
+   - добавлен явный контракт `manual_compare_url` и правило, что это supported permanent contract.
+3. Добавлен статический guard:
+   - `tests/static/test_config_validation.sh` проверяет contract language в docs и workflow.
+
+## Проверка после исправлений
+
+| Проверка | Результат | Evidence |
+|----------|-----------|----------|
+| `bash tests/static/test_config_validation.sh` | pass (92/92) | локальный прогон после изменений |
+| Workflow YAML parse | pass | `YAML_OK .github/workflows/moltis-update-proposal.yml` |
+| Existing fallback guard | pass | `static_moltis_update_proposal_falls_back_to_compare_url_when_pr_create_is_forbidden` |
+| New docs contract guard | pass | `static_version_update_docs_fix_manual_compare_url_contract` |
+
+## Уроки
+
+1. Для CI/CD governance недостаточно “код работает”; operator contract должен быть явно зафиксирован в docs и summary.
+2. Для репозиториев с ограниченным `GITHUB_TOKEN` нужно считать manual compare URL path штатным режимом, а не временной деградацией.
+3. Least-privilege решение должно быть зафиксировано тестами, чтобы future edits не вернули зависимость от внешних repo settings.

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -105,14 +105,22 @@ Workflow contract:
 2. Reads official latest release from `moltis-org/moltis`.
 3. Normalizes release tag to GHCR runtime tag (`vX.Y.Z -> X.Y.Z`).
 4. Verifies `ghcr.io/moltis-org/moltis:<tag>` is pullable.
-5. Creates or updates a PR against `main` with pinned compose changes only.
-6. Does not deploy directly.
+5. Tries to create or update a PR against `main` with pinned compose changes only.
+6. If GitHub Actions cannot create PRs (`createPullRequest` restricted), workflow stays successful and emits a compare URL (`.../compare/main...<branch>?expand=1`) for manual PR creation.
+7. Does not deploy directly.
+
+Approval modes (contract):
+
+- `auto_pr`: workflow produced a direct PR URL.
+- `manual_compare_url`: workflow produced compare URL; operator clicks `Create pull request`, then approve/merge.
+- `manual_compare_url` is a supported permanent contract and not a failure state.
 
 User flow:
 
-1. Receive notification with PR link.
-2. Approve and merge PR when ready.
-3. Existing hardened `Deploy Moltis` pipeline handles backup-safe rollout.
+1. Receive notification with PR URL or compare URL.
+2. If compare URL is provided, click `Create pull request`.
+3. Approve and merge PR when ready.
+4. Existing hardened `Deploy Moltis` pipeline handles backup-safe rollout.
 
 Optional email delivery secrets for proposal workflow:
 

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -593,11 +593,22 @@ PY
 
     test_start "static_moltis_update_proposal_falls_back_to_compare_url_when_pr_create_is_forbidden"
     if rg -Fq 'not permitted to create or approve pull requests' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
-       rg -Fq 'manual_pr_required_actions_permission' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
-       rg -Fq 'compare/main...${BRANCH}?expand=1' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW"; then
+       rg -Fq 'manual_compare_url' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -Fq 'compare/main...${BRANCH}?expand=1' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -Fq 'supported manual compare URL approval path' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW"; then
         test_pass
     else
         test_fail "Moltis update proposal workflow must fall back to a compare URL when GitHub token cannot create PRs"
+    fi
+
+    test_start "static_version_update_docs_fix_manual_compare_url_contract"
+    if rg -Fq 'manual_compare_url' "$PROJECT_ROOT/docs/version-update.md" && \
+       rg -Fq 'supported permanent contract' "$PROJECT_ROOT/docs/version-update.md" && \
+       rg -Fq 'not a failure state' "$PROJECT_ROOT/docs/version-update.md" && \
+       rg -Fq 'compare URL' "$PROJECT_ROOT/docs/version-update.md"; then
+        test_pass
+    else
+        test_fail "Version update docs must explicitly treat manual compare URL mode as a supported non-failure contract"
     fi
 
     test_start "static_moltis_update_proposal_email_action_uses_node24_compatible_major"


### PR DESCRIPTION
## Summary
- formalize `manual_compare_url` as the explicit proposal-workflow contract when Actions cannot create PRs
- improve proposal summary and email copy so compare URL is treated as supported mode (not failure)
- document the final governance decision in `docs/version-update.md`
- add static guards for workflow + docs contract
- add RCA record and rebuild lessons index

## Why
Issue #87 asks for a hard decision between enabling Actions PR creation vs documenting restricted-permission behavior.

Consilium verdict: keep least-privilege mode and treat compare URL as permanent supported contract.

## Validation
- `bash tests/static/test_config_validation.sh` (92/92)
- `python3` YAML parse for `.github/workflows/moltis-update-proposal.yml`
- live deploy status already green on `main` (`Deploy Moltis` run `23361513209`)

Closes #87
