### PR TITLE
fix(tests): model runtime-only beads fixture correctly

### DIFF
--- a/tests/unit/test_beads_worktree_audit.sh
+++ b/tests/unit/test_beads_worktree_audit.sh
@@ -73,7 +73,8 @@ EOF
 seed_post_migration_runtime_foundation() {
     local worktree_dir="$1"
 
-    mkdir -p "${worktree_dir}/.beads/beads.db"
+    mkdir -p "${worktree_dir}/.beads"
+    : > "${worktree_dir}/.beads/beads.db"
     cat > "${worktree_dir}/.beads/config.yaml" <<'EOF'
 issue-prefix: "demo"
 auto-start-daemon: false


### PR DESCRIPTION
## Summary
- fix the Beads audit test fixture for `post_migration_runtime_only`
- create a real local runtime artifact at `.beads/beads.db` instead of an empty directory shell
- unblock PR gates that were failing independently of the Moltis runtime carrier

## Validation
- `bash tests/unit/test_beads_worktree_audit.sh`
- `bash tests/unit/test_bd_dispatch.sh`
- `bash tests/static/test_beads_worktree_ownership.sh`

## Context
This is a prerequisite CI-baseline fix. PR #99 is currently blocked by this unrelated failing case in the shared `pr` lane.
