### PR TITLE
fix(moltis): stabilize runtime memory carrier

### DIFF
--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -654,21 +654,21 @@ reset_on_exit = true              # Reset serve/funnel when gateway shuts down
 [memory]
 llm_reranking = false
 session_export = false
-# provider = "local"              # Embedding provider:
+provider = "ollama"              # Pin embeddings to Ollama instead of chat-provider auto-detect
                                   #   "local"   - Built-in local embeddings
                                   #   "ollama"  - Ollama server
                                   #   "openai"  - OpenAI API
                                   #   "custom"  - Custom endpoint
                                   #   (none)    - Auto-detect from available providers
-# base_url = "http://localhost:11434/v1"  # API endpoint for embeddings
-# model = "nomic-embed-text"      # Embedding model name
+base_url = "http://ollama:11434"  # Root Ollama endpoint keeps model probes/pulls on /api/* working in Docker
+model = "nomic-embed-text"       # Lightweight embedding model verified on the live Ollama sidecar
 # api_key = "..."                 # API key (optional for local endpoints like Ollama)
 
 # Knowledge base directories for RAG (semantic search)
-# watch_dirs = [
-#   "~/.moltis/memory",           # Default memory location
-#   "/server/knowledge",          # Project knowledge base
-# ]
+watch_dirs = [
+  "~/.moltis/memory",            # Default memory location
+  "/server/knowledge",           # Project knowledge base
+]
 
 # ══════════════════════════════════════════════════════════════════════════════
 # CHANNELS

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,6 +65,8 @@ services:
       TAVILY_API_KEY: ${TAVILY_API_KEY}
       # GLM-5 API key for Z.ai Coding Plan (OpenAI-compatible)
       GLM_API_KEY: ${GLM_API_KEY}
+      # Ollama Cloud API key for cloud-backed fallback chat models
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
 
     # Resource limits for production
     deploy:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,6 +26,8 @@ FLEET_INTERNAL_NETWORK="${FLEET_INTERNAL_NETWORK:-fleet-internal}"
 MONITORING_NETWORK="${MONITORING_NETWORK:-moltinger_monitoring}"
 CLAWDIY_RUNTIME_UID="${CLAWDIY_RUNTIME_UID:-1000}"
 CLAWDIY_RUNTIME_GID="${CLAWDIY_RUNTIME_GID:-1000}"
+CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR="${CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR:-/opt/moltinger-state/config-runtime}"
+MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="${MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST:-$CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR}"
 
 HEALTH_CHECK_TIMEOUT="${HEALTH_CHECK_TIMEOUT:-300}"
 HEALTH_CHECK_INTERVAL="${HEALTH_CHECK_INTERVAL:-10}"
