### PR TITLE
fix: recover refreshable OAuth during runtime attestation

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,6 +1,6 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-03-26
+**Generated**: 2026-03-27
 **Total Lessons**: 51
 
 ---

--- a/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
+++ b/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
@@ -152,6 +152,12 @@ docker exec moltis moltis auth status
 If `auth status` is healthy, do not re-auth.
 Ordinary deploy/restart must not require a fresh OAuth login.
 
+If `oauth_tokens.json` still exists and `auth status` shows `openai-codex [expired]`,
+do not jump straight to interactive re-auth. First run a real operator-path canary
+that forces ordinary chat execution and then re-check `auth status`.
+This deployment flow now does that automatically in runtime attestation for the
+refreshable OAuth case.
+
 ## 8. Only if OAuth is missing, run interactive login
 
 Run inside the live container:

--- a/docs/rca/2026-03-26-runtime-attestation-false-fail-on-refreshable-oauth.md
+++ b/docs/rca/2026-03-26-runtime-attestation-false-fail-on-refreshable-oauth.md
@@ -1,0 +1,81 @@
+# RCA: Runtime Attestation False Failure on Refreshable OAuth
+
+Date: 2026-03-26
+Severity: high
+Scope: production deploy attestation for Moltis `openai-codex`
+Status: fixed
+
+## Summary
+
+Canonical production deploy from `main` reached a healthy live Moltis runtime, but
+`scripts/moltis-runtime-attestation.sh` failed with `AUTH_PROVIDER_INVALID`.
+The runtime was not actually broken: a real authenticated operator-path canary
+prompt succeeded and `docker exec moltis moltis auth status` flipped from
+`openai-codex [expired]` to `openai-codex [valid ...]`.
+
+Root cause: attestation treated pre-refresh `auth status` as terminal truth and did
+not account for refreshable OAuth tokens that only become valid after the first real
+provider use.
+
+## RCA "5 Why"
+
+### 1. Why did deploy fail after the container was already healthy?
+
+Because runtime attestation required `moltis auth status` to contain
+`openai-codex [valid ...]` immediately after restart.
+
+### 2. Why was `auth status` not valid immediately after restart?
+
+Because the persisted OAuth state was present but in an `expired` pre-refresh state.
+
+### 3. Why did that not mean the provider was actually broken?
+
+Because a real authenticated `chat.send` request refreshed the provider state and the
+same runtime then reported `openai-codex [valid ...]`.
+
+### 4. Why did attestation still fail?
+
+Because it used a single status snapshot and had no repo-approved live canary path
+for the refreshable-but-expired case.
+
+### 5. Why was that gap present?
+
+Because the deploy contract assumed `auth status` was authoritative immediately after
+restart, instead of modelling lazy OAuth refresh behavior in the live runtime.
+
+## Root Cause
+
+`moltis-runtime-attestation.sh` encoded an overly strict auth invariant:
+`expected provider must already be [valid] before any real request is sent`.
+That invariant was false for refreshable OAuth state persisted in
+`oauth_tokens.json`.
+
+## Fix
+
+1. Keep the strict fast-path for already-valid providers.
+2. If the expected provider is `expired` and `oauth_tokens.json` contains a
+   refresh token for that provider, run a repo-approved authenticated WS canary
+   (`chat.send`) against the live runtime.
+3. Re-check `moltis auth status`.
+4. Pass only if the provider becomes valid after the canary; otherwise fail with a
+   specific auth-canary error code.
+
+## Verification
+
+- `bash -n scripts/moltis-runtime-attestation.sh`
+- `bash tests/component/test_moltis_runtime_attestation.sh`
+  - direct valid path
+  - runtime config drift failure
+  - workspace provenance drift failure
+  - refreshable expired provider recovers via canary
+  - refreshable expired provider fails to recover
+  - wrong provider remains invalid
+
+## Prevention
+
+- Treat persisted OAuth plus immediate `expired` as a possible lazy-refresh state, not
+  automatic re-auth evidence.
+- Keep the operator-path canary in runtime attestation instead of forcing manual
+  browser login during deploy recovery.
+- Preserve runbook guidance: if `oauth_tokens.json` exists, verify with a real canary
+  before attempting interactive re-auth.

