### PR TITLE
feat(cicd): optional Telegram notifications for Moltis update proposals

### DIFF
--- a/.github/workflows/moltis-update-proposal.yml
+++ b/.github/workflows/moltis-update-proposal.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: true
         type: boolean
+      send_telegram:
+        description: "Send Telegram notification with approval link (requires Telegram secrets)"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -219,6 +224,29 @@ jobs:
             echo "reason=required SMTP secrets are missing" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Evaluate Telegram prerequisites
+        id: telegram
+        if: steps.pr.outputs.pr_url != ''
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.MOLTIS_UPDATE_NOTIFY_TELEGRAM_CHAT_ID }}
+          SEND_TELEGRAM_INPUT: ${{ github.event.inputs.send_telegram || 'true' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$SEND_TELEGRAM_INPUT" != "true" ]]; then
+            echo "should_send=false" >> "$GITHUB_OUTPUT"
+            echo "reason=workflow_dispatch input send_telegram=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -n "$TELEGRAM_BOT_TOKEN" && -n "$TELEGRAM_CHAT_ID" ]]; then
+            echo "should_send=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_send=false" >> "$GITHUB_OUTPUT"
+            echo "reason=required Telegram secrets are missing" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Send approval email (optional)
         if: ${{ steps.email.outputs.should_send == 'true' }}
         uses: dawidd6/action-send-mail@v16
@@ -244,6 +272,36 @@ jobs:
             Compare URL mode является поддерживаемым контрактом (это не failure state).
 
             Это безопасный proposal workflow: деплой напрямую не запускался.
+
+      - name: Send Telegram notification (optional)
+        if: ${{ steps.telegram.outputs.should_send == 'true' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.MOLTIS_UPDATE_NOTIFY_TELEGRAM_CHAT_ID }}
+        run: |
+          set -euo pipefail
+
+          MESSAGE=$(cat <<EOF
+          [Moltis] Доступно обновление до версии ${{ steps.pr.outputs.candidate_version }}.
+
+          Ссылка для подтверждения:
+          ${{ steps.pr.outputs.pr_url }}
+
+          Режим: ${{ steps.pr.outputs.pr_mode }}
+
+          Если это compare-ссылка, нажмите "Create pull request", затем approve/merge.
+          EOF
+          )
+
+          RESULT="$(bash ./scripts/telegram-bot-send.sh \
+            --chat-id "$TELEGRAM_CHAT_ID" \
+            --text "$MESSAGE")"
+          echo "$RESULT"
+
+          if ! jq -e '.ok == true' >/dev/null 2>&1 <<<"$RESULT"; then
+            echo "::error::Telegram send failed"
+            exit 1
+          fi
 
       - name: Proposal summary
         if: always()
@@ -274,6 +332,8 @@ jobs:
             echo "| Operator action | $OPERATOR_ACTION |"
             echo "| Email send | \`${{ steps.email.outputs.should_send || 'false' }}\` |"
             echo "| Email skip reason | \`${{ steps.email.outputs.reason || 'n/a' }}\` |"
+            echo "| Telegram send | \`${{ steps.telegram.outputs.should_send || 'false' }}\` |"
+            echo "| Telegram skip reason | \`${{ steps.telegram.outputs.reason || 'n/a' }}\` |"
             echo ""
             echo "> Manual compare URL mode is a supported contract when Actions cannot create PRs."
             echo "> This workflow only prepares/updates a PR. It does not deploy to production."

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -131,6 +131,11 @@ Optional email delivery secrets for proposal workflow:
 - `MOLTIS_UPDATE_NOTIFY_EMAIL`
 - `MOLTIS_UPDATE_NOTIFY_FROM` (optional)
 
+Optional Telegram delivery secrets for proposal workflow:
+
+- `TELEGRAM_BOT_TOKEN`
+- `MOLTIS_UPDATE_NOTIFY_TELEGRAM_CHAT_ID`
+
 ## Rollback Expectations
 
 If the update regresses, rollback must preserve:

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -619,6 +619,26 @@ PY
         test_fail "Moltis update proposal workflow must use a Node24-compatible action-send-mail major to avoid Node20 deprecation failures"
     fi
 
+    test_start "static_moltis_update_proposal_supports_optional_telegram_notification"
+    if rg -Fq 'send_telegram:' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -Fq 'Evaluate Telegram prerequisites' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -Fq 'Send Telegram notification (optional)' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -Fq 'MOLTIS_UPDATE_NOTIFY_TELEGRAM_CHAT_ID' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -Fq 'scripts/telegram-bot-send.sh' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW"; then
+        test_pass
+    else
+        test_fail "Moltis update proposal workflow must support optional Telegram notification via dedicated chat-id secret"
+    fi
+
+    test_start "static_version_update_docs_list_optional_telegram_delivery_secrets"
+    if rg -Fq 'Optional Telegram delivery secrets for proposal workflow' "$PROJECT_ROOT/docs/version-update.md" && \
+       rg -Fq 'TELEGRAM_BOT_TOKEN' "$PROJECT_ROOT/docs/version-update.md" && \
+       rg -Fq 'MOLTIS_UPDATE_NOTIFY_TELEGRAM_CHAT_ID' "$PROJECT_ROOT/docs/version-update.md"; then
+        test_pass
+    else
+        test_fail "Version update docs must list optional Telegram delivery secrets for proposal workflow"
+    fi
+
     test_start "static_ci_runtime_installs_sqlite3_for_codex_session_path_repair_suite"
     if rg -q 'Install OS dependencies' "$TEST_WORKFLOW" && \
        rg -q 'apt-get install -y -qq jq sqlite3' "$TEST_WORKFLOW" && \


### PR DESCRIPTION
## Summary
- add optional Telegram delivery to `.github/workflows/moltis-update-proposal.yml`
- add `send_telegram` workflow-dispatch input
- send Telegram message via `scripts/telegram-bot-send.sh` when proposal link is ready
- keep delivery optional and secret-gated (`TELEGRAM_BOT_TOKEN`, `MOLTIS_UPDATE_NOTIFY_TELEGRAM_CHAT_ID`)
- extend summary output with Telegram send/skip diagnostics
- update docs and static tests for the new contract

## Validation
- `bash tests/static/test_config_validation.sh` (94/94)
- YAML parse for proposal workflow

## Notes
- Workflow behavior remains non-deploying; this only adds notification channel parity with email.
