### PR TITLE
fix(beads): bootstrap fresh worktree runtimes without moving HEAD

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-03-24
-**Total Lessons**: 49
+**Generated**: 2026-03-26
+**Total Lessons**: 50
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (19 lessons)
+#### P1 (20 lessons)
+- [Beads worktree localization used stale bootstrap contracts and recreated the failure during Phase A](../docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md)
 - [Half-initialized Beads Dolt runtime was misclassified as a healthy local worktree state](../docs/rca/2026-03-24-beads-half-initialized-dolt-runtime-misclassified-as-healthy.md)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
 - [Tracked Moltis deploy failed because backup restore-check logs polluted deploy.sh JSON stdout contract](../docs/rca/2026-03-20-tracked-deploy-json-contract-broken-by-restore-check-stdout.md)
@@ -105,7 +106,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (15 lessons)
+#### process (16 lessons)
+- [Beads worktree localization used stale bootstrap contracts and recreated the failure during Phase A](../docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md)
 - [Half-initialized Beads Dolt runtime was misclassified as a healthy local worktree state](../docs/rca/2026-03-24-beads-half-initialized-dolt-runtime-misclassified-as-healthy.md)
 - [Telegram webhook monitor default expected webhook while production stayed in polling mode](../docs/rca/2026-03-20-telegram-webhook-monitor-webhook-requirement-drift.md)
 - [Telegram monitor generated unsolicited user-facing traffic by default](../docs/rca/2026-03-20-telegram-monitor-default-noise-via-cron-and-probe-fallback.md)
@@ -140,12 +142,12 @@
 - `github-actions` (13 lessons)
 - `deploy` (13 lessons)
 - `cicd` (11 lessons)
+- `rca` (9 lessons)
 - `process` (9 lessons)
 - `moltis` (9 lessons)
 - `lessons` (9 lessons)
-- `rca` (8 lessons)
 - `clawdiy` (8 lessons)
-- `openclaw` (6 lessons)
+- `git-worktree` (7 lessons)
 
 
 ---
@@ -154,10 +156,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 49 |
-| Critical (P0/P1) | 20 |
+| Total Lessons | 50 |
+| Critical (P0/P1) | 21 |
 | Categories | 5 |
-| Unique Tags | 113 |
+| Unique Tags | 114 |
 
 ---
 