--- a/scripts/moltis-runtime-attestation.sh
+++ b/scripts/moltis-runtime-attestation.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 OUTPUT_JSON=false
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_PATH="$(pwd)"
 ACTIVE_PATH="/opt/moltinger-active"
 MOLTIS_CONTAINER="moltis"
@@ -15,6 +16,9 @@ EXPECTED_RUNTIME_CONFIG_DIR=""
 EXPECTED_AUTH_PROVIDER=""
 CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR="${CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR:-/opt/moltinger-state/config-runtime}"
 MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="${MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST:-$CANONICAL_MOLTIS_RUNTIME_CONFIG_DIR}"
+AUTH_PROVIDER_CANARY_PROMPT="${AUTH_PROVIDER_CANARY_PROMPT:-Reply with exactly OK and nothing else.}"
+AUTH_PROVIDER_CANARY_WAIT_MS="${AUTH_PROVIDER_CANARY_WAIT_MS:-3000}"
+AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS="${AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS:-25}"
 
 timestamp() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -107,6 +111,88 @@ read_env_file_value() {
     printf '%s' "$value"
 }
 
+auth_status_provider_line() {
+    local raw="$1"
+    local provider="$2"
+
+    if [[ -z "$raw" || -z "$provider" ]]; then
+        return 1
+    fi
+
+    printf '%s\n' "$raw" | grep -F "$provider" | head -n 1 || true
+}
+
+auth_status_provider_is_valid() {
+    local provider_line="${1:-}"
+    [[ -n "$provider_line" ]] || return 1
+    grep -F '[valid' >/dev/null 2>&1 <<<"$provider_line"
+}
+
+auth_status_provider_is_expired() {
+    local provider_line="${1:-}"
+    [[ -n "$provider_line" ]] || return 1
+    grep -F '[expired' >/dev/null 2>&1 <<<"$provider_line"
+}
+
+oauth_tokens_have_refresh_token() {
+    local runtime_config_dir="$1"
+    local provider="$2"
+    local oauth_tokens_file="$runtime_config_dir/oauth_tokens.json"
+
+    [[ -f "$oauth_tokens_file" ]] || return 1
+
+    jq -e \
+        --arg provider "$provider" \
+        '((.[$provider].refresh_token // "") | type == "string") and ((.[$provider].refresh_token // "") | length > 0)' \
+        "$oauth_tokens_file" >/dev/null 2>&1
+}
+
+run_auth_provider_canary() {
+    local base_url="$1"
+    local password="$2"
+    local ws_rpc_cli script_ws_rpc_cli active_ws_rpc_cli deploy_ws_rpc_cli params_json
+
+    [[ -n "$password" ]] || return 1
+    command -v node >/dev/null 2>&1 || return 1
+
+    script_ws_rpc_cli="$SCRIPT_DIR/../tests/lib/ws_rpc_cli.mjs"
+    active_ws_rpc_cli="$ACTIVE_TARGET/tests/lib/ws_rpc_cli.mjs"
+    deploy_ws_rpc_cli="$DEPLOY_PATH/tests/lib/ws_rpc_cli.mjs"
+    if [[ -f "$script_ws_rpc_cli" ]]; then
+        ws_rpc_cli="$script_ws_rpc_cli"
+    elif [[ -f "$active_ws_rpc_cli" ]]; then
+        ws_rpc_cli="$active_ws_rpc_cli"
+    elif [[ -f "$deploy_ws_rpc_cli" ]]; then
+        ws_rpc_cli="$deploy_ws_rpc_cli"
+    else
+        return 1
+    fi
+
+    params_json="$(jq -nc --arg text "$AUTH_PROVIDER_CANARY_PROMPT" '{text: $text}')"
+    AUTH_CANARY_OUTPUT="$(
+        TEST_BASE_URL="$base_url" \
+        MOLTIS_PASSWORD="$password" \
+        TEST_TIMEOUT="$AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS" \
+        node "$ws_rpc_cli" \
+            request \
+            --method chat.send \
+            --params "$params_json" \
+            --wait-ms "$AUTH_PROVIDER_CANARY_WAIT_MS" \
+            --subscribe chat 2>/dev/null || true
+    )"
+
+    if ! jq -e '
+        .ok == true and
+        .result.ok == true and
+        .result.payload.ok == true and
+        ([.events[]? | select(.event == "chat" and .payload.state == "final")] | length) >= 1
+    ' >/dev/null 2>&1 <<<"$AUTH_CANARY_OUTPUT"; then
+        return 1
+    fi
+
+    return 0
+}
+
 container_mount_source() {
     local container="$1"
     local destination="$2"
@@ -178,6 +264,13 @@ emit_failure_json() {
         --arg http_code "$http_code" \
         --arg recorded_git_sha "$recorded_git_sha" \
         --arg live_git_sha "$live_git_sha" \
+        --arg expected_auth_provider "${EXPECTED_AUTH_PROVIDER:-}" \
+        --arg auth_status_raw "${AUTH_STATUS_RAW:-}" \
+        --arg auth_status_post_canary "${AUTH_STATUS_POST_CANARY:-}" \
+        --arg auth_status_valid "${AUTH_STATUS_VALID:-}" \
+        --arg auth_validation_path "${AUTH_VALIDATION_PATH:-}" \
+        --arg auth_canary_attempted "${AUTH_CANARY_ATTEMPTED:-}" \
+        --arg auth_canary_succeeded "${AUTH_CANARY_SUCCEEDED:-}" \
         '{
           status: $status,
           target: $target,
@@ -191,7 +284,14 @@ emit_failure_json() {
             container_state: $container_state,
             http_code: $http_code,
             recorded_git_sha: (if $recorded_git_sha == "" then null else $recorded_git_sha end),
-            live_git_sha: (if $live_git_sha == "" then null else $live_git_sha end)
+            live_git_sha: (if $live_git_sha == "" then null else $live_git_sha end),
+            expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
+            auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
+            auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
+            auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end),
+            auth_validation_path: (if $auth_validation_path == "" then null else $auth_validation_path end),
+            auth_canary_attempted: (if $auth_canary_attempted == "" then null else ($auth_canary_attempted == "true") end),
+            auth_canary_succeeded: (if $auth_canary_succeeded == "" then null else ($auth_canary_succeeded == "true") end)
           },
           errors: [{code: $code, message: $message}]
         }'