@@ -333,6 +335,81 @@ read_env_file_value() {
     fi
 
     printf '%s' "$value"
+}
+
+canonicalize_existing_path() {
+    local path="$1"
+
+    if [[ -z "$path" ]]; then
+        return 1
+    fi
+
+    if [[ -d "$path" ]]; then
+        (cd "$path" && pwd -P)
+        return 0
+    fi
+
+    if [[ -e "$path" ]]; then
+        local parent base
+        parent="$(dirname "$path")"
+        base="$(basename "$path")"
+        printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
+        return 0
+    fi
+
+    return 1
+}
+
+normalize_runtime_config_path() {
+    local path="$1"
+
+    if [[ -z "$path" ]]; then
+        return 1
+    fi
+
+    while [[ "$path" != "/" && "$path" == */ ]]; do
+        path="${path%/}"
+    done
+
+    printf '%s' "$path"
+}
+
+runtime_config_dir_allowed() {
+    local candidate="$1"
+    local normalized_candidate normalized_allowlist entry
+    normalized_candidate="$(normalize_runtime_config_path "$candidate" || true)"
+    [[ -n "$normalized_candidate" ]] || return 1
+
+    local old_ifs="$IFS"
+    IFS=':'
+    for entry in $MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST; do
+        normalized_allowlist="$(normalize_runtime_config_path "$entry" || true)"
+        if [[ -n "$normalized_allowlist" && "$normalized_candidate" == "$normalized_allowlist" ]]; then
+            IFS="$old_ifs"
+            return 0
+        fi
+    done
+    IFS="$old_ifs"
+
+    return 1
+}
+
+container_mount_source() {
+    local container="$1"
+    local destination="$2"
+
+    docker inspect "$container" 2>/dev/null | \
+        jq -r --arg destination "$destination" '.[0].Mounts[]? | select(.Destination == $destination) | .Source' | \
+        head -n 1
+}
+
+container_mount_rw() {
+    local container="$1"
+    local destination="$2"
+
+    docker inspect "$container" 2>/dev/null | \
+        jq -r --arg destination "$destination" '.[0].Mounts[]? | select(.Destination == $destination) | .RW' | \
+        head -n 1
 }
 
 tracked_moltis_version() {
@@ -1085,6 +1162,7 @@ pull_images() {
 deploy_containers() {
     log_info "Deploying containers for target $TARGET..."
     local -a deploy_services=("$TARGET_SERVICE")
+    local -a deploy_args=(up -d --remove-orphans)
     local service
 
     for service in "${TARGET_AUXILIARY_SERVICES[@]}"; do
@@ -1092,7 +1170,13 @@ deploy_containers() {
         deploy_services+=("$service")
     done
 
-    compose_cmd normal up -d --remove-orphans "${deploy_services[@]}"
+    if [[ "$TARGET" == "moltis" ]]; then
+        # Moltis loads runtime config at process start, so bind-mounted config
+        # changes must force a recreate to avoid stale live state.
+        deploy_args+=(--force-recreate)
+    fi
+
+    compose_cmd normal "${deploy_args[@]}" "${deploy_services[@]}"
     log_success "Containers deployed for target $TARGET"
 }
 
@@ -1167,6 +1251,79 @@ verify_deployment() {
         http_code=$(curl -s -o /dev/null -w "%{http_code}" "$TARGET_METRICS_URL" 2>/dev/null || echo "000")
         if [[ "$http_code" != "200" ]]; then
             log_warn "Metrics endpoint returned HTTP $http_code for target $TARGET (non-critical)"
+        fi
+    fi
+
+    if [[ "$TARGET" == "moltis" ]]; then
+        local expected_workspace expected_runtime_config
+        local actual_workspace_source actual_runtime_config_source
+        local actual_runtime_config_rw working_dir
+        local tracked_runtime_toml runtime_runtime_toml
+
+        working_dir="$(docker inspect --format '{{.Config.WorkingDir}}' "$TARGET_CONTAINER" 2>/dev/null || echo "")"
+        if [[ "$working_dir" != "/server" ]]; then
+            log_error "Moltis runtime contract mismatch: working_dir is '$working_dir', expected '/server'"
+            return 1
+        fi
+
+        expected_workspace="$(canonicalize_existing_path "$PROJECT_ROOT" || printf '%s\n' "$PROJECT_ROOT")"
+        actual_workspace_source="$(container_mount_source "$TARGET_CONTAINER" "/server")"
+        if [[ -z "$actual_workspace_source" ]]; then
+            log_error "Moltis runtime contract mismatch: /server mount is missing in container $TARGET_CONTAINER"
+            return 1
+        fi
+        actual_workspace_source="$(canonicalize_existing_path "$actual_workspace_source" || printf '%s\n' "$actual_workspace_source")"
+        if [[ "$actual_workspace_source" != "$expected_workspace" ]]; then
+            log_error "Moltis runtime contract mismatch: /server source is '$actual_workspace_source', expected '$expected_workspace'"
+            return 1
+        fi
+
+        expected_runtime_config="$(read_env_file_value "MOLTIS_RUNTIME_CONFIG_DIR" || true)"
+        expected_runtime_config="${expected_runtime_config:-$CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR}"
+        expected_runtime_config="$(normalize_runtime_config_path "$expected_runtime_config")"
+        if ! runtime_config_dir_allowed "$expected_runtime_config"; then
+            log_error "Moltis runtime contract mismatch: runtime config dir '$expected_runtime_config' is outside the production allowlist '$MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST'"
+            return 1
+        fi
+        expected_runtime_config="$(canonicalize_existing_path "$expected_runtime_config" || printf '%s\n' "$expected_runtime_config")"
+        actual_runtime_config_source="$(container_mount_source "$TARGET_CONTAINER" "/home/moltis/.config/moltis")"
+        if [[ -z "$actual_runtime_config_source" ]]; then
+            log_error "Moltis runtime contract mismatch: runtime config mount is missing for /home/moltis/.config/moltis"
+            return 1
+        fi
+        actual_runtime_config_source="$(canonicalize_existing_path "$actual_runtime_config_source" || printf '%s\n' "$actual_runtime_config_source")"
+        if [[ "$actual_runtime_config_source" != "$expected_runtime_config" ]]; then
+            log_error "Moltis runtime contract mismatch: runtime config source is '$actual_runtime_config_source', expected '$expected_runtime_config'"
+            return 1
+        fi
+
+        actual_runtime_config_rw="$(container_mount_rw "$TARGET_CONTAINER" "/home/moltis/.config/moltis")"
+        if [[ "$actual_runtime_config_rw" != "true" ]]; then
+            log_error "Moltis runtime contract mismatch: runtime config mount must be writable for runtime-managed auth/key files"
+            return 1
+        fi
+
+        tracked_runtime_toml="$PROJECT_ROOT/config/moltis.toml"
+        runtime_runtime_toml="$expected_runtime_config/moltis.toml"
+        if [[ ! -f "$tracked_runtime_toml" || ! -f "$runtime_runtime_toml" ]]; then
+            log_error "Moltis runtime contract mismatch: tracked or runtime moltis.toml is missing"
+            return 1
+        fi
+        if ! cmp -s "$tracked_runtime_toml" "$runtime_runtime_toml"; then
+            log_error "Moltis runtime contract mismatch: runtime moltis.toml diverges from tracked config/moltis.toml"
+            return 1
+        fi
+
+        if ! docker exec "$TARGET_CONTAINER" sh -lc '
+            test -d /server &&
+            test -d /server/skills &&
+            test -f /home/moltis/.config/moltis/moltis.toml &&
+            tmp_path="/home/moltis/.config/moltis/provider_keys.json.tmp.contract-check.$$" &&
+            : > "$tmp_path" &&
+            rm -f "$tmp_path"
+        ' >/dev/null 2>&1; then
+            log_error "Moltis runtime contract mismatch: repo skills are not visible or runtime config is not writable inside the container"
+            return 1
         fi
     fi
 

--- a/scripts/moltis-runtime-attestation.sh
+++ b/scripts/moltis-runtime-attestation.sh
@@ -1,0 +1,532 @@
+#!/usr/bin/env bash
+# Prove that the live Moltis container still matches the tracked runtime provenance.
+
+set -euo pipefail
+
+OUTPUT_JSON=false
+DEPLOY_PATH="$(pwd)"
+ACTIVE_PATH="/opt/moltinger-active"
+MOLTIS_CONTAINER="moltis"
+MOLTIS_URL="http://localhost:13131"
+EXPECTED_GIT_SHA=""
+EXPECTED_GIT_REF=""
+EXPECTED_VERSION=""
+EXPECTED_RUNTIME_CONFIG_DIR=""
+EXPECTED_AUTH_PROVIDER=""
+CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR="${CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR:-/opt/moltinger-state/config-runtime}"
+MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="${MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST:-$CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR}"
+
+timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+usage() {
+    cat <<'EOF'
+Usage: moltis-runtime-attestation.sh [--json] [--deploy-path <path>] [--active-path <path>] \
+  [--container <name>] [--base-url <url>] [--expected-git-sha <sha>] [--expected-git-ref <ref>] \
+  [--expected-version <version>] [--expected-runtime-config-dir <path>] [--expected-auth-provider <provider>]
+
+Verify the live Moltis runtime provenance against the tracked deploy contract:
+  - active deploy root resolves to the live /server mount
+  - recorded deployed SHA/version still match the active root and live binary
+  - runtime config and runtime home mounts stay attached to the expected durable state
+EOF
+}
+
+normalize_runtime_config_path() {
+    local path="$1"
+
+    if [[ -z "$path" ]]; then
+        return 1
+    fi
+
+    while [[ "$path" != "/" && "$path" == */ ]]; do
+        path="${path%/}"
+    done
+
+    printf '%s' "$path"
+}
+
+runtime_config_dir_allowed() {
+    local candidate normalized_candidate allowlist_entry normalized_allowlist old_ifs
+    candidate="$1"
+    normalized_candidate="$(normalize_runtime_config_path "$candidate" || true)"
+    [[ -n "$normalized_candidate" ]] || return 1
+
+    old_ifs="$IFS"
+    IFS=':'
+    for allowlist_entry in $MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST; do
+        normalized_allowlist="$(normalize_runtime_config_path "$allowlist_entry" || true)"
+        if [[ -n "$normalized_allowlist" && "$normalized_candidate" == "$normalized_allowlist" ]]; then
+            IFS="$old_ifs"
+            return 0
+        fi
+    done
+    IFS="$old_ifs"
+
+    return 1
+}
+
+canonicalize_existing_path() {
+    local path="$1"
+
+    if [[ -z "$path" || ! -e "$path" ]]; then
+        return 1
+    fi
+
+    if [[ -d "$path" ]]; then
+        (
+            cd "$path"
+            pwd -P
+        )
+    else
+        (
+            cd "$(dirname "$path")"
+            printf '%s/%s\n' "$(pwd -P)" "$(basename "$path")"
+        )
+    fi
+}
+
+read_env_file_value() {
+    local env_file="$1"
+    local key="$2"
+    local value
+
+    if [[ ! -f "$env_file" ]]; then
+        return 1
+    fi
+
+    value="$(grep -E "^${key}=" "$env_file" | tail -1 | cut -d'=' -f2- || true)"
+    value="${value%\"}"
+    value="${value#\"}"
+
+    if [[ -z "$value" ]]; then
+        return 1
+    fi
+
+    printf '%s' "$value"
+}
+
+container_mount_source() {
+    local container="$1"
+    local destination="$2"
+
+    docker inspect "$container" 2>/dev/null | \
+        jq -r --arg destination "$destination" '.[0].Mounts[]? | select(.Destination == $destination) | .Source' | \
+        head -n 1
+}
+
+container_mount_rw() {
+    local container="$1"
+    local destination="$2"
+
+    docker inspect "$container" 2>/dev/null | \
+        jq -r --arg destination "$destination" '.[0].Mounts[]? | select(.Destination == $destination) | .RW' | \
+        head -n 1
+}
+
+container_state() {
+    docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$MOLTIS_CONTAINER" 2>/dev/null || echo "not_found"
+}
+
+container_working_dir() {
+    docker inspect --format '{{.Config.WorkingDir}}' "$MOLTIS_CONTAINER" 2>/dev/null || echo ""
+}
+
+health_status_code() {
+    curl -s -o /dev/null -w '%{http_code}' --max-time 5 "${MOLTIS_URL%/}/health" 2>/dev/null || echo "000"
+}
+
+read_deployment_info_field() {
+    local info_file="$1"
+    local key="$2"
+    local value
+
+    if [[ ! -f "$info_file" ]]; then
+        return 1
+    fi
+
+    value="$(grep -E "^${key}=" "$info_file" | tail -1 | cut -d'=' -f2- || true)"
+    [[ -n "$value" ]] || return 1
+    printf '%s' "$value"
+}
+
+emit_failure_json() {
+    local code="$1"
+    local message="$2"
+    local deploy_path="$3"
+    local active_path="$4"
+    local active_target="${5:-}"
+    local release_root_mode="${6:-unknown}"
+    local container_state_value="${7:-unknown}"
+    local http_code="${8:-000}"
+    local recorded_git_sha="${9:-}"
+    local live_git_sha="${10:-}"
+
+    jq -n \
+        --arg status "failure" \
+        --arg target "moltis" \
+        --arg action "runtime-attestation" \
+        --arg timestamp "$(timestamp)" \
+        --arg code "$code" \
+        --arg message "$message" \
+        --arg deploy_path "$deploy_path" \
+        --arg active_path "$active_path" \
+        --arg active_target "$active_target" \
+        --arg release_root_mode "$release_root_mode" \
+        --arg container_state "$container_state_value" \
+        --arg http_code "$http_code" \
+        --arg recorded_git_sha "$recorded_git_sha" \
+        --arg live_git_sha "$live_git_sha" \
+        '{
+          status: $status,
+          target: $target,
+          action: $action,
+          timestamp: $timestamp,
+          details: {
+            deploy_path: $deploy_path,
+            active_path: $active_path,
+            active_target: (if $active_target == "" then null else $active_target end),
+            release_root_mode: $release_root_mode,
+            container_state: $container_state,
+            http_code: $http_code,
+            recorded_git_sha: (if $recorded_git_sha == "" then null else $recorded_git_sha end),
+            live_git_sha: (if $live_git_sha == "" then null else $live_git_sha end)
+          },
+          errors: [{code: $code, message: $message}]
+        }'
+}
+
+fail_with() {
+    local code="$1"
+    local message="$2"
+
+    if [[ "$OUTPUT_JSON" == "true" ]]; then
+        emit_failure_json \
+            "$code" \
+            "$message" \
+            "$DEPLOY_PATH" \
+            "$ACTIVE_PATH" \
+            "${ACTIVE_TARGET:-}" \
+            "${RELEASE_ROOT_MODE:-unknown}" \
+            "${CONTAINER_STATE_VALUE:-unknown}" \
+            "${HTTP_CODE:-000}" \
+            "${RECORDED_GIT_SHA:-}" \
+            "${LIVE_GIT_SHA:-}"
+    else
+        echo "moltis-runtime-attestation.sh: [$code] $message" >&2
+    fi
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json)
+            OUTPUT_JSON=true
+            shift
+            ;;
+        --deploy-path)
+            DEPLOY_PATH="${2:-}"
+            shift 2
+            ;;
+        --active-path)
+            ACTIVE_PATH="${2:-}"
+            shift 2
+            ;;
+        --container)
+            MOLTIS_CONTAINER="${2:-}"
+            shift 2
+            ;;
+        --base-url)
+            MOLTIS_URL="${2:-}"
+            shift 2
+            ;;
+        --expected-git-sha)
+            EXPECTED_GIT_SHA="${2:-}"
+            shift 2
+            ;;
+        --expected-git-ref)
+            EXPECTED_GIT_REF="${2:-}"
+            shift 2
+            ;;
+        --expected-version)
+            EXPECTED_VERSION="${2:-}"
+            shift 2
+            ;;
+        --expected-runtime-config-dir)
+            EXPECTED_RUNTIME_CONFIG_DIR="${2:-}"
+            shift 2
+            ;;
+        --expected-auth-provider)
+            EXPECTED_AUTH_PROVIDER="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "moltis-runtime-attestation.sh: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+DEPLOY_PATH="$(cd "$DEPLOY_PATH" && pwd)"
+ENV_FILE="$DEPLOY_PATH/.env"
+ACTIVE_CANONICAL="$(canonicalize_existing_path "$ACTIVE_PATH" || true)"
+ACTIVE_TARGET="${ACTIVE_CANONICAL:-}"
+RELEASE_ROOT_MODE="unknown"
+CONTAINER_STATE_VALUE="unknown"
+HTTP_CODE="000"
+RECORDED_GIT_SHA=""
+RECORDED_GIT_REF=""
+RECORDED_VERSION=""
+RECORDED_WORKFLOW_RUN=""
+RECORDED_DEPLOY_PATH=""
+RECORDED_RUNTIME_CONFIG_DIR=""
+LIVE_GIT_SHA=""
+LIVE_GIT_REF=""
+LIVE_VERSION=""
+RUNTIME_CONFIG_RW=""
+AUTH_STATUS_RAW=""
+AUTH_STATUS_VALID=""
+TRACKED_RUNTIME_TOML=""
+RUNTIME_RUNTIME_TOML=""
+
+if [[ ! -L "$ACTIVE_PATH" ]]; then
+    fail_with "ACTIVE_ROOT_NOT_SYMLINK" "Active deploy root is not a symlink: $ACTIVE_PATH"
+fi
+
+if [[ -z "$ACTIVE_TARGET" || ! -d "$ACTIVE_TARGET" ]]; then
+    fail_with "ACTIVE_ROOT_TARGET_MISSING" "Active deploy root does not resolve to an existing directory: $ACTIVE_PATH"
+fi
+
+if [[ "$ACTIVE_TARGET" == "$DEPLOY_PATH" ]]; then
+    RELEASE_ROOT_MODE="mutable-root"
+else
+    RELEASE_ROOT_MODE="active-symlink"
+fi
+
+DEPLOY_INFO_FILE="$ACTIVE_TARGET/data/.deployment-info"
+DEPLOY_SHA_FILE="$ACTIVE_TARGET/data/.deployed-sha"
+if [[ ! -f "$DEPLOY_INFO_FILE" && -f "$DEPLOY_PATH/data/.deployment-info" ]]; then
+    DEPLOY_INFO_FILE="$DEPLOY_PATH/data/.deployment-info"
+fi
+if [[ ! -f "$DEPLOY_SHA_FILE" && -f "$DEPLOY_PATH/data/.deployed-sha" ]]; then
+    DEPLOY_SHA_FILE="$DEPLOY_PATH/data/.deployed-sha"
+fi
+
+if [[ ! -f "$DEPLOY_SHA_FILE" ]]; then
+    fail_with "DEPLOYED_SHA_MISSING" "Recorded deployed SHA file is missing: $DEPLOY_SHA_FILE"
+fi
+if [[ ! -f "$DEPLOY_INFO_FILE" ]]; then
+    fail_with "DEPLOYMENT_INFO_MISSING" "Recorded deployment info file is missing: $DEPLOY_INFO_FILE"
+fi
+
+RECORDED_GIT_SHA="$(cat "$DEPLOY_SHA_FILE" 2>/dev/null || true)"
+[[ -n "$RECORDED_GIT_SHA" ]] || fail_with "DEPLOYED_SHA_EMPTY" "Recorded deployed SHA is empty: $DEPLOY_SHA_FILE"
+
+RECORDED_GIT_REF="$(read_deployment_info_field "$DEPLOY_INFO_FILE" "git_ref" || true)"
+RECORDED_VERSION="$(read_deployment_info_field "$DEPLOY_INFO_FILE" "version" || true)"
+RECORDED_WORKFLOW_RUN="$(read_deployment_info_field "$DEPLOY_INFO_FILE" "workflow_run" || true)"
+RECORDED_DEPLOY_PATH="$(read_deployment_info_field "$DEPLOY_INFO_FILE" "deploy_path" || true)"
+RECORDED_RUNTIME_CONFIG_DIR="$(read_deployment_info_field "$DEPLOY_INFO_FILE" "runtime_config_dir" || true)"
+
+if [[ -n "$EXPECTED_GIT_REF" && -n "$RECORDED_GIT_REF" && "$EXPECTED_GIT_REF" != "$RECORDED_GIT_REF" ]]; then
+    fail_with "RECORDED_GIT_REF_MISMATCH" "Recorded git ref '$RECORDED_GIT_REF' does not match expected '$EXPECTED_GIT_REF'"
+fi
+
+if [[ -n "$EXPECTED_VERSION" && -n "$RECORDED_VERSION" && "$EXPECTED_VERSION" != "$RECORDED_VERSION" ]]; then
+    fail_with "RECORDED_VERSION_MISMATCH" "Recorded version '$RECORDED_VERSION' does not match expected '$EXPECTED_VERSION'"
+fi
+
+INFO_GIT_SHA="$(read_deployment_info_field "$DEPLOY_INFO_FILE" "git_sha" || true)"
+if [[ -n "$INFO_GIT_SHA" && "$INFO_GIT_SHA" != "$RECORDED_GIT_SHA" ]]; then
+    fail_with "DEPLOY_METADATA_MISMATCH" "Recorded deployment info git_sha '$INFO_GIT_SHA' does not match $DEPLOY_SHA_FILE value '$RECORDED_GIT_SHA'"
+fi
+
+if [[ -n "$EXPECTED_GIT_SHA" && "$RECORDED_GIT_SHA" != "$EXPECTED_GIT_SHA" ]]; then
+    fail_with "RECORDED_GIT_SHA_MISMATCH" "Recorded deployed SHA '$RECORDED_GIT_SHA' does not match expected '$EXPECTED_GIT_SHA'"
+fi
+
+CONTAINER_STATE_VALUE="$(container_state)"
+HTTP_CODE="$(health_status_code)"
+
+if [[ "$CONTAINER_STATE_VALUE" != "healthy" && "$CONTAINER_STATE_VALUE" != "running" ]]; then
+    fail_with "CONTAINER_NOT_READY" "Moltis container state is not ready: $CONTAINER_STATE_VALUE"
+fi
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+    fail_with "HEALTHCHECK_HTTP_MISMATCH" "Moltis /health returned HTTP $HTTP_CODE"
+fi
+
+WORKING_DIR="$(container_working_dir)"
+if [[ "$WORKING_DIR" != "/server" ]]; then
+    fail_with "WORKING_DIR_MISMATCH" "Moltis working_dir is '$WORKING_DIR', expected '/server'"
+fi
+
+WORKSPACE_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "/server")"
+if [[ -z "$WORKSPACE_SOURCE" ]]; then
+    fail_with "WORKSPACE_MOUNT_MISSING" "Moltis container does not expose /server mount"
+fi
+WORKSPACE_SOURCE="$(canonicalize_existing_path "$WORKSPACE_SOURCE" || printf '%s\n' "$WORKSPACE_SOURCE")"
+if [[ "$WORKSPACE_SOURCE" != "$ACTIVE_TARGET" ]]; then
+    fail_with "WORKSPACE_PROVENANCE_MISMATCH" "Live /server mount source '$WORKSPACE_SOURCE' does not match active deploy target '$ACTIVE_TARGET'"
+fi
+
+if [[ -f "$ACTIVE_TARGET/.env" ]]; then
+    ENV_FILE="$ACTIVE_TARGET/.env"
+fi
+
+EXPECTED_RUNTIME_CONFIG="${EXPECTED_RUNTIME_CONFIG_DIR:-}"
+if [[ -z "$EXPECTED_RUNTIME_CONFIG" ]]; then
+    EXPECTED_RUNTIME_CONFIG="$(read_env_file_value "$ENV_FILE" "MOLTIS_RUNTIME_CONFIG_DIR" || true)"
+fi
+EXPECTED_RUNTIME_CONFIG="${EXPECTED_RUNTIME_CONFIG:-$CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR}"
+EXPECTED_RUNTIME_CONFIG="$(normalize_runtime_config_path "$EXPECTED_RUNTIME_CONFIG")"
+if ! runtime_config_dir_allowed "$EXPECTED_RUNTIME_CONFIG"; then
+    fail_with "RUNTIME_CONFIG_ALLOWLIST_MISMATCH" "Runtime config dir '$EXPECTED_RUNTIME_CONFIG' is outside allowlist '$MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST'"
+fi
+if [[ ! -d "$EXPECTED_RUNTIME_CONFIG" ]]; then
+    fail_with "RUNTIME_CONFIG_DIR_MISSING" "Expected runtime config dir is missing: $EXPECTED_RUNTIME_CONFIG"
+fi
+EXPECTED_RUNTIME_CONFIG="$(canonicalize_existing_path "$EXPECTED_RUNTIME_CONFIG" || printf '%s\n' "$EXPECTED_RUNTIME_CONFIG")"
+
+RUNTIME_CONFIG_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "/home/moltis/.config/moltis")"
+if [[ -z "$RUNTIME_CONFIG_SOURCE" ]]; then
+    fail_with "RUNTIME_CONFIG_MOUNT_MISSING" "Moltis runtime config mount is missing"
+fi
+RUNTIME_CONFIG_SOURCE="$(canonicalize_existing_path "$RUNTIME_CONFIG_SOURCE" || printf '%s\n' "$RUNTIME_CONFIG_SOURCE")"
+if [[ "$RUNTIME_CONFIG_SOURCE" != "$EXPECTED_RUNTIME_CONFIG" ]]; then
+    fail_with "RUNTIME_CONFIG_SOURCE_MISMATCH" "Runtime config source '$RUNTIME_CONFIG_SOURCE' does not match expected '$EXPECTED_RUNTIME_CONFIG'"
+fi
+
+RUNTIME_CONFIG_RW="$(container_mount_rw "$MOLTIS_CONTAINER" "/home/moltis/.config/moltis")"
+if [[ "$RUNTIME_CONFIG_RW" != "true" ]]; then
+    fail_with "RUNTIME_CONFIG_NOT_WRITABLE" "Runtime config mount for /home/moltis/.config/moltis must be writable"
+fi
+
+TRACKED_RUNTIME_TOML="$ACTIVE_TARGET/config/moltis.toml"
+RUNTIME_RUNTIME_TOML="$EXPECTED_RUNTIME_CONFIG/moltis.toml"
+if [[ ! -f "$TRACKED_RUNTIME_TOML" || ! -f "$RUNTIME_RUNTIME_TOML" ]]; then
+    fail_with "RUNTIME_CONFIG_FILE_MISSING" "Tracked or runtime moltis.toml is missing; expected '$TRACKED_RUNTIME_TOML' and '$RUNTIME_RUNTIME_TOML'"
+fi
+if ! cmp -s "$TRACKED_RUNTIME_TOML" "$RUNTIME_RUNTIME_TOML"; then
+    fail_with "RUNTIME_CONFIG_FILE_MISMATCH" "Runtime moltis.toml diverges from tracked config/moltis.toml"
+fi
+
+RUNTIME_HOME_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "/home/moltis/.moltis")"
+if [[ -z "$RUNTIME_HOME_SOURCE" ]]; then
+    fail_with "RUNTIME_HOME_MOUNT_MISSING" "Moltis runtime home mount /home/moltis/.moltis is missing"
+fi
+RUNTIME_HOME_SOURCE="$(canonicalize_existing_path "$RUNTIME_HOME_SOURCE" || printf '%s\n' "$RUNTIME_HOME_SOURCE")"
+
+LIVE_GIT_SHA="$(git -C "$ACTIVE_TARGET" rev-parse HEAD 2>/dev/null || true)"
+LIVE_GIT_REF="$(git -C "$ACTIVE_TARGET" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+if [[ -n "$RECORDED_GIT_SHA" && -n "$LIVE_GIT_SHA" && "$RECORDED_GIT_SHA" != "$LIVE_GIT_SHA" ]]; then
+    fail_with "DEPLOYED_SHA_MISMATCH" "Recorded deployed SHA '$RECORDED_GIT_SHA' does not match active root HEAD '$LIVE_GIT_SHA'"
+fi
+
+LIVE_VERSION_RAW="$(docker exec "$MOLTIS_CONTAINER" moltis --version 2>/dev/null || true)"
+LIVE_VERSION="${LIVE_VERSION_RAW##* }"
+if [[ -n "$EXPECTED_VERSION" && -n "$LIVE_VERSION" && "$EXPECTED_VERSION" != "$LIVE_VERSION" ]]; then
+    fail_with "LIVE_VERSION_MISMATCH" "Expected version '$EXPECTED_VERSION' does not match live Moltis version '$LIVE_VERSION'"
+fi
+if [[ -n "$RECORDED_VERSION" && -n "$LIVE_VERSION" && "$RECORDED_VERSION" != "$LIVE_VERSION" ]]; then
+    fail_with "LIVE_VERSION_MISMATCH" "Recorded version '$RECORDED_VERSION' does not match live Moltis version '$LIVE_VERSION'"
+fi
+
+if [[ -n "$EXPECTED_AUTH_PROVIDER" ]]; then
+    AUTH_STATUS_RAW="$(docker exec "$MOLTIS_CONTAINER" moltis auth status 2>/dev/null || true)"
+    if ! printf '%s\n' "$AUTH_STATUS_RAW" | grep -F "$EXPECTED_AUTH_PROVIDER" | grep -F '[valid' >/dev/null 2>&1; then
+        fail_with "AUTH_PROVIDER_INVALID" "Expected valid auth provider '$EXPECTED_AUTH_PROVIDER' was not found in live Moltis auth status"
+    fi
+    AUTH_STATUS_VALID="true"
+fi
+
+if [[ "$OUTPUT_JSON" == "true" ]]; then
+    jq -n \
+        --arg status "success" \
+        --arg target "moltis" \
+        --arg action "runtime-attestation" \
+        --arg timestamp "$(timestamp)" \
+        --arg deploy_path "$DEPLOY_PATH" \
+        --arg active_path "$ACTIVE_PATH" \
+        --arg active_target "$ACTIVE_TARGET" \
+        --arg release_root_mode "$RELEASE_ROOT_MODE" \
+        --arg container "$MOLTIS_CONTAINER" \
+        --arg container_state "$CONTAINER_STATE_VALUE" \
+        --arg http_code "$HTTP_CODE" \
+        --arg workspace_source "$WORKSPACE_SOURCE" \
+        --arg runtime_config_source "$RUNTIME_CONFIG_SOURCE" \
+        --arg runtime_home_source "$RUNTIME_HOME_SOURCE" \
+        --arg recorded_git_sha "$RECORDED_GIT_SHA" \
+        --arg recorded_git_ref "$RECORDED_GIT_REF" \
+        --arg recorded_version "$RECORDED_VERSION" \
+        --arg recorded_workflow_run "$RECORDED_WORKFLOW_RUN" \
+        --arg recorded_deploy_path "$RECORDED_DEPLOY_PATH" \
+        --arg recorded_runtime_config_dir "$RECORDED_RUNTIME_CONFIG_DIR" \
+        --arg live_git_sha "$LIVE_GIT_SHA" \
+        --arg live_git_ref "$LIVE_GIT_REF" \
+        --arg live_version "$LIVE_VERSION" \
+        --arg runtime_config_rw "$RUNTIME_CONFIG_RW" \
+        --arg tracked_runtime_toml "$TRACKED_RUNTIME_TOML" \
+        --arg runtime_runtime_toml "$RUNTIME_RUNTIME_TOML" \
+        --arg expected_auth_provider "$EXPECTED_AUTH_PROVIDER" \
+        --arg auth_status_valid "$AUTH_STATUS_VALID" \
+        '{
+          status: $status,
+          target: $target,
+          action: $action,
+          timestamp: $timestamp,
+          details: {
+            deploy_path: $deploy_path,
+            active_path: $active_path,
+            active_target: $active_target,
+            release_root_mode: $release_root_mode,
+            container: $container,
+            container_state: $container_state,
+            http_code: $http_code,
+            workspace_source: $workspace_source,
+            runtime_config_source: $runtime_config_source,
+            runtime_home_source: $runtime_home_source,
+            recorded_git_sha: (if $recorded_git_sha == "" then null else $recorded_git_sha end),
+            recorded_git_ref: (if $recorded_git_ref == "" then null else $recorded_git_ref end),
+            recorded_version: (if $recorded_version == "" then null else $recorded_version end),
+            recorded_workflow_run: (if $recorded_workflow_run == "" then null else $recorded_workflow_run end),
+            recorded_deploy_path: (if $recorded_deploy_path == "" then null else $recorded_deploy_path end),
+            recorded_runtime_config_dir: (if $recorded_runtime_config_dir == "" then null else $recorded_runtime_config_dir end),
+            live_git_sha: (if $live_git_sha == "" then null else $live_git_sha end),
+            live_git_ref: (if $live_git_ref == "" then null else $live_git_ref end),
+            live_version: (if $live_version == "" then null else $live_version end),
+            runtime_config_rw: (if $runtime_config_rw == "" then null else $runtime_config_rw end),
+            tracked_runtime_toml: (if $tracked_runtime_toml == "" then null else $tracked_runtime_toml end),
+            runtime_runtime_toml: (if $runtime_runtime_toml == "" then null else $runtime_runtime_toml end),
+            expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
+            auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end)
+          },
+          errors: []
+        }'
+else
+    cat <<EOF
+[OK] Moltis runtime attestation passed
+deploy_path=$DEPLOY_PATH
+active_path=$ACTIVE_PATH
+active_target=$ACTIVE_TARGET
+release_root_mode=$RELEASE_ROOT_MODE
+workspace_source=$WORKSPACE_SOURCE
+runtime_config_source=$RUNTIME_CONFIG_SOURCE
+runtime_home_source=$RUNTIME_HOME_SOURCE
+recorded_git_sha=${RECORDED_GIT_SHA:-unknown}
+live_git_sha=${LIVE_GIT_SHA:-unknown}
+recorded_version=${RECORDED_VERSION:-unknown}
+live_version=${LIVE_VERSION:-unknown}
+runtime_config_rw=${RUNTIME_CONFIG_RW:-unknown}
+tracked_runtime_toml=${TRACKED_RUNTIME_TOML:-unknown}
+runtime_runtime_toml=${RUNTIME_RUNTIME_TOML:-unknown}
+expected_auth_provider=${EXPECTED_AUTH_PROVIDER:-none}
+auth_status_valid=${AUTH_STATUS_VALID:-skipped}
+EOF
+fi