--- a/docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md
+++ b/docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md
@@ -1,0 +1,86 @@
+---
+title: "Beads worktree localization used stale bootstrap contracts and recreated the failure during Phase A"
+date: 2026-03-26
+severity: P1
+category: process
+tags: [beads, dolt, git-worktree, bootstrap, phase-a, rca]
+root_cause: "The localization helper still relied on outdated Beads CLI assumptions: `bd --db ... info` was treated as a runtime-materialization probe even though it now creates a half-initialized Dolt shell with no named `beads` DB, and the first repair attempt (`bd init --from-jsonl`) was too heavy for Phase A because it moves HEAD by committing tracked files."
+---
+
+# RCA: Beads worktree localization used stale bootstrap contracts and recreated the failure during Phase A
+
+Date: 2026-03-26  
+Context: follow-up `moltinger-fng` after `032-post-close-task-classifier` was created from `main` but could not use local Beads state
+
+## Error
+
+Fresh worktrees created through `scripts/worktree-phase-a.sh create-from-base` could immediately fail with:
+
+```text
+database "beads" not found on Dolt server
+```
+
+The broken worktree ended up with `.beads/dolt/.dolt` but without `.beads/dolt/beads/.dolt` and without a healthy named `beads` database. A first repair attempt using `bd init --from-jsonl` proved that the runtime could be rebuilt, but it also committed tracked files and moved `HEAD`, which is incompatible with Phase A's base-anchored contract.
+
+## Lessons Pre-Check
+
+Before this RCA, the lessons index already contained the related incident [Half-initialized Beads Dolt runtime was misclassified as a healthy local worktree state](./2026-03-24-beads-half-initialized-dolt-runtime-misclassified-as-healthy.md). That RCA covered how helpers should classify an **existing** broken `.beads/dolt/` shell.
+
+What it did **not** yet cover:
+
+1. the localization helper itself still used an outdated CLI bootstrap probe that could **create** the broken shell during `partial_foundation` repair;
+2. a seemingly correct repair path (`bd init --from-jsonl`) was incompatible with `worktree-phase-a` because it mutated git history inside the fresh worktree.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Why did fresh Phase A worktrees fail on `database "beads" not found`? | Because localization created `.beads/dolt/.dolt` but never materialized the named `beads` DB inside that runtime. |
+| 2 | Why did localization create only the shell? | Because `scripts/beads-worktree-localize.sh` still treated `system bd --db <path> info` as a safe materialization probe. |
+| 3 | Why was that probe wrong? | Because newer Beads CLI behavior no longer treats `info` as a lightweight bootstrap; it can create a Dolt shell and then fail closed if the named DB does not exist. |
+| 4 | Why didn't the first repair attempt become the final fix? | Because `bd init --from-jsonl` rebuilt the runtime but also committed tracked files, which changed the fresh worktree `HEAD` and broke the Phase A invariant. |
+| 5 | Why did both wrong paths remain in the repo? | Because repo-local helper logic had not been revalidated against the current official Beads CLI contract, and regression coverage checked only helper-local artifacts, not the full `worktree-phase-a -> localize -> live bd status` flow. |
+
+## Root Cause
+
+Repo-local localization logic depended on stale Beads CLI contracts. The old `bd info` bootstrap probe was no longer a safe way to materialize a local runtime, and the first replacement (`bd init --from-jsonl`) was not compatible with Phase A because it mutates git history. The correct non-committing path for this repository is: quarantine any stale incomplete shell, run `bd bootstrap` to materialize the named runtime, then run `bd --db .beads/beads.db import .beads/issues.jsonl`.
+
+## Fixes Applied
+
+1. Updated `scripts/beads-worktree-localize.sh` to quarantine incomplete `.beads/dolt` shells under `.beads/recovery/` before repair.
+2. Replaced the stale materialization probe with the non-committing official path:
+   - `bd bootstrap`
+   - `bd --db .beads/beads.db import .beads/issues.jsonl`
+3. Updated the legacy `scripts/beads-resolve-db.sh localize` path to use the same non-committing bootstrap/import flow.
+4. Added a regression test covering stale-shell repair before re-init in `tests/unit/test_bd_dispatch.sh`.
+5. Updated `tests/unit/test_worktree_phase_a.sh` so Phase A proves both invariants:
+   - healthy named local runtime is created;
+   - `HEAD` still matches the requested base SHA.
+6. Re-ran a live disposable repro against the real system `bd` binary and confirmed:
+   - `worktree-phase-a` exits `0`;
+   - the new worktree contains `.beads/dolt/beads/.dolt`;
+   - `bd info` points to the worktree-local `.beads/dolt`;
+   - `bd status` no longer fails on `database "beads" not found`.
+
+## Prevention
+
+1. Do not use `bd --db ... info` as a bootstrap/materialization probe for worktree localization.
+2. Do not use `bd init --from-jsonl` inside Phase A or other base-anchored worktree create flows unless git mutation is explicitly allowed.
+3. For `partial_foundation` worktrees, use the official non-committing sequence:
+   - `bd bootstrap`
+   - `bd --db .beads/beads.db import .beads/issues.jsonl`
+4. Any Beads bootstrap change must be validated against a real disposable `worktree-phase-a` repro, not only fake-bin unit tests.
+
+## Related Updates
+
+- [x] Helper fixed in [scripts/beads-worktree-localize.sh](/Users/rl/coding/moltinger/moltinger-main-032-post-close-task-classifier/scripts/beads-worktree-localize.sh)
+- [x] Legacy localize path aligned in [scripts/beads-resolve-db.sh](/Users/rl/coding/moltinger/moltinger-main-032-post-close-task-classifier/scripts/beads-resolve-db.sh)
+- [x] Phase A regression updated in [tests/unit/test_worktree_phase_a.sh](/Users/rl/coding/moltinger/moltinger-main-032-post-close-task-classifier/tests/unit/test_worktree_phase_a.sh)
+- [x] Localization regressions updated in [tests/unit/test_bd_dispatch.sh](/Users/rl/coding/moltinger/moltinger-main-032-post-close-task-classifier/tests/unit/test_bd_dispatch.sh) and [tests/unit/test_beads_worktree_audit.sh](/Users/rl/coding/moltinger/moltinger-main-032-post-close-task-classifier/tests/unit/test_beads_worktree_audit.sh)
+- [x] Guard check updated in [tests/static/test_beads_worktree_ownership.sh](/Users/rl/coding/moltinger/moltinger-main-032-post-close-task-classifier/tests/static/test_beads_worktree_ownership.sh)
+
+## Уроки
+
+- **Worktree bootstrap нельзя валидировать только fake-bin тестами** — нужен хотя бы один disposable repro на реальном CLI.
+- **Официальный CLI path должен проверяться не только на “чинит”, но и на побочные эффекты** — `bd init --from-jsonl` восстановил runtime, но оказался несовместим с Phase A из-за git commit.
+- **Broken runtime shell нужно не только распознавать, но и не создавать заново** — helper, который лечит `partial_foundation`, сам не должен превращать его в `database "beads" not found`.