@@ -291,7 +391,12 @@ LIVE_GIT_REF=""
 LIVE_VERSION=""
 RUNTIME_CONFIG_RW=""
 AUTH_STATUS_RAW=""
+AUTH_STATUS_POST_CANARY=""
 AUTH_STATUS_VALID=""
+AUTH_VALIDATION_PATH=""
+AUTH_CANARY_ATTEMPTED=""
+AUTH_CANARY_SUCCEEDED=""
+AUTH_CANARY_OUTPUT=""
 TRACKED_RUNTIME_TOML=""
 RUNTIME_RUNTIME_TOML=""
 
@@ -440,10 +545,31 @@ fi
 
 if [[ -n "$EXPECTED_AUTH_PROVIDER" ]]; then
     AUTH_STATUS_RAW="$(docker exec "$MOLTIS_CONTAINER" moltis auth status 2>/dev/null || true)"
-    if ! printf '%s\n' "$AUTH_STATUS_RAW" | grep -F "$EXPECTED_AUTH_PROVIDER" | grep -F '[valid' >/dev/null 2>&1; then
+    AUTH_PROVIDER_STATUS_LINE="$(auth_status_provider_line "$AUTH_STATUS_RAW" "$EXPECTED_AUTH_PROVIDER" || true)"
+
+    if auth_status_provider_is_valid "$AUTH_PROVIDER_STATUS_LINE"; then
+        AUTH_STATUS_VALID="true"
+        AUTH_VALIDATION_PATH="status"
+    elif auth_status_provider_is_expired "$AUTH_PROVIDER_STATUS_LINE" && oauth_tokens_have_refresh_token "$EXPECTED_RUNTIME_CONFIG" "$EXPECTED_AUTH_PROVIDER"; then
+        AUTH_CANARY_ATTEMPTED="true"
+        AUTH_CANARY_PASSWORD="$(read_env_file_value "$ENV_FILE" "MOLTIS_PASSWORD" || true)"
+
+        if run_auth_provider_canary "$MOLTIS_URL" "$AUTH_CANARY_PASSWORD"; then
+            AUTH_CANARY_SUCCEEDED="true"
+            AUTH_STATUS_POST_CANARY="$(docker exec "$MOLTIS_CONTAINER" moltis auth status 2>/dev/null || true)"
+            AUTH_PROVIDER_STATUS_LINE="$(auth_status_provider_line "$AUTH_STATUS_POST_CANARY" "$EXPECTED_AUTH_PROVIDER" || true)"
+            if auth_status_provider_is_valid "$AUTH_PROVIDER_STATUS_LINE"; then
+                AUTH_STATUS_VALID="true"
+                AUTH_VALIDATION_PATH="refreshable-canary"
+            else
+                fail_with "AUTH_PROVIDER_INVALID_AFTER_CANARY" "Expected auth provider '$EXPECTED_AUTH_PROVIDER' remained non-valid after successful refresh canary"
+            fi
+        else
+            fail_with "AUTH_PROVIDER_CANARY_FAILED" "Expected auth provider '$EXPECTED_AUTH_PROVIDER' was refreshable-but-expired and the runtime canary did not recover it"
+        fi
+    else
         fail_with "AUTH_PROVIDER_INVALID" "Expected valid auth provider '$EXPECTED_AUTH_PROVIDER' was not found in live Moltis auth status"
     fi
