### PR TITLE
fix: verify prod mutation guard via run metadata

### DIFF
--- a/docs/rca/2026-03-26-prod-mutation-guard-github-token-user-endpoint-mismatch.md
+++ b/docs/rca/2026-03-26-prod-mutation-guard-github-token-user-endpoint-mismatch.md
@@ -1,0 +1,66 @@
+# RCA: prod-mutation-guard denied canonical main deploy because it required `/user` on `github.token`
+
+Date: 2026-03-26  
+Scope: canonical `Deploy Moltis` workflow from `main`  
+Triggering run: `23616874000`
+
+## Summary
+
+The canonical production deploy from `main` failed before rollout even began. The failure happened inside `scripts/prod-mutation-guard.sh` during `align-server-checkout`, where the guard tried to verify `github.token` by calling `GET https://api.github.com/user`.
+
+That assumption was wrong for the actual GitHub Actions runtime. The same token could successfully read the current Actions run metadata, but the `/user` endpoint was not a reliable identity check for this token shape. The guard therefore fail-closed on a legitimate `main` deploy.
+
+## Impact
+
+- `Deploy Moltis` run `23616874000` stopped before any production mutation.
+- The Telegram activity-leak fix merged to `main` but did not become live.
+- Operators saw a false branch-policy-style denial even though the workflow really was the canonical `main` deploy.
+
+## What Happened
+
+1. PR `#105` with the Telegram activity-leak hardening was merged into `main`.
+2. `Deploy Moltis` auto-started from the `main` push.
+3. `Pre-flight Checks`, `GitOps Compliance Check`, `Pre-deployment Tests`, and `Backup Current State` all succeeded.
+4. `Deploy to Production` failed in `Align server git checkout before sync`.
+5. The failing guard output was:
+   - `Production mutation denied for action 'align-server-checkout'.`
+   - `Unable to verify GitHub token identity.`
+
+## Root Cause
+
+`prod-mutation-guard.sh` required two different proofs:
+
+- read current run metadata from `repos/<repo>/actions/runs/<run_id>`
+- read `GET /user` and confirm `login == github-actions[bot]`
+
+The second proof was overfit to an incorrect model of `github.token`. In this workflow, the token had enough permission to read the current run metadata but not to satisfy the `/user`-based identity check reliably.
+
+The guard therefore rejected a legitimate canonical deploy.
+
+## Why It Escaped
+
+- Unit tests modeled the happy path with a fake `/user` response, so they preserved the invalid assumption.
+- The first real canonical deploy after introducing this stricter check exposed the mismatch.
+
+## Fix
+
+- Remove the hard requirement on `GET /user`.
+- Keep the fail-closed run-based verification:
+  - repository
+  - workflow name
+  - event
+  - branch/tag
+  - SHA
+- Add a repository match check from the run payload so the guard still verifies the run against the expected repo.
+- Update unit tests so the sanctioned happy path no longer depends on `/user`.
+
+## Prevention
+
+- Do not treat `github.token` as a user token unless the official GitHub Actions contract guarantees that behavior.
+- Prefer verifying immutable run metadata over trying to infer “who the token is”.
+- For new GitHub Actions guards, add at least one test where `/user` is unavailable but the run API still succeeds.
+
+## Lessons
+
+- Security/production guards can be wrong in ways that look like policy violations but are actually contract mismatches with the CI runtime.
+- When a guard protects production mutation, validate it against the real canonical workflow path, not only local mocks.

--- a/scripts/prod-mutation-guard.sh
+++ b/scripts/prod-mutation-guard.sh
@@ -149,28 +149,23 @@ if ! command -v jq >/dev/null 2>&1; then
     deny "jq is required for production mutation guard verification."
 fi
 
-USER_JSON="$(api_get "https://api.github.com/user" 2>/dev/null || true)"
-if [[ -z "$USER_JSON" ]]; then
-    deny "Unable to verify GitHub token identity."
-fi
-
-USER_LOGIN="$(jq -r '.login // empty' <<<"$USER_JSON" 2>/dev/null || true)"
-if [[ "$USER_LOGIN" != "github-actions[bot]" ]]; then
-    deny "Guard token is not a GitHub Actions token."
-fi
-
 RUN_JSON="$(api_get "https://api.github.com/repos/$REPOSITORY_VALUE/actions/runs/${GITHUB_RUN_ID}" 2>/dev/null || true)"
 if [[ -z "$RUN_JSON" ]]; then