--- a/docs/rules/beads-worktree-localize-must-bootstrap-and-import-without-moving-head.md
+++ b/docs/rules/beads-worktree-localize-must-bootstrap-and-import-without-moving-head.md
@@ -1,0 +1,24 @@
+# Beads Worktree Localization Must Bootstrap And Import Without Moving HEAD
+
+## Rule
+
+When repo-local helpers materialize Beads state for a dedicated worktree in `partial_foundation` or legacy-localize mode:
+
+1. Do not use `bd --db ... info` as a bootstrap/materialization probe.
+2. Do not use `bd init --from-jsonl` inside Phase A or other base-anchored create flows.
+3. If a stale incomplete `.beads/dolt/` shell exists, quarantine it under `.beads/recovery/` first.
+4. Use the non-committing official path instead:
+   - `bd bootstrap`
+   - `bd --db .beads/beads.db import .beads/issues.jsonl`
+
+## Why
+
+- `bd --db ... info` can create a half-initialized Dolt shell without the named `beads` database.
+- `bd init --from-jsonl` can commit tracked files and move `HEAD`, which violates Phase A's deterministic base-anchored contract.
+- `bd bootstrap` plus explicit `import` materializes the named runtime and loads tracked issue state without changing git history.
+
+## Required Guardrails
+
+1. `tests/unit/test_worktree_phase_a.sh` must prove that `HEAD` remains equal to the requested base SHA after localization.
+2. `tests/unit/test_bd_dispatch.sh` must cover stale-shell repair before re-materialization.
+3. `tests/static/test_beads_worktree_ownership.sh` must ensure the helper still uses the bootstrap+import path and not the stale probe.