-    AUTH_STATUS_VALID="true"
 fi
 
 if [[ "$OUTPUT_JSON" == "true" ]]; then
@@ -475,7 +601,12 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
         --arg tracked_runtime_toml "$TRACKED_RUNTIME_TOML" \
         --arg runtime_runtime_toml "$RUNTIME_RUNTIME_TOML" \
         --arg expected_auth_provider "$EXPECTED_AUTH_PROVIDER" \
+        --arg auth_status_raw "$AUTH_STATUS_RAW" \
+        --arg auth_status_post_canary "$AUTH_STATUS_POST_CANARY" \
         --arg auth_status_valid "$AUTH_STATUS_VALID" \
+        --arg auth_validation_path "$AUTH_VALIDATION_PATH" \
+        --arg auth_canary_attempted "$AUTH_CANARY_ATTEMPTED" \
+        --arg auth_canary_succeeded "$AUTH_CANARY_SUCCEEDED" \
         '{
           status: $status,
           target: $target,
@@ -505,7 +636,12 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
             tracked_runtime_toml: (if $tracked_runtime_toml == "" then null else $tracked_runtime_toml end),
             runtime_runtime_toml: (if $runtime_runtime_toml == "" then null else $runtime_runtime_toml end),
             expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
-            auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end)
+            auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
+            auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
+            auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end),
+            auth_validation_path: (if $auth_validation_path == "" then null else $auth_validation_path end),
+            auth_canary_attempted: (if $auth_canary_attempted == "" then null else ($auth_canary_attempted == "true") end),
+            auth_canary_succeeded: (if $auth_canary_succeeded == "" then null else ($auth_canary_succeeded == "true") end)
           },
           errors: []
         }'
@@ -527,6 +663,11 @@ runtime_config_rw=${RUNTIME_CONFIG_RW:-unknown}
 tracked_runtime_toml=${TRACKED_RUNTIME_TOML:-unknown}
 runtime_runtime_toml=${RUNTIME_RUNTIME_TOML:-unknown}
 expected_auth_provider=${EXPECTED_AUTH_PROVIDER:-none}