--- a/scripts/moltis-search-memory-diagnostics.sh
+++ b/scripts/moltis-search-memory-diagnostics.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_PATH="config/moltis.toml"
+LOG_PATH=""
+
+usage() {
+    cat <<'EOF'
+Usage: moltis-search-memory-diagnostics.sh [--config <path>] [--log-file <path>]
+
+Emit a JSON summary of the tracked Tavily search + memory/embeddings contract and,
+optionally, a runtime-log failure taxonomy for Tavily SSE and memory_search errors.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config)
+            CONFIG_PATH="${2:-}"
+            shift 2
+            ;;
+        --log-file)
+            LOG_PATH="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "moltis-search-memory-diagnostics.sh: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "moltis-search-memory-diagnostics.sh: config file not found: $CONFIG_PATH" >&2
+    exit 2
+fi
+
+if [[ -n "$LOG_PATH" && ! -f "$LOG_PATH" ]]; then
+    echo "moltis-search-memory-diagnostics.sh: log file not found: $LOG_PATH" >&2
+    exit 2
+fi
+
+python3 - "$CONFIG_PATH" "$LOG_PATH" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+
+config_path = Path(sys.argv[1])
+log_path = Path(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2] else None
+
+with config_path.open("rb") as fh:
+    config = tomllib.load(fh)
+
+tools = config.get("tools") or {}
+web_tools = tools.get("web") or {}
+search = web_tools.get("search") or {}
+mcp_servers = ((config.get("mcp") or {}).get("servers") or {})
+tavily = mcp_servers.get("tavily") or {}
+memory = config.get("memory") or {}
+
+watch_dirs = memory.get("watch_dirs") or []
+if isinstance(watch_dirs, str):
+    watch_dirs = [watch_dirs]
+
+tracked = {
+    "config_path": str(config_path),
+    "search": {
+        "builtin_enabled": bool(search.get("enabled", True)),
+        "tavily_mcp_enabled": bool(tavily),
+        "tavily_transport": tavily.get("transport"),
+        "tavily_url_present": bool(tavily.get("url")),
+        "tavily_url_uses_query_api_key": "tavilyApiKey=" in str(tavily.get("url", "")),
+    },
+    "memory": {
+        "disable_rag": memory.get("disable_rag"),
+        "provider": memory.get("provider"),
+        "model": memory.get("model"),
+        "provider_pinned": bool(memory.get("provider")),
+        "watch_dirs": watch_dirs,
+        "watch_dirs_configured": bool(watch_dirs),
+    },
+}
+
+runtime = {
+    "log_path": str(log_path) if log_path else None,
+    "tavily": {
+        "tavily_search_invocations": 0,
+        "mcp_sse_handshake_failures": 0,
+        "mcp_auto_restart_failures": 0,
+    },
+    "memory": {
+        "memory_search_invocations": 0,
+        "memory_search_tool_failures": 0,
+        "openai_embeddings_400": 0,
+        "groq_embeddings_401": 0,
+    },
+}
+
+if log_path:
+    text = log_path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+
+    def count_lines(predicate) -> int:
+        return sum(1 for line in lines if predicate(line))
+
+    runtime["tavily"]["tavily_search_invocations"] = count_lines(lambda line: "mcp__tavily__tavily_search" in line)
+    runtime["tavily"]["mcp_sse_handshake_failures"] = count_lines(lambda line: "MCP SSE initialize handshake failed" in line)
+    runtime["tavily"]["mcp_auto_restart_failures"] = count_lines(lambda line: "MCP auto-restart failed" in line)
+    runtime["memory"]["memory_search_invocations"] = count_lines(lambda line: "memory_search" in line)
+    runtime["memory"]["memory_search_tool_failures"] = count_lines(
+        lambda line: "memory_search" in line and ("tool execution failed" in line or "all embedding providers failed" in line)
+    )
+    runtime["memory"]["openai_embeddings_400"] = count_lines(
+        lambda line: "https://api.z.ai/api/coding/paas/v4/embeddings" in line or "openai: HTTP status client error (400 Bad Request)" in line
+    )
+    runtime["memory"]["groq_embeddings_401"] = count_lines(
+        lambda line: "https://api.groq.com/openai/v1/embeddings" in line or "groq: HTTP status client error (401 Unauthorized)" in line
+    )
+
+keyword_only_mode = tracked["memory"]["disable_rag"] is True
+provider_pinned = tracked["memory"]["provider_pinned"]
+watch_dirs_configured = tracked["memory"]["watch_dirs_configured"]
+
+risk_summary = {
+    "tavily_relies_on_remote_sse": (not tracked["search"]["builtin_enabled"]) and tracked["search"]["tavily_transport"] == "sse",
+    "tavily_transport_unstable": runtime["tavily"]["mcp_sse_handshake_failures"] > 0 or runtime["tavily"]["mcp_auto_restart_failures"] > 0,
+    "memory_provider_autodetect": (not keyword_only_mode) and not provider_pinned,
+    "memory_missing_watch_dirs": not watch_dirs_configured,
+    "memory_embedding_provider_failures_present": runtime["memory"]["openai_embeddings_400"] > 0 or runtime["memory"]["groq_embeddings_401"] > 0 or runtime["memory"]["memory_search_tool_failures"] > 0,
+    "openai_embeddings_endpoint_mismatch_suspected": runtime["memory"]["openai_embeddings_400"] > 0,
+    "groq_runtime_drift_suspected": runtime["memory"]["groq_embeddings_401"] > 0,
+}
+
+print(
+    json.dumps(
+        {
+            "tracked": tracked,
+            "runtime_log_signals": runtime,
+            "risk_summary": risk_summary,
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+)
+PY

--- a/scripts/run-tracked-moltis-deploy.sh
+++ b/scripts/run-tracked-moltis-deploy.sh
@@ -13,6 +13,9 @@ EXPECTED_VERSION=""
 TRACKED_VERSION=""
 RUNTIME_CONFIG_DIR=""
 MOLTIS_DOMAIN_VALUE="moltis.ainetic.tech"
+ACTIVE_DEPLOY_PATH="${ACTIVE_DEPLOY_PATH:-/opt/moltinger-active}"
+CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR="${CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR:-/opt/moltinger-state/config-runtime}"
+MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="${MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST:-$CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR}"
 
 timestamp() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -29,7 +32,7 @@ log_info() {
 usage() {
     cat <<'EOF'
 Usage: run-tracked-moltis-deploy.sh [--json] [--dry-run] [--deploy-path <path>] \
-  --git-sha <sha> --git-ref <ref> --workflow-run <run-id> [--version <version>]
+  [--active-path <path>] --git-sha <sha> --git-ref <ref> --workflow-run <run-id> [--version <version>]
 
 Runs the tracked Moltis deploy control plane on the remote host:
   1. prepare writable runtime config
@@ -37,6 +40,7 @@ Runs the tracked Moltis deploy control plane on the remote host:
   3. call scripts/deploy.sh --json moltis deploy
   4. record deployed git SHA + deployment metadata
   5. align the server checkout to the deployed commit
+  6. attest the live runtime provenance against the tracked intent
 EOF
 }
 
@@ -140,6 +144,57 @@ require_file() {
     fi
 }
 
+normalize_runtime_config_path() {
+    local path="$1"
+
+    if [[ -z "$path" ]]; then
+        return 1
+    fi
+
+    while [[ "$path" != "/" && "$path" == */ ]]; do
+        path="${path%/}"
+    done
+
+    printf '%s' "$path"
+}
+
+runtime_config_dir_allowed() {
+    local candidate normalized_candidate allowlist_entry normalized_allowlist
+    candidate="$1"
+    normalized_candidate="$(normalize_runtime_config_path "$candidate" || true)"
+    [[ -n "$normalized_candidate" ]] || return 1
+
+    OLD_IFS="$IFS"
+    IFS=':'
+    for allowlist_entry in $MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST; do
+        normalized_allowlist="$(normalize_runtime_config_path "$allowlist_entry" || true)"
+        if [[ -n "$normalized_allowlist" && "$normalized_candidate" == "$normalized_allowlist" ]]; then
+            IFS="$OLD_IFS"
+            return 0
+        fi
+    done
+    IFS="$OLD_IFS"
+
+    return 1
+}
+
+validate_runtime_config_dir_policy() {
+    local candidate="$1"
+    local message
+
+    if runtime_config_dir_allowed "$candidate"; then
+        return 0
+    fi
+
+    message="Moltis runtime config dir '$candidate' is outside the production allowlist '$MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST'"
+    if [[ "$OUTPUT_JSON" == "true" ]]; then
+        emit_failure_json "$message"
+    else
+        echo "$message" >&2
+    fi
+    exit 1
+}
+
 read_env_file_value() {
     local env_file="$1"
     local key="$2"
@@ -166,6 +221,8 @@ load_runtime_settings() {
 
     RUNTIME_CONFIG_DIR="$(read_env_file_value "$env_file" "MOLTIS_RUNTIME_CONFIG_DIR" || true)"
     [[ -n "$RUNTIME_CONFIG_DIR" ]] || RUNTIME_CONFIG_DIR="/opt/moltinger-state/config-runtime"
+    RUNTIME_CONFIG_DIR="$(normalize_runtime_config_path "$RUNTIME_CONFIG_DIR")"
+    validate_runtime_config_dir_policy "$RUNTIME_CONFIG_DIR"
 
     MOLTIS_DOMAIN_VALUE="$(read_env_file_value "$env_file" "MOLTIS_DOMAIN" || true)"
     [[ -n "$MOLTIS_DOMAIN_VALUE" ]] || MOLTIS_DOMAIN_VALUE="moltis.ainetic.tech"
@@ -216,15 +273,42 @@ validate_tracked_contract() {
 }
 
 record_deployment_state() {
-    mkdir -p "$DEPLOY_PATH/data"
-    printf '%s\n' "$GIT_SHA" > "$DEPLOY_PATH/data/.deployed-sha"
+    local target_root="$1"
 
-    cat > "$DEPLOY_PATH/data/.deployment-info" <<EOF
+    mkdir -p "$target_root/data"
+    printf '%s\n' "$GIT_SHA" > "$target_root/data/.deployed-sha"
+
+    cat > "$target_root/data/.deployment-info" <<EOF
 deployed_at=$(timestamp)
 git_sha=$GIT_SHA
+git_ref=$GIT_REF
 workflow_run=$WORKFLOW_RUN
 version=${TRACKED_VERSION:-$EXPECTED_VERSION}
+deploy_path=$DEPLOY_PATH
+active_path=$ACTIVE_DEPLOY_PATH
+runtime_config_dir=$RUNTIME_CONFIG_DIR
+audit_root=$target_root
 EOF
+}
+
+resolve_active_target() {
+    if [[ -d "$ACTIVE_DEPLOY_PATH" ]]; then
+        (
+            cd "$ACTIVE_DEPLOY_PATH"
+            pwd -P
+        )
+    fi
+}
+
+record_deployment_markers() {
+    local active_target=""
+
+    record_deployment_state "$DEPLOY_PATH"
+
+    active_target="$(resolve_active_target || true)"
+    if [[ -n "$active_target" && "$active_target" != "$DEPLOY_PATH" ]]; then
+        record_deployment_state "$active_target"
+    fi
 }
 
 align_checkout() {
@@ -279,6 +363,10 @@ while [[ $# -gt 0 ]]; do
             DEPLOY_PATH="${2:-}"
             shift 2
             ;;
+        --active-path)
+            ACTIVE_DEPLOY_PATH="${2:-}"
+            shift 2
+            ;;
         --git-sha)
             GIT_SHA="${2:-}"
             shift 2
@@ -316,6 +404,7 @@ DEPLOY_PATH="$(cd "$DEPLOY_PATH" && pwd)"
 require_file "$DEPLOY_PATH/scripts/prepare-moltis-runtime-config.sh"
 require_file "$DEPLOY_PATH/scripts/moltis-version.sh"
 require_file "$DEPLOY_PATH/scripts/deploy.sh"
+require_file "$DEPLOY_PATH/scripts/moltis-runtime-attestation.sh"
 require_file "$DEPLOY_PATH/docker-compose.prod.yml"
 require_file "$DEPLOY_PATH/config/moltis.toml"
 
@@ -351,7 +440,8 @@ if [[ "$DRY_RUN" == "true" ]]; then
               "validate-tracked-contract",
               "deploy-via-deploy-sh",
               "record-deployed-state",
-              "align-server-checkout"
+              "align-server-checkout",
+              "attest-live-runtime"
             ]
           },
           errors: []
@@ -396,7 +486,7 @@ ROLLBACK_VERIFIED=false
 
 if [[ "$DEPLOY_EXIT" -eq 0 && "$DEPLOY_STATUS" == "success" ]]; then
     log_info "Recording deployed git SHA and deployment metadata"
-    if ! record_deployment_state; then
+    if ! record_deployment_markers; then
         emit_failure_json "Deploy succeeded but recording deployment metadata failed" "healthy"
         exit 1
     fi
@@ -407,7 +497,58 @@ if [[ "$DEPLOY_EXIT" -eq 0 && "$DEPLOY_STATUS" == "success" ]]; then
         exit 1
     fi
 
-    append_result_context "$DEPLOY_OUTPUT" "success" "$ROLLBACK_VERIFIED"
+    log_info "Attesting live Moltis runtime provenance"
+    set +e
+    ATTESTATION_OUTPUT="$(
+        "$DEPLOY_PATH/scripts/moltis-runtime-attestation.sh" \
+            --json \
+            --deploy-path "$DEPLOY_PATH" \
+            --active-path "$ACTIVE_DEPLOY_PATH" \
+            --container "moltis" \
+            --base-url "http://localhost:13131" \
+            --expected-git-sha "$GIT_SHA" \
+            --expected-git-ref "$GIT_REF" \
+            --expected-version "${TRACKED_VERSION:-$EXPECTED_VERSION}" \
+            --expected-runtime-config-dir "$RUNTIME_CONFIG_DIR" \
+            --expected-auth-provider "openai-codex"
+    )"
+    ATTESTATION_EXIT=$?
+    set -e
+
+    if ! jq empty >/dev/null 2>&1 <<<"$ATTESTATION_OUTPUT"; then
+        emit_failure_json "Deploy succeeded but runtime attestation returned non-JSON output" "healthy"
+        exit 1
+    fi
+
+    if [[ "$ATTESTATION_EXIT" -ne 0 || "$(jq -r '.status // empty' <<<"$ATTESTATION_OUTPUT")" != "success" ]]; then
+        ATTESTATION_MESSAGE="$(jq -r '.errors[0].message // empty' <<<"$ATTESTATION_OUTPUT" 2>/dev/null || true)"
+        ATTESTATION_MESSAGE="${ATTESTATION_MESSAGE:-Deploy succeeded but live runtime attestation failed}"
+        RESULT_JSON="$(append_result_context "$DEPLOY_OUTPUT" "failure" "$ROLLBACK_VERIFIED" "$ATTESTATION_MESSAGE")"
+        RESULT_JSON="$(jq \
+            --argjson attestation "$ATTESTATION_OUTPUT" \
+            '.details = ((.details // {}) + {
+                runtime_attestation: {
+                    status: ($attestation.status // null),
+                    details: ($attestation.details // {}),
+                    errors: ($attestation.errors // [])
+                }
+            })' <<<"$RESULT_JSON")"
+        printf '%s\n' "$RESULT_JSON"
+        exit 1
+    fi
+
+    RESULT_JSON="$(append_result_context "$DEPLOY_OUTPUT" "success" "$ROLLBACK_VERIFIED")"
+    RESULT_JSON="$(jq \
+        --argjson attestation "$ATTESTATION_OUTPUT" \
+        '.details = ((.details // {}) + {
+            runtime_attestation: {
+                status: ($attestation.status // null),
+                details: ($attestation.details // {}),
+                errors: ($attestation.errors // [])
+            }
+        })' <<<"$RESULT_JSON")"
+
+    printf '%s\n' "$RESULT_JSON"
     exit 0
 fi
 

--- a/tests/component/test_moltis_runtime_attestation.sh
+++ b/tests/component/test_moltis_runtime_attestation.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+ATTESTATION_SCRIPT="$PROJECT_ROOT/scripts/moltis-runtime-attestation.sh"
+
+create_fake_runtime_bin() {
+    local fixture_root="$1"
+    local fake_bin="$fixture_root/bin"
+
+    mkdir -p "$fake_bin"
+
+    cat >"$fake_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  inspect)
+    if [[ "${2:-}" == "--format" ]]; then
+      case "${3:-}" in
+        '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}')
+          printf '%s\n' "${FAKE_DOCKER_STATE:-healthy}"
+          ;;
+        '{{.Config.WorkingDir}}')
+          printf '%s\n' "${FAKE_DOCKER_WORKDIR:-/server}"
+          ;;
+        *)
+          printf 'unsupported inspect format: %s\n' "${3:-}" >&2
+          exit 1
+          ;;
+      esac
+      exit 0
+    fi
+
+    if [[ $# -eq 2 && "${2:-}" == "moltis" ]]; then
+      cat "${FAKE_DOCKER_MOUNTS_FILE}"
+      exit 0
+    fi
+
+    printf 'unsupported docker inspect invocation\n' >&2
+    exit 1
+    ;;
+  exec)
+    shift
+    if [[ "${1:-}" == "moltis" && "${2:-}" == "moltis" && "${3:-}" == "--version" ]]; then
+      printf 'moltis %s\n' "${FAKE_MOLTIS_VERSION:-0.10.18}"
+      exit 0
+    fi
+    if [[ "${1:-}" == "moltis" && "${2:-}" == "moltis" && "${3:-}" == "auth" && "${4:-}" == "status" ]]; then
+      printf '%s\n' "${FAKE_AUTH_STATUS:-openai-codex [valid (10m remaining)]}"
+      exit 0
+    fi
+    printf 'unsupported docker exec invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+  *)
+    printf 'unsupported fake docker command: %s\n' "${1:-}" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+    cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "${FAKE_CURL_HTTP_CODE:-200}"
+EOF
+
+    cat >"$fake_bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-C" && "${3:-}" == "rev-parse" && "${4:-}" == "HEAD" ]]; then
+  printf '%s\n' "${FAKE_LIVE_GIT_SHA:?}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "-C" && "${3:-}" == "symbolic-ref" && "${4:-}" == "--quiet" && "${5:-}" == "--short" && "${6:-}" == "HEAD" ]]; then
+  printf '%s\n' "${FAKE_LIVE_GIT_REF:-main}"
+  exit 0
+fi
+
+printf 'unsupported fake git invocation: %s\n' "$*" >&2
+exit 1
+EOF
+
+    chmod +x "$fake_bin/docker" "$fake_bin/curl" "$fake_bin/git"
+    printf '%s\n' "$fake_bin"
+}
+
+create_workspace_fixture() {
+    local workspace_root="$1"
+
+    mkdir -p "$workspace_root/data" "$workspace_root/skills" "$workspace_root/config"
+    git -C "$workspace_root" init -q
+    git -C "$workspace_root" config user.name "Codex Test"
+    git -C "$workspace_root" config user.email "codex@example.com"
+    printf 'runtime\n' >"$workspace_root/runtime.txt"
+    cat >"$workspace_root/config/moltis.toml" <<'EOF'
+[memory]
+provider = "ollama"
+base_url = "http://ollama:11434"
+model = "nomic-embed-text"
+EOF
+    git -C "$workspace_root" add runtime.txt
+    git -C "$workspace_root" add config/moltis.toml
+    git -C "$workspace_root" commit -q -m "fixture"
+}
+
+run_component_moltis_runtime_attestation_tests() {
+    start_timer
+
+    local fixture_root fake_bin workspace_root workspace_root_canonical active_root runtime_config_dir runtime_config_dir_canonical runtime_home_dir mounts_file output_json live_sha
+    fixture_root="$(secure_temp_dir moltis-runtime-attestation)"
+    fake_bin="$(create_fake_runtime_bin "$fixture_root")"
+    workspace_root="$fixture_root/deploy-root"
+    active_root="$fixture_root/moltis-active"
+    runtime_config_dir="$fixture_root/runtime-config"
+    runtime_home_dir="$fixture_root/runtime-home"
+    mounts_file="$fixture_root/mounts.json"
+    output_json="$fixture_root/output.json"
+
+    mkdir -p "$runtime_config_dir" "$runtime_home_dir"
+    create_workspace_fixture "$workspace_root"
+    workspace_root_canonical="$(cd "$workspace_root" && pwd -P)"
+    runtime_config_dir_canonical="$(cd "$runtime_config_dir" && pwd -P)"
+    live_sha="$(git -C "$workspace_root" rev-parse HEAD)"
+    cp "$workspace_root/config/moltis.toml" "$runtime_config_dir/moltis.toml"
+
+    cat >"$workspace_root/.env" <<EOF
+MOLTIS_RUNTIME_CONFIG_DIR=$runtime_config_dir
+EOF
+    printf '%s\n' "$live_sha" >"$workspace_root/data/.deployed-sha"
+    cat >"$workspace_root/data/.deployment-info" <<EOF
+deployed_at=2026-03-22T00:00:00Z
+git_sha=$live_sha
+git_ref=main
+workflow_run=12345
+version=0.10.18
+deploy_path=$workspace_root
+runtime_config_dir=$runtime_config_dir
+EOF
+
+    ln -s "$workspace_root" "$active_root"
+
+    cat >"$mounts_file" <<EOF
+[
+  {
+    "Mounts": [
+      {"Destination": "/server", "Source": "$workspace_root", "RW": false},
+      {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
+      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true}
+    ]
+  }
+]
+EOF
+
+    test_start "component_runtime_attestation_succeeds_for_live_provenance_contract"
+    if ! PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" \
+            --expected-auth-provider "openai-codex" >"$output_json" 2>"$fixture_root/stderr.log"; then
+        test_fail "Runtime attestation should pass for matching live provenance"
+        rm -rf "$fixture_root"
+        return
+    fi
+
+    if [[ "$(jq -r '.status' "$output_json")" != "success" ]] || \
+       [[ "$(jq -r '.details.active_target' "$output_json")" != "$workspace_root_canonical" ]] || \
+       [[ "$(jq -r '.details.workspace_source' "$output_json")" != "$workspace_root_canonical" ]] || \
+       [[ "$(jq -r '.details.recorded_git_sha' "$output_json")" != "$live_sha" ]] || \
+       [[ "$(jq -r '.details.live_version' "$output_json")" != "0.10.18" ]] || \
+       [[ "$(jq -r '.details.runtime_config_source' "$output_json")" != "$runtime_config_dir_canonical" ]] || \
+       [[ "$(jq -r '.details.runtime_config_rw' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.tracked_runtime_toml' "$output_json")" != "$workspace_root_canonical/config/moltis.toml" ]] || \
+       [[ "$(jq -r '.details.runtime_runtime_toml' "$output_json")" != "$runtime_config_dir_canonical/moltis.toml" ]] || \
+       [[ "$(jq -r '.details.expected_auth_provider' "$output_json")" != "openai-codex" ]] || \
+       [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]]; then
+        test_fail "Runtime attestation success output does not reflect the expected provenance details"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    printf '[memory]\nprovider = "openai"\n' >"$runtime_config_dir/moltis.toml"
+
+    test_start "component_runtime_attestation_fails_when_runtime_config_drifted_from_tracked_contract"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" >"$output_json" 2>"$fixture_root/stderr-runtime-config.log"
+    exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "RUNTIME_CONFIG_FILE_MISMATCH")' "$output_json" >/dev/null 2>&1; then
+        test_fail "Runtime attestation should fail when runtime moltis.toml drifts from the tracked config contract"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    cp "$workspace_root/config/moltis.toml" "$runtime_config_dir/moltis.toml"
+
+    cat >"$mounts_file" <<EOF
+[
+  {
+    "Mounts": [
+      {"Destination": "/server", "Source": "$fixture_root/untracked-root", "RW": false},
+      {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
+      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true}
+    ]
+  }
+]
+EOF
+    mkdir -p "$fixture_root/untracked-root"
+
+    test_start "component_runtime_attestation_fails_when_workspace_mount_drifts_from_active_root"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" >"$output_json" 2>"$fixture_root/stderr-fail.log"
+    local exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "WORKSPACE_PROVENANCE_MISMATCH")' "$output_json" >/dev/null 2>&1; then
+        test_fail "Runtime attestation should fail when the live /server mount source drifts from the active deploy root"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    cat >"$mounts_file" <<EOF
+[
+  {
+    "Mounts": [
+      {"Destination": "/server", "Source": "$workspace_root", "RW": false},
+      {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
+      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true}
+    ]
+  }
+]
+EOF
+
+    test_start "component_runtime_attestation_fails_when_expected_auth_provider_is_invalid"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        FAKE_AUTH_STATUS="other-provider [valid (10m remaining)]" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" \
+            --expected-auth-provider "openai-codex" >"$output_json" 2>"$fixture_root/stderr-auth.log"
+    exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "AUTH_PROVIDER_INVALID")' "$output_json" >/dev/null 2>&1; then
+        test_fail "Runtime attestation should fail when the expected auth provider is not valid in live auth status"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    rm -rf "$fixture_root"
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    run_component_moltis_runtime_attestation_tests
+fi