--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -733,11 +733,19 @@ beads_localize_worktree() {
   local current_config=""
   local current_issues=""
   local system_bd=""
-  local tmp_db=""
-  local backup_dir=""
   local timestamp=""
-  local backup_path=""
+  local recovery_dir=""
+  local recovery_path=""
+  local artifact=""
   local has_local_runtime="false"
+  local -a stale_runtime_artifacts=(
+    "metadata.json"
+    "interactions.jsonl"
+    "dolt-server.lock"
+    "dolt-server.log"
+    "dolt-server.pid"
+    "dolt-server.port"
+  )
 
   BEADS_LOCALIZE_FORMAT="${output_format}"
 
@@ -798,40 +806,42 @@ beads_localize_worktree() {
   fi
 
   timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-  tmp_db="${repo_root}/.beads/beads.db.tmp.$$"
-  backup_dir="${repo_root}/.beads/backups"
-  backup_path=""
+  recovery_dir="${repo_root}/.beads/recovery"
 
-  cleanup_tmp_db() {
-    rm -f "${tmp_db}"
-  }
-  trap cleanup_tmp_db EXIT
-
-  mkdir -p "${repo_root}/.beads"
-  if [[ -f "${current_db}" ]]; then
-    mkdir -p "${backup_dir}"
-    backup_path="${backup_dir}/beads-${timestamp}.db"
-    cp "${current_db}" "${backup_path}"
+  if [[ ! -d "${current_dolt}/beads" && ! -d "${current_dolt}/beads/.dolt" ]] && \
+     [[ -d "${current_dolt}" || -e "${repo_root}/.beads/metadata.json" || -e "${repo_root}/.beads/interactions.jsonl" ]]; then
+    recovery_path="${recovery_dir}/runtime-pre-init-${timestamp}"
+    mkdir -p "${recovery_path}"
+    if [[ -d "${current_dolt}" ]]; then
+      mv "${current_dolt}" "${recovery_path}/dolt"
+    fi
+    for artifact in "${stale_runtime_artifacts[@]}"; do
+      if [[ -e "${repo_root}/.beads/${artifact}" ]]; then
+        mv "${repo_root}/.beads/${artifact}" "${recovery_path}/${artifact}"
+      fi
+    done
   fi
 
-  rm -f "${tmp_db}"
-  "${system_bd}" --db "${tmp_db}" import -i "${current_issues}" --force --strict >/dev/null
-  mv "${tmp_db}" "${current_db}"
+  (
+    cd "${repo_root}"
+    "${system_bd}" bootstrap >/dev/null 2>&1
+    "${system_bd}" --db "${current_db}" import "${current_issues}" >/dev/null 2>&1
+  )
   rm -f "${current_redirect}"
 
   if [[ "${output_format}" == "env" ]]; then
     printf 'result=%q\n' "localized"
     printf 'repo_root=%q\n' "${repo_root}"
     printf 'db_path=%q\n' "${current_db}"
-    if [[ -n "${backup_path}" ]]; then
-      printf 'backup_path=%q\n' "${backup_path}"
+    if [[ -n "${recovery_path}" ]]; then
+      printf 'backup_path=%q\n' "${recovery_path}"
     fi
     return 0
   fi
 
-  printf 'Localized Beads state to %s\n' "${current_db}"
-  if [[ -n "${backup_path}" ]]; then
-    printf 'Backup: %s\n' "${backup_path}"
+  printf 'Localized Beads state to the named runtime behind %s\n' "${current_db}"
+  if [[ -n "${recovery_path}" ]]; then
+    printf 'Backup: %s\n' "${recovery_path}"
   fi
 }
 

--- a/scripts/beads-worktree-localize.sh
+++ b/scripts/beads-worktree-localize.sh
@@ -14,9 +14,9 @@ Usage:
 
 Description:
   Localize Beads ownership for an existing git worktree by removing legacy
-  redirect residue and materializing a worktree-local SQLite DB from the local
-  JSONL/config foundation when that is safe to do. For older worktrees that
-  still lack the plain-bd foundation, `--bootstrap-source` can import the
+  redirect residue and materializing a worktree-local Beads runtime from the
+  local JSONL/config foundation when that is safe to do. For older worktrees
+  that still lack the plain-bd foundation, `--bootstrap-source` can import the
   tracked recovery files before localization.
 EOF
 }