+auth_status_raw=${AUTH_STATUS_RAW:-none}
+auth_status_post_canary=${AUTH_STATUS_POST_CANARY:-none}
 auth_status_valid=${AUTH_STATUS_VALID:-skipped}
+auth_validation_path=${AUTH_VALIDATION_PATH:-skipped}
+auth_canary_attempted=${AUTH_CANARY_ATTEMPTED:-false}
+auth_canary_succeeded=${AUTH_CANARY_SUCCEEDED:-false}
 EOF
 fi

--- a/tests/component/test_moltis_runtime_attestation.sh
+++ b/tests/component/test_moltis_runtime_attestation.sh
@@ -17,6 +17,29 @@ create_fake_runtime_bin() {
 #!/usr/bin/env bash
 set -euo pipefail
 
+read_auth_status() {
+  if [[ -n "${FAKE_AUTH_STATUS_SEQUENCE_FILE:-}" && -f "${FAKE_AUTH_STATUS_SEQUENCE_FILE:-}" ]]; then
+    local state_file="${FAKE_AUTH_STATUS_SEQUENCE_STATE_FILE:-${FAKE_AUTH_STATUS_SEQUENCE_FILE}.state}"
+    local index=1
+    if [[ -f "$state_file" ]]; then
+      index="$(cat "$state_file")"
+    fi
+
+    local line
+    line="$(sed -n "${index}p" "$FAKE_AUTH_STATUS_SEQUENCE_FILE")"
+    if [[ -z "$line" ]]; then
+      line="$(tail -n 1 "$FAKE_AUTH_STATUS_SEQUENCE_FILE")"
+    else
+      printf '%s\n' "$((index + 1))" >"$state_file"
+    fi
+
+    printf '%s\n' "$line"
+    return 0
+  fi
+
+  printf '%s\n' "${FAKE_AUTH_STATUS:-openai-codex [valid (10m remaining)]}"
+}
+
 case "${1:-}" in
   inspect)
     if [[ "${2:-}" == "--format" ]]; then
@@ -50,7 +73,7 @@ case "${1:-}" in
       exit 0
     fi
     if [[ "${1:-}" == "moltis" && "${2:-}" == "moltis" && "${3:-}" == "auth" && "${4:-}" == "status" ]]; then
-      printf '%s\n' "${FAKE_AUTH_STATUS:-openai-codex [valid (10m remaining)]}"
+      read_auth_status
       exit 0
     fi
     printf 'unsupported docker exec invocation: %s\n' "$*" >&2
@@ -67,6 +90,36 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s' "${FAKE_CURL_HTTP_CODE:-200}"
+EOF
+
+    cat >"$fake_bin/node" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == *"/tests/lib/ws_rpc_cli.mjs" ]]; then
+  if [[ "${FAKE_AUTH_CANARY_RESULT:-success}" == "success" ]]; then
+    cat <<'JSON'
+{
+  "ok": true,
+  "login": { "status": 200 },
+  "result": { "ok": true, "payload": { "ok": true } },
+  "events": [{ "event": "chat", "payload": { "state": "final" } }]
+}
+JSON
+    exit 0
+  fi
+
+  cat <<'JSON'
+{
+  "ok": false,
+  "message": "canary failed"
+}
+JSON
+  exit "${FAKE_AUTH_CANARY_EXIT_CODE:-1}"
+fi
+
+printf 'unsupported fake node invocation: %s\n' "$*" >&2
+exit 1
 EOF
 
     cat >"$fake_bin/git" <<'EOF'
@@ -87,7 +140,7 @@ printf 'unsupported fake git invocation: %s\n' "$*" >&2
 exit 1
 EOF
 
-    chmod +x "$fake_bin/docker" "$fake_bin/curl" "$fake_bin/git"
+    chmod +x "$fake_bin/docker" "$fake_bin/curl" "$fake_bin/node" "$fake_bin/git"
     printf '%s\n' "$fake_bin"
 }
 