-    deny "Unable to verify GitHub Actions run ${GITHUB_RUN_ID}."
+    deny "Unable to verify GitHub Actions run ${GITHUB_RUN_ID} with the approved guard token."
 fi
 
 RUN_NAME="$(jq -r '.name // empty' <<<"$RUN_JSON" 2>/dev/null || true)"
 RUN_EVENT="$(jq -r '.event // empty' <<<"$RUN_JSON" 2>/dev/null || true)"
 RUN_HEAD_SHA="$(jq -r '.head_sha // empty' <<<"$RUN_JSON" 2>/dev/null || true)"
 RUN_HEAD_BRANCH="$(jq -r '.head_branch // empty' <<<"$RUN_JSON" 2>/dev/null || true)"
+RUN_REPOSITORY="$(jq -r '.repository.full_name // empty' <<<"$RUN_JSON" 2>/dev/null || true)"
 
 if [[ "$RUN_NAME" != "$WORKFLOW_VALUE" ]]; then
     deny "Guard workflow mismatch: expected '$WORKFLOW_VALUE', got '$RUN_NAME'."
+fi
+
+if [[ "$RUN_REPOSITORY" != "$REPOSITORY_VALUE" ]]; then
+    deny "Guard run repository mismatch: expected '$REPOSITORY_VALUE', got '$RUN_REPOSITORY'."
 fi
 
 if [[ "$RUN_HEAD_SHA" != "$REF_SHA" ]]; then

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -412,7 +412,7 @@ PY
         test_fail "UAT and Clawdiy workflows must explicitly block feature-branch promotion and point operators to sanctioned paths"
     fi
 
-    test_start "static_production_workflows_pass_guard_github_identity_context"
+    test_start "static_production_workflows_pass_guard_github_run_context"
     if rg -q 'MOLTINGER_PROD_GUARD_GITHUB_TOKEN' "$DEPLOY_WORKFLOW" && \
        rg -q 'MOLTINGER_PROD_GUARD_REPOSITORY' "$DEPLOY_WORKFLOW" && \
        rg -q 'MOLTINGER_PROD_GUARD_WORKFLOW' "$DEPLOY_WORKFLOW" && \
@@ -423,7 +423,7 @@ PY
        rg -q 'actions: read' "$CLAWDIY_WORKFLOW"; then
         test_pass
     else
-        test_fail "Production-adjacent workflows must pass GitHub identity context to the mutation guard and grant actions:read"
+        test_fail "Production-adjacent workflows must pass GitHub run context to the mutation guard and grant actions:read"
     fi
 
     test_start "static_tracked_deploy_detects_missing_json_contract_from_deploy_sh"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -1135,7 +1135,7 @@ test_prod_mutation_guard_rejects_spoofed_ci_context_without_github_proof() {
     fi
 
     if ! grep -Fq "Missing approved workflow identity" "$output_file" && \
-       ! grep -Fq "Unable to verify GitHub token identity" "$output_file"; then
+       ! grep -Fq "Unable to verify GitHub Actions run" "$output_file"; then
         test_fail "Spoofed CI denial should explain missing GitHub proof"
         rm -rf "$tmp_dir"
         return
@@ -1162,11 +1162,8 @@ test_prod_mutation_guard_allows_main_ci_context() {
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
-  *"/user"*)
-    printf '%s\n' '{"login":"github-actions[bot]"}'
-    ;;
   *"/repos/RussianLioN/moltinger/actions/runs/12345"*)
-    printf '%s\n' '{"name":"Deploy Moltis","event":"workflow_dispatch","head_sha":"deadbeef","head_branch":"main"}'
+    printf '%s\n' '{"name":"Deploy Moltis","event":"workflow_dispatch","head_sha":"deadbeef","head_branch":"main","repository":{"full_name":"RussianLioN/moltinger"}}'
     ;;
   *)
     exit 1


### PR DESCRIPTION
## Summary
- fix production mutation guard so canonical GitHub Actions deploys verify via Actions run metadata instead of requiring `/user` on `github.token`
- keep fail-closed workflow/ref/sha checks and add repository match verification from the run payload
- add RCA and update guard tests for the real GitHub Actions token contract

## Testing
- bash -n scripts/prod-mutation-guard.sh
- bash tests/unit/test_deploy_workflow_guards.sh
- bash tests/static/test_config_validation.sh
- git diff --check