@@ -194,7 +194,7 @@ classify_state() {
   if [[ -f "${config_path}" && -f "${issues_path}" ]]; then
     report_state="partial_foundation"
     report_action="rebuild_local_foundation"
-    report_message="Local Beads foundation exists, but the SQLite DB must be materialized in place."
+    report_message="Local Beads foundation exists, but the named local Beads runtime must be materialized in place."
     return 0
   fi
 
@@ -232,14 +232,44 @@ bootstrap_foundation() {
 
 materialize_local_db() {
   local system_bd="${BEADS_SYSTEM_BD:-}"
+  local beads_dir="${target_path}/.beads"
+  local dolt_path="${beads_dir}/dolt"
+  local recovery_dir="${beads_dir}/recovery"
+  local recovery_path=""
+  local timestamp=""
+  local artifact=""
+  local -a stale_runtime_artifacts=(
+    "metadata.json"
+    "interactions.jsonl"
+    "dolt-server.lock"
+    "dolt-server.log"
+    "dolt-server.pid"
+    "dolt-server.port"
+  )
 
   if [[ -z "${system_bd}" ]]; then
     system_bd="$(beads_resolve_find_system_bd "${REPO_ROOT}/bin/bd")" || die "Could not locate the system bd binary"
   fi
 
+  if [[ ! -d "${dolt_path}/beads" && ! -d "${dolt_path}/beads/.dolt" ]] && \
+     [[ -d "${dolt_path}" || -e "${beads_dir}/metadata.json" || -e "${beads_dir}/interactions.jsonl" ]]; then
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    recovery_path="${recovery_dir}/runtime-pre-init-${timestamp}"
+    mkdir -p "${recovery_path}"
+    if [[ -d "${dolt_path}" ]]; then
+      mv "${dolt_path}" "${recovery_path}/dolt"
+    fi
+    for artifact in "${stale_runtime_artifacts[@]}"; do
+      if [[ -e "${beads_dir}/${artifact}" ]]; then
+        mv "${beads_dir}/${artifact}" "${recovery_path}/${artifact}"
+      fi
+    done
+  fi
+
   (
     cd "${target_path}"
-    "${system_bd}" --db "${report_db_path}" info >/dev/null
+    "${system_bd}" bootstrap >/dev/null 2>&1
+    "${system_bd}" --db "${report_db_path}" import "${beads_dir}/issues.jsonl" >/dev/null 2>&1
   )
 }
 

--- a/tests/static/test_beads_worktree_ownership.sh
+++ b/tests/static/test_beads_worktree_ownership.sh
@@ -69,6 +69,8 @@ run_static_beads_worktree_ownership_tests() {
        rg -q 'partial_foundation' "$LOCALIZE_SCRIPT" && \
        rg -q 'post_migration_runtime_only' "$LOCALIZE_SCRIPT" && \
        rg -q 'bootstrap_required' "$LOCALIZE_SCRIPT" && \
+       rg -q '"\$\{system_bd\}" bootstrap' "$LOCALIZE_SCRIPT" && \
+       rg -q '"\$\{system_bd\}" --db "\$\{report_db_path\}" import "\$\{beads_dir\}/issues\.jsonl"' "$LOCALIZE_SCRIPT" && \
        rg -q -- '--bootstrap-source' "$LOCALIZE_SCRIPT"; then
         test_pass
     else

--- a/tests/unit/test_bd_dispatch.sh
+++ b/tests/unit/test_bd_dispatch.sh
@@ -13,7 +13,7 @@ create_fake_system_bd_bin() {
     local fake_bin="${fixture_root}/system-bd-bin"
 
     mkdir -p "${fake_bin}"
-    cat > "${fake_bin}/bd" <<'EOF'
+cat > "${fake_bin}/bd" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -36,6 +36,19 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ "${args[0]:-}" == "bootstrap" ]]; then
+  mkdir -p ".beads/dolt/beads/.dolt"
+  printf 'BOOTSTRAP_DB=beads\n'
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "import" ]]; then
+  mkdir -p ".beads/dolt/beads/.dolt"
+  : > ".beads/last-touched"
+  printf 'IMPORTED=%s\n' "${args[1]:-}"
+  exit 0
+fi
 
 if [[ -n "${db_path}" ]]; then
   mkdir -p "$(dirname "${db_path}")"
@@ -160,6 +173,18 @@ canonicalize_path() {
         cd "${target_path}"
         pwd -P
     )