--- a/tests/component/test_moltis_search_memory_diagnostics.sh
+++ b/tests/component/test_moltis_search_memory_diagnostics.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+DIAGNOSTIC_SCRIPT="$PROJECT_ROOT/scripts/moltis-search-memory-diagnostics.sh"
+REAL_CONFIG="$PROJECT_ROOT/config/moltis.toml"
+
+run_component_moltis_search_memory_diagnostics_tests() {
+    start_timer
+
+    local tmp_dir config_file log_file output_json
+    tmp_dir="$(mktemp -d /tmp/moltis-search-memory-diagnostics.XXXXXX)"
+    config_file="$tmp_dir/moltis.toml"
+    log_file="$tmp_dir/logs.jsonl"
+    output_json="$tmp_dir/report.json"
+
+    cat > "$config_file" <<'EOF'
+[tools.web.search]
+enabled = false
+
+[mcp.servers.tavily]
+transport = "sse"
+url = "https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}"
+
+[memory]
+llm_reranking = false
+session_export = false
+EOF
+
+    cat > "$log_file" <<'EOF'
+{"message":"MCP SSE initialize handshake failed"}
+{"message":"MCP auto-restart failed"}
+{"tool":"mcp__tavily__tavily_search","message":"tool invocation"}
+{"tool":"memory_search","message":"tool execution failed"}
+all embedding providers failed: openai: HTTP status client error (400 Bad Request) for url (https://api.z.ai/api/coding/paas/v4/embeddings); groq: HTTP status client error (401 Unauthorized) for url (https://api.groq.com/openai/v1/embeddings)
+EOF
+
+    test_start "component_diagnostics_script_parses_tavily_and_embedding_failure_taxonomy"
+    if ! bash "$DIAGNOSTIC_SCRIPT" --config "$config_file" --log-file "$log_file" >"$output_json" 2>"$tmp_dir/stderr.log"; then
+        test_fail "Diagnostic script failed on fixture config/log input"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    if [[ "$(jq -r '.tracked.search.builtin_enabled' "$output_json")" != "false" ]] || \
+       [[ "$(jq -r '.tracked.search.tavily_transport' "$output_json")" != "sse" ]] || \
+       [[ "$(jq -r '.tracked.memory.provider_pinned' "$output_json")" != "false" ]] || \
+       [[ "$(jq -r '.runtime_log_signals.tavily.mcp_sse_handshake_failures' "$output_json")" != "1" ]] || \
+       [[ "$(jq -r '.runtime_log_signals.tavily.mcp_auto_restart_failures' "$output_json")" != "1" ]] || \
+       [[ "$(jq -r '.runtime_log_signals.memory.openai_embeddings_400' "$output_json")" != "1" ]] || \
+       [[ "$(jq -r '.runtime_log_signals.memory.groq_embeddings_401' "$output_json")" != "1" ]] || \
+       [[ "$(jq -r '.risk_summary.tavily_transport_unstable' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.risk_summary.memory_provider_autodetect' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.risk_summary.memory_embedding_provider_failures_present' "$output_json")" != "true" ]]; then
+        test_fail "Diagnostic JSON did not capture the expected Tavily/embedding failure taxonomy"
+        rm -rf "$tmp_dir"
+        return
+    fi
+    test_pass
+
+    test_start "component_diagnostics_script_handles_real_tracked_config_without_log_input"
+    if ! bash "$DIAGNOSTIC_SCRIPT" --config "$REAL_CONFIG" >"$output_json" 2>"$tmp_dir/stderr-real.log"; then
+        test_fail "Diagnostic script failed on the real tracked Moltis config"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    if [[ "$(jq -r '.tracked.search.tavily_mcp_enabled' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.tracked.search.tavily_transport' "$output_json")" != "sse" ]] || \
+       [[ "$(jq -r '.tracked.memory.provider_pinned' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.tracked.memory.provider' "$output_json")" != "ollama" ]] || \
+       [[ "$(jq -r '.tracked.memory.model' "$output_json")" != "nomic-embed-text" ]] || \
+       [[ "$(jq -r '.tracked.memory.watch_dirs_configured' "$output_json")" != "true" ]]; then
+        test_fail "Real tracked config summary no longer reflects the expected pinned Tavily + memory provider contract"
+        rm -rf "$tmp_dir"
+        return
+    fi
+    test_pass
+
+    rm -rf "$tmp_dir"
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    run_component_moltis_search_memory_diagnostics_tests
+fi

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -31,6 +31,7 @@ HOST_AUTOMATION_SCRIPT="$PROJECT_ROOT/scripts/apply-moltis-host-automation.sh"
 MOLTIS_ENV_RENDER_SCRIPT="$PROJECT_ROOT/scripts/render-moltis-env.sh"
 TRACKED_DEPLOY_SCRIPT="$PROJECT_ROOT/scripts/run-tracked-moltis-deploy.sh"
 SSH_TRACKED_DEPLOY_SCRIPT="$PROJECT_ROOT/scripts/ssh-run-tracked-moltis-deploy.sh"
+RUNTIME_ATTESTATION_SCRIPT="$PROJECT_ROOT/scripts/moltis-runtime-attestation.sh"
 CHECKOUT_ALIGN_SCRIPT="$PROJECT_ROOT/scripts/align-server-checkout.sh"
 SYNC_SURFACE_SCRIPT="$PROJECT_ROOT/scripts/gitops-sync-managed-surface.sh"
 
@@ -202,6 +203,24 @@ PY
         test_fail "Primary Moltis config must use container-visible /server paths for codex-update skill code and ~/.moltis paths for writable state"
     fi
 
+    test_start "static_config_pins_memory_provider_and_repo_watch_dirs"
+    if rg -Fq 'provider = "ollama"' "$TOML_CONFIG" && \
+       rg -Fq 'base_url = "http://ollama:11434"' "$TOML_CONFIG" && \
+       rg -Fq 'model = "nomic-embed-text"' "$TOML_CONFIG" && \
+       rg -Fq '"~/.moltis/memory"' "$TOML_CONFIG" && \
+       rg -Fq '"/server/knowledge"' "$TOML_CONFIG"; then
+        test_pass
+    else
+        test_fail "Primary Moltis config must pin the memory embeddings backend, use the root Ollama endpoint for model probes, and keep repo-visible watch_dirs instead of relying on auto-detect"
+    fi
+
+    test_start "static_moltis_compose_forwards_ollama_cloud_key_to_runtime"
+    if rg -Fq 'OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}' "$COMPOSE_PROD"; then
+        test_pass
+    else
+        test_fail "Production Moltis container must receive OLLAMA_API_KEY so cloud-backed Ollama chat models can appear in the runtime provider catalog"
+    fi
+
     test_start "static_codex_cli_update_delivery_script_is_executable"
     if [[ -x "$PROJECT_ROOT/scripts/codex-cli-update-delivery.sh" ]]; then
         test_pass
@@ -340,10 +359,11 @@ PY
     test_start "static_deploy_script_scopes_moltis_rollout_to_core_and_sidecars"
     if [[ -f "$DEPLOY_SCRIPT" ]] && \
        rg -Fq 'TARGET_AUXILIARY_SERVICES=("watchtower" "ollama")' "$DEPLOY_SCRIPT" && \
-       rg -Fq 'compose_cmd normal up -d --remove-orphans "${deploy_services[@]}"' "$DEPLOY_SCRIPT"; then
+       rg -Fq 'deploy_args+=(--force-recreate)' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'compose_cmd normal "${deploy_args[@]}" "${deploy_services[@]}"' "$DEPLOY_SCRIPT"; then
         test_pass
     else
-        test_fail "Moltis deploy path must target only moltis + required sidecars so unrelated monitoring services cannot block tracked upgrades"
+        test_fail "Moltis deploy path must target only moltis + required sidecars and force-recreate the runtime so config changes take effect immediately"
     fi
 
     test_start "static_deploy_workflow_uses_shared_host_automation_entrypoint"
@@ -501,6 +521,29 @@ PY
         test_pass
     else
         test_fail "UAT gate must derive the Moltis version from git and deploy only through the shared tracked deploy entrypoint backed by deploy.sh"
+    fi
+
+    test_start "static_tracked_deploy_attests_live_runtime_provenance"
+    if [[ -f "$TRACKED_DEPLOY_SCRIPT" ]] && \
+       [[ -f "$RUNTIME_ATTESTATION_SCRIPT" ]] && \
+       rg -Fq 'moltis-runtime-attestation.sh' "$TRACKED_DEPLOY_SCRIPT" && \
+       rg -Fq '"attest-live-runtime"' "$TRACKED_DEPLOY_SCRIPT" && \
+       rg -Fq 'runtime_attestation' "$TRACKED_DEPLOY_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Tracked deploy control-plane must attest live runtime provenance through the shared runtime attestation script"
+    fi
+
+    test_start "static_runtime_contract_enforces_tracked_runtime_config_parity"
+    if [[ -f "$DEPLOY_SCRIPT" ]] && \
+       [[ -f "$RUNTIME_ATTESTATION_SCRIPT" ]] && \
+       rg -Fq 'cmp -s "$tracked_runtime_toml" "$runtime_runtime_toml"' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'runtime moltis.toml diverges from tracked config/moltis.toml' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'cmp -s "$TRACKED_RUNTIME_TOML" "$RUNTIME_RUNTIME_TOML"' "$RUNTIME_ATTESTATION_SCRIPT" && \
+       rg -Fq 'RUNTIME_CONFIG_FILE_MISMATCH' "$RUNTIME_ATTESTATION_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Deploy verification and runtime attestation must fail closed when live runtime moltis.toml drifts from tracked config/moltis.toml"
     fi
 
     test_start "static_production_workflows_share_remote_lock_group"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -233,6 +233,44 @@ test_tracked_deploy_workflows_use_shared_script_entrypoint() {
     test_pass
 }
 
+test_deploy_script_verifies_live_moltis_runtime_contract() {
+    test_start "Deploy verification should enforce the live Moltis runtime contract"
+
+    if [[ ! -f "$PROJECT_ROOT/scripts/deploy.sh" ]]; then
+        test_skip "Missing deploy script"
+        return
+    fi
+
+    if ! grep -Fq "working_dir is" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "/server mount is missing" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "/server/skills" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "MOLTIS_RUNTIME_CONFIG_DIR" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "provider_keys.json.tmp.contract-check" "$PROJECT_ROOT/scripts/deploy.sh"; then
+        test_fail "deploy.sh must verify /server visibility, runtime config mount source, and writable runtime config behavior for Moltis"
+        return
+    fi
+
+    test_pass
+}
+
+test_deploy_script_force_recreates_moltis_runtime_on_rollout() {
+    test_start "Deploy rollout should force-recreate Moltis so runtime config changes are applied"
+
+    if [[ ! -f "$PROJECT_ROOT/scripts/deploy.sh" ]]; then
+        test_skip "Missing deploy script"
+        return
+    fi
+
+    if ! grep -Fq 'deploy_args+=(--force-recreate)' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'compose_cmd normal "${deploy_args[@]}" "${deploy_services[@]}"' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'bind-mounted config' "$PROJECT_ROOT/scripts/deploy.sh"; then
+        test_fail "deploy.sh must force-recreate Moltis during deploy so updated runtime config is not left pending until a manual restart"
+        return
+    fi
+
+    test_pass
+}
+
 test_tracked_deploy_workflows_pass_remote_args_without_inline_shell_string() {
     test_start "Tracked deploy workflows should pass remote args safely without inline command strings"
 
@@ -696,10 +734,11 @@ test_tracked_deploy_script_dry_run_reports_control_plane_steps() {
     mkdir -p "$project_root/config" "$project_root/scripts"
     printf 'services: {}\n' > "$project_root/docker-compose.prod.yml"
     printf 'name = "moltis"\n' > "$project_root/config/moltis.toml"
-    printf 'MOLTIS_RUNTIME_CONFIG_DIR=/srv/runtime-config\n' > "$project_root/.env"
+    printf 'MOLTIS_RUNTIME_CONFIG_DIR=/opt/moltinger-state/config-runtime\n' > "$project_root/.env"
     : > "$project_root/scripts/prepare-moltis-runtime-config.sh"
     : > "$project_root/scripts/moltis-version.sh"
     : > "$project_root/scripts/deploy.sh"
+    : > "$project_root/scripts/moltis-runtime-attestation.sh"
 
     if ! bash "$TRACKED_DEPLOY_SCRIPT" \
         --dry-run \
@@ -717,7 +756,8 @@ test_tracked_deploy_script_dry_run_reports_control_plane_steps() {
     if ! grep -Fq '"status": "dry-run"' "$output_file" || \
        ! grep -Fq '"prepare-runtime-config"' "$output_file" || \
        ! grep -Fq '"align-server-checkout"' "$output_file" || \
-       ! grep -Fq '"/srv/runtime-config"' "$output_file"; then
+       ! grep -Fq '"attest-live-runtime"' "$output_file" || \
+       ! grep -Fq '"/opt/moltinger-state/config-runtime"' "$output_file"; then
         test_fail "Tracked deploy dry-run output should describe the shared control-plane contract"
         rm -rf "$tmp_dir"
         return
@@ -743,10 +783,11 @@ test_tracked_deploy_script_dry_run_emits_required_workflow_contract_fields() {
     mkdir -p "$project_root/config" "$project_root/scripts"
     printf 'services: {}\n' > "$project_root/docker-compose.prod.yml"
     printf 'name = "moltis"\n' > "$project_root/config/moltis.toml"
-    printf 'MOLTIS_RUNTIME_CONFIG_DIR=/srv/runtime-config\n' > "$project_root/.env"
+    printf 'MOLTIS_RUNTIME_CONFIG_DIR=/opt/moltinger-state/config-runtime\n' > "$project_root/.env"
     : > "$project_root/scripts/prepare-moltis-runtime-config.sh"
     : > "$project_root/scripts/moltis-version.sh"
     : > "$project_root/scripts/deploy.sh"
+    : > "$project_root/scripts/moltis-runtime-attestation.sh"
 
     if ! bash "$TRACKED_DEPLOY_SCRIPT" \
         --dry-run \
@@ -766,7 +807,7 @@ test_tracked_deploy_script_dry_run_emits_required_workflow_contract_fields() {
        [[ "$(jq -r '.details.git_ref' "$output_json")" != "main" ]] || \
        [[ "$(jq -r '.details.workflow_run' "$output_json")" != "123456" ]] || \
        [[ "$(jq -r '.details.tracked_version' "$output_json")" != "1.2.3" ]] || \
-       [[ "$(jq -r '.details.runtime_config_dir' "$output_json")" != "/srv/runtime-config" ]]; then
+       [[ "$(jq -r '.details.runtime_config_dir' "$output_json")" != "/opt/moltinger-state/config-runtime" ]]; then
         test_fail "Tracked deploy dry-run JSON must preserve the workflow ABI fields consumed by GitHub Actions"
         rm -rf "$tmp_dir"
         return
@@ -795,7 +836,8 @@ test_tracked_deploy_script_failure_json_keeps_health_and_rollback_fields() {
     : > "$deploy_dir/scripts/prepare-moltis-runtime-config.sh"
     : > "$deploy_dir/scripts/moltis-version.sh"
     : > "$deploy_dir/scripts/deploy.sh"
-    chmod +x "$deploy_dir/scripts/prepare-moltis-runtime-config.sh" "$deploy_dir/scripts/moltis-version.sh" "$deploy_dir/scripts/deploy.sh"
+    : > "$deploy_dir/scripts/moltis-runtime-attestation.sh"
+    chmod +x "$deploy_dir/scripts/prepare-moltis-runtime-config.sh" "$deploy_dir/scripts/moltis-version.sh" "$deploy_dir/scripts/deploy.sh" "$deploy_dir/scripts/moltis-runtime-attestation.sh"
 
     if bash "$TRACKED_DEPLOY_SCRIPT" \
         --json \
@@ -903,11 +945,12 @@ EOF
 #!/bin/bash
 exit 0
 EOF
-    chmod +x "$scripts_dir/prepare-moltis-runtime-config.sh" "$scripts_dir/moltis-version.sh" "$scripts_dir/deploy.sh"
+    : > "$scripts_dir/moltis-runtime-attestation.sh"
+    chmod +x "$scripts_dir/prepare-moltis-runtime-config.sh" "$scripts_dir/moltis-version.sh" "$scripts_dir/deploy.sh" "$scripts_dir/moltis-runtime-attestation.sh"
     printf 'services: {}\n' > "$deploy_dir/docker-compose.prod.yml"
     printf '[server]\nport = 13131\n' > "$config_dir/moltis.toml"
 
-    if ! output_json="$(bash "$TRACKED_DEPLOY_SCRIPT" \
+    if ! output_json="$(MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_dir" bash "$TRACKED_DEPLOY_SCRIPT" \
         --deploy-path "$deploy_dir" \
         --git-sha "deadbeef" \
         --git-ref "feature/unsafe'quote" \
@@ -1045,6 +1088,8 @@ run_all_tests() {
     test_gitops_sync_workflows_use_shared_script_entrypoint
     test_moltis_env_workflows_use_shared_render_script
     test_tracked_deploy_workflows_use_shared_script_entrypoint
+    test_deploy_script_verifies_live_moltis_runtime_contract
+    test_deploy_script_force_recreates_moltis_runtime_on_rollout
     test_tracked_deploy_workflows_pass_remote_args_without_inline_shell_string
     test_ssh_tracked_deploy_wrapper_dry_run_quotes_unsafe_refs
     test_checkout_align_script_dry_run_uses_constant_remote_command


### PR DESCRIPTION
## Summary
- carry the minimal runtime-only Moltis fix path from `031-moltis-reliability-diagnostics` into `main`
- pin the tracked memory contract to Ollama embeddings with repo-visible watch dirs
- forward `OLLAMA_API_KEY` to the `moltis` container and enforce tracked runtime-config parity with deploy/runtime attestation
- include only the blocking verification lanes needed for the canonical deploy path

## Validation
- `bash tests/unit/test_deploy_workflow_guards.sh`
- `bash tests/component/test_moltis_runtime_attestation.sh`
- `bash tests/component/test_moltis_search_memory_diagnostics.sh`
- `bash tests/static/test_config_validation.sh`

## Context
This is PR1 from the split incident strategy: `PR1 -> merge to main -> canonical deploy from main -> live verification -> PR2 docs/RCA/runbook/spec follow-up`.