@@ -132,6 +185,7 @@ run_component_moltis_runtime_attestation_tests() {
 
     cat >"$workspace_root/.env" <<EOF
 MOLTIS_RUNTIME_CONFIG_DIR=$runtime_config_dir
+MOLTIS_PASSWORD=test-password
 EOF
     printf '%s\n' "$live_sha" >"$workspace_root/data/.deployed-sha"
     cat >"$workspace_root/data/.deployment-info" <<EOF
@@ -187,7 +241,8 @@ EOF
        [[ "$(jq -r '.details.tracked_runtime_toml' "$output_json")" != "$workspace_root_canonical/config/moltis.toml" ]] || \
        [[ "$(jq -r '.details.runtime_runtime_toml' "$output_json")" != "$runtime_config_dir_canonical/moltis.toml" ]] || \
        [[ "$(jq -r '.details.expected_auth_provider' "$output_json")" != "openai-codex" ]] || \
-       [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]]; then
+       [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.auth_validation_path' "$output_json")" != "status" ]]; then
         test_fail "Runtime attestation success output does not reflect the expected provenance details"
         rm -rf "$fixture_root"
         return
@@ -274,6 +329,85 @@ EOF
   }
 ]
 EOF
+
+    cat >"$runtime_config_dir/oauth_tokens.json" <<'EOF'
+{
+  "openai-codex": {
+    "refresh_token": "refresh-token"
+  }
+}
+EOF
+    cat >"$fixture_root/auth-status-sequence.txt" <<'EOF'
+openai-codex [expired]
+openai-codex [valid (10m remaining)]
+EOF
+
+    test_start "component_runtime_attestation_recovers_refreshable_expired_auth_provider_via_canary"
+    if ! PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        FAKE_AUTH_STATUS_SEQUENCE_FILE="$fixture_root/auth-status-sequence.txt" \
+        FAKE_AUTH_CANARY_RESULT="success" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" \
+            --expected-auth-provider "openai-codex" >"$output_json" 2>"$fixture_root/stderr-auth-refresh.log"; then
+        test_fail "Runtime attestation should recover a refreshable expired auth provider via canary"
+        rm -rf "$fixture_root"
+        return
+    fi
+
+    if [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.auth_validation_path' "$output_json")" != "refreshable-canary" ]] || \
+       [[ "$(jq -r '.details.auth_canary_attempted' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.auth_canary_succeeded' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.auth_status_raw' "$output_json")" != "openai-codex [expired]" ]] || \
+       [[ "$(jq -r '.details.auth_status_post_canary' "$output_json")" != "openai-codex [valid (10m remaining)]" ]]; then
+        test_fail "Runtime attestation should record refreshable auth recovery details after a successful canary"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    cat >"$fixture_root/auth-status-sequence.txt" <<'EOF'
+openai-codex [expired]
+openai-codex [expired]
+EOF
+
+    test_start "component_runtime_attestation_fails_when_refreshable_expired_auth_provider_does_not_recover"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        FAKE_AUTH_STATUS_SEQUENCE_FILE="$fixture_root/auth-status-sequence.txt" \
+        FAKE_AUTH_CANARY_RESULT="failure" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" \
+            --expected-auth-provider "openai-codex" >"$output_json" 2>"$fixture_root/stderr-auth-refresh-fail.log"
+    exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "AUTH_PROVIDER_CANARY_FAILED")' "$output_json" >/dev/null 2>&1; then
+        test_fail "Runtime attestation should fail when a refreshable expired auth provider does not recover after canary"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
 
     test_start "component_runtime_attestation_fails_when_expected_auth_provider_is_invalid"
     set +e


### PR DESCRIPTION
## Summary
- teach runtime attestation to handle refreshable-but-expired OpenAI OAuth via a repo-approved WS canary
- re-check auth status after canary instead of failing immediately on the pre-refresh snapshot
- add component coverage for successful recovery and true non-recovery

## Verification
- bash -n scripts/moltis-runtime-attestation.sh
- bash tests/component/test_moltis_runtime_attestation.sh
- bash tests/static/test_config_validation.sh
- ./scripts/build-lessons-index.sh