+}
+
+assert_named_beads_runtime_present() {
+    local worktree_path="$1"
+    local message="$2"
+
+    if [[ ! -d "${worktree_path}/.beads/dolt/beads/.dolt" ]]; then
+        test_fail "${message} (missing named beads runtime)"
+    fi
+    if [[ ! -f "${worktree_path}/.beads/last-touched" ]]; then
+        test_fail "${message} (missing import marker)"
+    fi
 }
 
 test_plain_bd_executes_against_worktree_local_db() {
@@ -557,9 +582,7 @@ test_localize_materializes_local_db_and_removes_redirect() {
     if [[ -f "${worktree_path}/.beads/redirect" ]]; then
         test_fail "Localization should remove legacy redirect metadata"
     fi
-    if [[ ! -f "${worktree_path}/.beads/beads.db" ]]; then
-        test_fail "Localization should materialize the local beads.db"
-    fi
+    assert_named_beads_runtime_present "${worktree_path}" "Localization should materialize the named local Beads runtime"
 
     rm -rf "${fixture_root}"
     test_pass
@@ -609,8 +632,34 @@ test_localize_bootstraps_missing_foundation_from_source_ref() {
     if [[ ! -f "${worktree_path}/bin/bd" || ! -f "${worktree_path}/scripts/beads-resolve-db.sh" ]]; then
         test_fail "Bootstrap localization should restore the plain bd toolchain"
     fi
-    if [[ ! -f "${worktree_path}/.beads/beads.db" ]]; then
-        test_fail "Bootstrap localization should materialize the local beads.db"
+    assert_named_beads_runtime_present "${worktree_path}" "Bootstrap localization should materialize the named local Beads runtime"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_localize_repairs_stale_dolt_shell_before_reinit() {
+    test_start "localize_repairs_stale_dolt_shell_before_reinit"
+
+    local fixture_root repo_dir worktree_path fake_bin output recovery_shell
+    fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    seed_repo_local_bd_tools "${repo_dir}"
+    worktree_path="${fixture_root}/moltinger-stale-shell-localize"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/stale-shell-localize" "main"
+    worktree_path="$(canonicalize_path "${worktree_path}")"
+    seed_local_beads_foundation "${worktree_path}"
+    mkdir -p "${worktree_path}/.beads/dolt/.dolt"
+    : > "${worktree_path}/.beads/metadata.json"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    output="$(run_localize "${worktree_path}" "${fake_bin}" --path "${worktree_path}")"
+
+    assert_contains "${output}" "State: current" "Localization should recover from a stale Dolt shell and finish current"
+    assert_named_beads_runtime_present "${worktree_path}" "Localization should rebuild the named local Beads runtime after stale-shell repair"
+    recovery_shell="$(find "${worktree_path}/.beads/recovery" -path '*/dolt/.dolt' -print -quit 2>/dev/null || true)"
+    if [[ -z "${recovery_shell}" ]]; then
+        test_fail "Localization should preserve the broken Dolt shell under .beads/recovery before re-init"
     fi
 
     rm -rf "${fixture_root}"
@@ -645,6 +694,7 @@ run_all_tests() {
     test_localize_reports_runtime_bootstrap_required_for_broken_runtime_only_state
     test_localize_materializes_local_db_and_removes_redirect
     test_localize_bootstraps_missing_foundation_from_source_ref
+    test_localize_repairs_stale_dolt_shell_before_reinit
     generate_report
 }
 

--- a/tests/unit/test_beads_worktree_audit.sh
+++ b/tests/unit/test_beads_worktree_audit.sh
@@ -26,11 +26,12 @@ create_fake_system_bd_bin() {
     local fake_bin="${fixture_root}/system-bd-bin"
 
     mkdir -p "${fake_bin}"
-    cat > "${fake_bin}/bd" <<'EOF'
+cat > "${fake_bin}/bd" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
 db_path=""
+args=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --db)
@@ -42,14 +43,30 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     *)
+      args+=("$1")
       shift
       ;;
   esac
 done
 
+if [[ "${args[0]:-}" == "bootstrap" ]]; then
+  mkdir -p ".beads/dolt/beads/.dolt"
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "import" ]]; then
+  mkdir -p ".beads/dolt/beads/.dolt"
+  : > ".beads/last-touched"
+  exit 0
+fi
+
 if [[ -n "${db_path}" ]]; then
   mkdir -p "$(dirname "${db_path}")"
-  : > "${db_path}"
+  if [[ -d "${db_path}" ]]; then
+    : > "${db_path}/.fake-db-touch"
+  else
+    : > "${db_path}"
+  fi
 fi
 EOF
     chmod +x "${fake_bin}/bd"
@@ -140,8 +157,8 @@ test_audit_apply_safe_localizes_redirected_sibling() {
     if [[ -f "${worktree_path}/.beads/redirect" ]]; then
         test_fail "Safe apply should remove redirect metadata from migratable siblings"
     fi
-    if [[ ! -f "${worktree_path}/.beads/beads.db" ]]; then
-        test_fail "Safe apply should materialize a local beads.db for migratable siblings"
+    if [[ ! -d "${worktree_path}/.beads/dolt/beads/.dolt" || ! -f "${worktree_path}/.beads/last-touched" ]]; then
+        test_fail "Safe apply should materialize a named local Beads runtime for migratable siblings"
     fi
     assert_contains "${output}" "Actions: 1" "Audit should report one localization action"
 
@@ -182,8 +199,8 @@ test_audit_apply_safe_bootstraps_damaged_sibling() {
     if [[ -f "${worktree_path}/.beads/redirect" ]]; then
         test_fail "Safe apply should remove redirect metadata from bootstrap-repair siblings"
     fi
-    if [[ ! -f "${worktree_path}/.beads/beads.db" ]]; then
-        test_fail "Safe apply should materialize a local beads.db for bootstrap-repair siblings"
+    if [[ ! -d "${worktree_path}/.beads/dolt/beads/.dolt" || ! -f "${worktree_path}/.beads/last-touched" ]]; then
+        test_fail "Safe apply should materialize a named local Beads runtime for bootstrap-repair siblings"
     fi
     if [[ ! -f "${worktree_path}/bin/bd" || ! -f "${worktree_path}/scripts/beads-resolve-db.sh" ]]; then
         test_fail "Safe apply should restore the plain bd toolchain for bootstrap-repair siblings"

--- a/tests/unit/test_worktree_phase_a.sh
+++ b/tests/unit/test_worktree_phase_a.sh
@@ -15,31 +15,47 @@ create_fake_bd_bin() {
     local fake_bin="${fixture_root}/bin"
 
     mkdir -p "${fake_bin}"
-    cat > "${fake_bin}/bd" <<'EOF'
+cat > "${fake_bin}/bd" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${1:-}" == "--no-daemon" ]]; then
-  shift
-fi
+db_path=""
+args=()
 
-if [[ "${1:-}" == "--db" ]]; then
-  db_path="${2:-}"
-  shift 2
-  if [[ "${1:-}" == "info" ]]; then
-    mkdir -p "$(dirname "${db_path}")"
-    : > "${db_path}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db)
+      db_path="${2:-}"
+      shift 2
+      ;;
+    --db=*)
+      db_path="${1#--db=}"
+      shift
+      ;;
+    --no-daemon)
+      shift
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+case "${args[0]:-}" in
+  bootstrap)
+    mkdir -p ".beads/dolt/beads/.dolt"
     exit 0
-  fi
-fi
-
-if [[ "${1:-}" == "list" ]]; then
-  if [[ -n "${BEADS_DB:-}" ]]; then
-    mkdir -p "$(dirname "${BEADS_DB}")"
-    : > "${BEADS_DB}"
-  fi
-  exit 0
-fi
+    ;;
+  import)
+    mkdir -p ".beads/dolt/beads/.dolt"
+    : > ".beads/last-touched"
+    exit 0
+    ;;
+  list)
+    exit 0
+    ;;
+esac
 
 printf 'unsupported fake bd invocation\n' >&2
 exit 1
@@ -105,8 +121,11 @@ test_phase_a_create_from_base_anchors_new_branch_to_main() {
     assert_eq "$base_sha" "$branch_sha" "New branch should be created exactly at canonical main"
     assert_eq "$base_sha" "$worktree_sha" "New worktree HEAD should match canonical main"
     assert_file_missing "${target_path}/.beads/redirect" "Phase A create should not leave redirect metadata in the new worktree"
-    if [[ ! -f "${target_path}/.beads/beads.db" ]]; then
-        test_fail "Phase A create should bootstrap a local beads.db in the new worktree"
+    if [[ ! -d "${target_path}/.beads/dolt/beads/.dolt" ]]; then
+        test_fail "Phase A create should bootstrap a named local Beads runtime in the new worktree"
+    fi
+    if [[ ! -f "${target_path}/.beads/last-touched" ]]; then
+        test_fail "Phase A create should import the tracked issues into the new runtime"
     fi
 
     rm -rf "$fixture_root"


### PR DESCRIPTION
## Summary
- replace the stale Phase A localization probe with the non-committing Beads path `bd bootstrap` + `bd --db .beads/beads.db import .beads/issues.jsonl`
- quarantine incomplete `.beads/dolt` shells under `.beads/recovery/` before rebuilding the local runtime
- add regression coverage for stale-shell repair, Phase A HEAD preservation, and the static guardrail for the new bootstrap contract

## RCA
- add RCA: `docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md`
- add rule: `docs/rules/beads-worktree-localize-must-bootstrap-and-import-without-moving-head.md`

## Verification
- `bash tests/unit/test_worktree_phase_a.sh`
- `bash tests/unit/test_bd_dispatch.sh`
- `bash tests/unit/test_beads_worktree_audit.sh`
- `bash tests/unit/test_bd_local.sh`
- `bash tests/static/test_beads_worktree_ownership.sh`
- disposable real-CLI repro of `scripts/worktree-phase-a.sh create-from-base` against canonical `main`
