### PR TITLE
fix: restore Moltis browser sandbox Docker contract

### DIFF
--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -490,6 +490,7 @@ allowed_domains = []              # Empty = all domains allowed
 memory_limit_percent = 90
 chrome_args = []
 sandbox_image = "browserless/chrome"
+container_host = "host.docker.internal"  # Moltis runs in Docker; sibling browser container must be reached via host gateway, not 127.0.0.1
 # allowed_domains = [
 #     "docs.example.com",         # Exact match
 #     "*.github.com",             # Wildcard: matches any subdomain of github.com

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,8 @@ services:
     # Required for Docker socket access (sandbox execution)
     privileged: true
     read_only: false
+    group_add:
+      - "${DOCKER_SOCKET_GID:-999}"
 
     ports:
       - "${MOLTIS_PORT:-13131}:13131"
@@ -51,6 +53,8 @@ services:
       - ${MOLTIS_RUNTIME_CONFIG_DIR:-/opt/moltinger-state/config-runtime}:/home/moltis/.config/moltis
       - moltis-data:/home/moltis/.moltis
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
     environment:
       <<: *common-env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
     # SECURITY: privileged mode required for Docker-in-Docker sandbox execution
     # See SECURITY NOTICE above for details
     privileged: true
+    group_add:
+      - "${DOCKER_SOCKET_GID:-999}"
     networks:
       - ainetic_net
 
@@ -71,6 +73,8 @@ services:
       - ./data:/home/moltis/.moltis
       # Docker socket for sandbox execution (WARNING: root access)
       - /var/run/docker.sock:/var/run/docker.sock
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
     environment:
       <<: *common-env

--- a/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
+++ b/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
@@ -304,6 +304,39 @@ Fix:
 - inspect `docker logs moltis` before changing Traefik
 - do not guess at websocket headers first
 
+### Symptom: Browser tool fails with `failed to pull browser image` or Docker `permission denied`
+
+Likely cause:
+
+- `/var/run/docker.sock` is mounted, but the live Moltis process does not have the
+  socket's numeric GID in its supplementary groups
+- or containerized Moltis is still trying to reach sibling browser containers via
+  loopback instead of the host gateway
+
+Inspect:
+
+```bash
+docker inspect moltis --format '{{range .Mounts}}{{println .Source "->" .Destination}}{{end}}'
+docker exec moltis sh -lc 'id -G && stat -c "%g %a" /var/run/docker.sock'
+docker exec moltis sh -lc 'grep host.docker.internal /etc/hosts || true'
+docker exec moltis sh -lc 'sed -n "470,505p" /home/moltis/.config/moltis/moltis.toml'
+```
+
+Fix:
+
+- ensure compose passes `group_add` with the real host `docker.sock` GID
+- ensure deploy-time `DOCKER_SOCKET_GID` comes from `stat -c %g /var/run/docker.sock`
+- ensure `tools.browser.container_host` is not left at loopback for a Dockerized
+  Moltis runtime
+- ensure the container maps `host.docker.internal:host-gateway`
+
+Why this matters:
+
+- the official Moltis browser docs require sibling-container routing when Moltis
+  runs inside Docker
+- Docker socket access is controlled by numeric UID/GID, not the textual group name
+  shown inside the container
+
 ## Anti-Patterns
 
 Do not do any of the following:

--- a/docs/rca/2026-03-27-moltis-browser-sandbox-docker-socket-gid-mismatch.md
+++ b/docs/rca/2026-03-27-moltis-browser-sandbox-docker-socket-gid-mismatch.md
@@ -1,0 +1,122 @@
+# RCA: Moltis Browser Sandbox Failed in Docker Due to Numeric `docker.sock` GID Mismatch
+
+Date: 2026-03-27
+Severity: high
+Scope: production Moltis browser automation, Telegram user chat, Tavily-assisted research flows
+Status: fixed
+
+## Summary
+
+Telegram user requests that required browser automation started failing with:
+
+- `browser launch failed: failed to ensure browser image`
+- `failed to pull browser image`
+- `permission denied while trying to connect to the docker API at unix:///var/run/docker.sock`
+
+The live agent then continued with `memory_search` and Tavily, consumed the remaining
+30-second agent budget, and the timeout path published a Telegram reply that included
+an internal `Activity log` suffix.
+
+This was not a Tavily outage and not a random runtime drift. The tracked Docker
+contract for containerized Moltis was incomplete:
+
+1. the Moltis container mounted `/var/run/docker.sock`, but did not align its
+   supplementary groups to the socket's numeric GID;
+2. the browser config did not explicitly model the documented
+   `Moltis Inside Docker (Sibling Containers)` routing requirement.
+
+## Evidence
+
+- Production logs showed:
+  - browser tool entered sandbox mode;
+  - Moltis attempted to pull `browserless/chrome`;
+  - Docker API access failed with `permission denied`;
+  - the run then timed out at 30 seconds;
+  - Telegram outbound used `text+suffix`, matching the leaked `Activity log`.
+- Live container inspection showed:
+  - Moltis runs as non-root user `moltis`;
+  - `/var/run/docker.sock` is mounted read-only;
+  - inside the container the process groups were `1001 1000`;
+  - the mounted socket had `gid=999 mode=660`.
+- Official Moltis documentation confirms:
+  - browser sandbox follows session sandbox mode;
+  - when Moltis runs inside Docker, the browser launches as a sibling container
+    through the host Docker socket;
+  - `container_host` must be set for containerized Moltis so it does not try to
+    reach the sibling browser via `127.0.0.1`;
+  - many generic cloud platforms do not support Docker-in-Docker at all, so this
+    contract must be explicit and verified.
+
+## RCA "5 Why"
+
+### 1. Why did the Telegram request fail?
+
+Because the browser tool could not launch its sandbox container and the run later hit
+the global 30-second timeout.
+
+### 2. Why could the browser sandbox container not launch?
+
+Because Moltis could not talk to Docker through `/var/run/docker.sock`.
+
+### 3. Why was Docker access denied even though the socket was mounted?
+
+Because the mounted socket kept the host numeric GID (`999`), while the Moltis
+process inside the container only had supplementary group `1000`.
+
+### 4. Why did that reach the user as a noisy Telegram reply?
+
+Because the timeout path still emitted a `text+suffix` response containing internal
+activity telemetry after the actual browser failure had already consumed part of the
+run budget.
+
+### 5. Why was this not blocked before production?
+
+Because the tracked deploy/runtime guardrails verified workspace and config
+provenance, but did not yet verify the browser sandbox Docker contract:
+numeric socket-group access plus host-gateway routing for sibling browser containers.
+
+## Root Cause
+
+The production compose and runtime attestation contract modeled Docker socket
+presence, but not Docker socket usability from the live Moltis process.
+
+The missing invariants were:
+
+- the live Moltis process groups must contain the mounted socket's numeric GID;
+- containerized Moltis must not leave browser sibling routing on the default
+  loopback path.
+
+## Fix
+
+1. Add `group_add: "${DOCKER_SOCKET_GID:-999}"` to the Moltis Docker services.
+2. Detect `DOCKER_SOCKET_GID` at deploy time from `stat -c %g /var/run/docker.sock`
+   and pass it into `docker compose`.
+3. Add `extra_hosts: "host.docker.internal:host-gateway"` for containerized Moltis.
+4. Set `tools.browser.container_host = "host.docker.internal"` in tracked
+   `config/moltis.toml`.
+5. Extend deploy verification and runtime attestation so they fail closed when:
+   - `docker.sock` is mounted but its GID is not present in the live Moltis process
+     groups;
+   - `host.docker.internal` is not mapped for the sibling browser path.
+
+## Verification
+
+- `bash -n scripts/deploy.sh`
+- `bash -n scripts/moltis-runtime-attestation.sh`
+- `bash tests/component/test_moltis_runtime_attestation.sh`
+- `bash tests/unit/test_deploy_workflow_guards.sh`
+- `bash tests/static/test_config_validation.sh`
+- production log check:
+  - no more `permission denied while trying to connect to the docker API`
+  - browser tool can launch sandbox container successfully
+  - Telegram repro no longer times out on this path
+
+## Prevention
+
+- Treat mounted Docker socket access as a numeric-ID contract, not as a boolean
+  “socket exists” contract.
+- Keep browser-sandbox checks in deploy verification and runtime attestation.
+- Follow the official Moltis Docker guidance for sibling browser containers instead
+  of relying on implicit loopback behavior.
+- Continue treating Telegram `Activity log` output as a failure signal in UAT, even
+  when the primary incident is infrastructure-related.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -507,6 +507,7 @@ compose_cmd() {
 
     local args=("$@")
     local -a compose_args=()
+    local -a env_prefix=(env)
     local redirect_stdout=false
 
     if [[ -n "$ENV_FILE" && -f "$ENV_FILE" ]]; then
@@ -520,17 +521,32 @@ compose_cmd() {
     fi
 
     if [[ "$TARGET" == "moltis" ]]; then
+        local docker_socket_gid="${DOCKER_SOCKET_GID:-}"
+        if [[ -z "$docker_socket_gid" && -S /var/run/docker.sock ]]; then
+            docker_socket_gid="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
+        fi
+        if [[ -z "$docker_socket_gid" ]]; then
+            log_error "Moltis browser sandbox contract requires a detectable DOCKER_SOCKET_GID for /var/run/docker.sock"
+            exit 2
+        fi
+        if [[ ! "$docker_socket_gid" =~ ^[0-9]+$ ]]; then
+            log_error "DOCKER_SOCKET_GID must be numeric; got '$docker_socket_gid'"
+            exit 2
+        fi
+
         if [[ "${ALLOW_MOLTIS_VERSION_OVERRIDE:-false}" == "true" && -n "${MOLTIS_VERSION:-}" ]]; then
+            env_prefix=(env "DOCKER_SOCKET_GID=$docker_socket_gid" "MOLTIS_VERSION=$MOLTIS_VERSION")
             if [[ "$redirect_stdout" == "true" ]]; then
-                MOLTIS_VERSION="$MOLTIS_VERSION" docker compose "${compose_args[@]}" "${args[@]}" 1>&2
+                "${env_prefix[@]}" docker compose "${compose_args[@]}" "${args[@]}" 1>&2
             else
-                MOLTIS_VERSION="$MOLTIS_VERSION" docker compose "${compose_args[@]}" "${args[@]}"
+                "${env_prefix[@]}" docker compose "${compose_args[@]}" "${args[@]}"
             fi
         else
+            env_prefix=(env -u MOLTIS_VERSION "DOCKER_SOCKET_GID=$docker_socket_gid")
             if [[ "$redirect_stdout" == "true" ]]; then
-                env -u MOLTIS_VERSION docker compose "${compose_args[@]}" "${args[@]}" 1>&2
+                "${env_prefix[@]}" docker compose "${compose_args[@]}" "${args[@]}" 1>&2
             else
-                env -u MOLTIS_VERSION docker compose "${compose_args[@]}" "${args[@]}"
+                "${env_prefix[@]}" docker compose "${compose_args[@]}" "${args[@]}"
             fi
         fi
         return
@@ -1323,6 +1339,21 @@ verify_deployment() {
             rm -f "$tmp_path"
         ' >/dev/null 2>&1; then
             log_error "Moltis runtime contract mismatch: repo skills are not visible or runtime config is not writable inside the container"
+            return 1
+        fi
+
+        if ! docker exec "$TARGET_CONTAINER" sh -lc '
+            sock_gid="$(stat -c %g /var/run/docker.sock)" &&
+            id -G | tr " " "\n" | grep -qx "$sock_gid"
+        ' >/dev/null 2>&1; then
+            log_error "Moltis runtime contract mismatch: mounted docker.sock gid is not present in the live Moltis process groups"
+            return 1
+        fi
+
+        if ! docker exec "$TARGET_CONTAINER" sh -lc '
+            grep -Eq "(^|[[:space:]])host\.docker\.internal([[:space:]]|$)" /etc/hosts
+        ' >/dev/null 2>&1; then
+            log_error "Moltis runtime contract mismatch: host.docker.internal is not mapped inside the live container for sibling browser connectivity"
             return 1
         fi
     fi

--- a/scripts/moltis-runtime-attestation.sh
+++ b/scripts/moltis-runtime-attestation.sh
@@ -19,6 +19,14 @@ MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="${MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST:-$CAN
 AUTH_PROVIDER_CANARY_PROMPT="${AUTH_PROVIDER_CANARY_PROMPT:-Reply with exactly OK and nothing else.}"
 AUTH_PROVIDER_CANARY_WAIT_MS="${AUTH_PROVIDER_CANARY_WAIT_MS:-3000}"
 AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS="${AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS:-25}"
+BROWSER_ENABLED=""
+BROWSER_SANDBOX_IMAGE=""
+BROWSER_CONTAINER_HOST=""
+DOCKER_SOCKET_SOURCE=""
+DOCKER_SOCKET_GID=""
+DOCKER_SOCKET_MODE=""
+CONTAINER_GROUP_IDS=""
+HOST_DOCKER_INTERNAL_MAPPED=""
 
 timestamp() {
     date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -89,6 +97,32 @@ canonicalize_existing_path() {
             printf '%s/%s\n' "$(pwd -P)" "$(basename "$path")"
         )
     fi
+}
+
+read_toml_key() {
+    local toml_file="$1"
+    local section="$2"
+    local key="$3"
+
+    [[ -f "$toml_file" ]] || return 1
+
+    awk -v section="$section" -v key="$key" '
+        BEGIN { in_section = 0 }
+        /^[[:space:]]*\[/ {
+            in_section = ($0 == section)
+            next
+        }
+        in_section && $0 ~ ("^[[:space:]]*" key "[[:space:]]*=") {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            sub(/[[:space:]]*#.*$/, "", line)
+            sub("^[^=]+=[[:space:]]*", "", line)
+            gsub(/^"/, "", line)
+            gsub(/"$/, "", line)
+            print line
+            exit
+        }
+    ' "$toml_file"
 }
 
 read_env_file_value() {
@@ -209,6 +243,34 @@ container_mount_rw() {
     docker inspect "$container" 2>/dev/null | \
         jq -r --arg destination "$destination" '.[0].Mounts[]? | select(.Destination == $destination) | .RW' | \
         head -n 1
+}
+
+container_exec_shell() {
+    local command="$1"
+    docker exec "$MOLTIS_CONTAINER" sh -lc "$command" 2>/dev/null || true
+}
+
+container_exec_ok() {
+    local command="$1"
+    docker exec "$MOLTIS_CONTAINER" sh -lc "$command" >/dev/null 2>&1
+}
+
+browser_contract_required() {
+    [[ "$BROWSER_ENABLED" == "true" && -n "$BROWSER_SANDBOX_IMAGE" ]]
+}
+
+container_group_has_gid() {
+    local groups="$1"
+    local gid="$2"
+    local group_id
+
+    for group_id in $groups; do
+        if [[ "$group_id" == "$gid" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 container_state() {
@@ -522,6 +584,40 @@ if ! cmp -s "$TRACKED_RUNTIME_TOML" "$RUNTIME_RUNTIME_TOML"; then
     fail_with "RUNTIME_CONFIG_FILE_MISMATCH" "Runtime moltis.toml diverges from tracked config/moltis.toml"
 fi
 
+BROWSER_ENABLED="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "enabled" || true)"
+BROWSER_SANDBOX_IMAGE="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "sandbox_image" || true)"
+BROWSER_CONTAINER_HOST="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "container_host" || true)"
+
+if browser_contract_required; then
+    DOCKER_SOCKET_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "/var/run/docker.sock")"
+    if [[ -z "$DOCKER_SOCKET_SOURCE" ]]; then
+        fail_with "BROWSER_DOCKER_SOCKET_MOUNT_MISSING" "Browser sandbox requires /var/run/docker.sock to be mounted into the Moltis container"
+    fi
+
+    if [[ -z "$BROWSER_CONTAINER_HOST" || "$BROWSER_CONTAINER_HOST" == "127.0.0.1" || "$BROWSER_CONTAINER_HOST" == "localhost" ]]; then
+        fail_with "BROWSER_CONTAINER_HOST_INVALID" "Browser sandbox requires tools.browser.container_host to point to the host gateway when Moltis itself runs in Docker"
+    fi
+
+    CONTAINER_GROUP_IDS="$(container_exec_shell 'id -G')"
+    DOCKER_SOCKET_GID="$(container_exec_shell 'stat -c "%g" /var/run/docker.sock')"
+    DOCKER_SOCKET_MODE="$(container_exec_shell 'stat -c "%a" /var/run/docker.sock')"
+
+    if [[ -z "$CONTAINER_GROUP_IDS" || -z "$DOCKER_SOCKET_GID" ]]; then
+        fail_with "BROWSER_DOCKER_SOCKET_METADATA_MISSING" "Browser sandbox contract could not read docker socket ownership metadata from the live container"
+    fi
+
+    if ! container_group_has_gid "$CONTAINER_GROUP_IDS" "$DOCKER_SOCKET_GID"; then
+        fail_with "BROWSER_DOCKER_SOCKET_GID_MISMATCH" "Browser sandbox docker.sock gid '$DOCKER_SOCKET_GID' is not present in the live Moltis process groups '$CONTAINER_GROUP_IDS'"
+    fi
+
+    if [[ "$BROWSER_CONTAINER_HOST" == "host.docker.internal" ]]; then
+        if ! container_exec_ok 'grep -Eq "(^|[[:space:]])host\.docker\.internal([[:space:]]|$)" /etc/hosts'; then
+            fail_with "BROWSER_CONTAINER_HOST_MAPPING_MISSING" "tools.browser.container_host points to host.docker.internal but the hostname is not mapped inside the live Moltis container"
+        fi
+        HOST_DOCKER_INTERNAL_MAPPED="true"
+    fi
+fi
+
 RUNTIME_HOME_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "/home/moltis/.moltis")"
 if [[ -z "$RUNTIME_HOME_SOURCE" ]]; then
     fail_with "RUNTIME_HOME_MOUNT_MISSING" "Moltis runtime home mount /home/moltis/.moltis is missing"
@@ -600,6 +696,14 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
         --arg runtime_config_rw "$RUNTIME_CONFIG_RW" \
         --arg tracked_runtime_toml "$TRACKED_RUNTIME_TOML" \
         --arg runtime_runtime_toml "$RUNTIME_RUNTIME_TOML" \
+        --arg browser_enabled "$BROWSER_ENABLED" \
+        --arg browser_sandbox_image "$BROWSER_SANDBOX_IMAGE" \
+        --arg browser_container_host "$BROWSER_CONTAINER_HOST" \
+        --arg docker_socket_source "$DOCKER_SOCKET_SOURCE" \
+        --arg docker_socket_gid "$DOCKER_SOCKET_GID" \
+        --arg docker_socket_mode "$DOCKER_SOCKET_MODE" \
+        --arg container_group_ids "$CONTAINER_GROUP_IDS" \
+        --arg host_docker_internal_mapped "$HOST_DOCKER_INTERNAL_MAPPED" \
         --arg expected_auth_provider "$EXPECTED_AUTH_PROVIDER" \
         --arg auth_status_raw "$AUTH_STATUS_RAW" \
         --arg auth_status_post_canary "$AUTH_STATUS_POST_CANARY" \
@@ -635,6 +739,14 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
             runtime_config_rw: (if $runtime_config_rw == "" then null else $runtime_config_rw end),
             tracked_runtime_toml: (if $tracked_runtime_toml == "" then null else $tracked_runtime_toml end),
             runtime_runtime_toml: (if $runtime_runtime_toml == "" then null else $runtime_runtime_toml end),
+            browser_enabled: (if $browser_enabled == "" then null else ($browser_enabled == "true") end),
+            browser_sandbox_image: (if $browser_sandbox_image == "" then null else $browser_sandbox_image end),
+            browser_container_host: (if $browser_container_host == "" then null else $browser_container_host end),
+            docker_socket_source: (if $docker_socket_source == "" then null else $docker_socket_source end),
+            docker_socket_gid: (if $docker_socket_gid == "" then null else $docker_socket_gid end),
+            docker_socket_mode: (if $docker_socket_mode == "" then null else $docker_socket_mode end),
+            container_group_ids: (if $container_group_ids == "" then null else ($container_group_ids | split(" ")) end),
+            host_docker_internal_mapped: (if $host_docker_internal_mapped == "" then null else ($host_docker_internal_mapped == "true") end),
             expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
             auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
             auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
@@ -662,6 +774,14 @@ live_version=${LIVE_VERSION:-unknown}
 runtime_config_rw=${RUNTIME_CONFIG_RW:-unknown}
 tracked_runtime_toml=${TRACKED_RUNTIME_TOML:-unknown}
 runtime_runtime_toml=${RUNTIME_RUNTIME_TOML:-unknown}
+browser_enabled=${BROWSER_ENABLED:-unknown}
+browser_sandbox_image=${BROWSER_SANDBOX_IMAGE:-none}
+browser_container_host=${BROWSER_CONTAINER_HOST:-none}
+docker_socket_source=${DOCKER_SOCKET_SOURCE:-none}
+docker_socket_gid=${DOCKER_SOCKET_GID:-none}
+docker_socket_mode=${DOCKER_SOCKET_MODE:-none}
+container_group_ids=${CONTAINER_GROUP_IDS:-none}
+host_docker_internal_mapped=${HOST_DOCKER_INTERNAL_MAPPED:-false}
 expected_auth_provider=${EXPECTED_AUTH_PROVIDER:-none}
 auth_status_raw=${AUTH_STATUS_RAW:-none}
 auth_status_post_canary=${AUTH_STATUS_POST_CANARY:-none}

--- a/tests/component/test_moltis_runtime_attestation.sh
+++ b/tests/component/test_moltis_runtime_attestation.sh
@@ -76,6 +76,28 @@ case "${1:-}" in
       read_auth_status
       exit 0
     fi
+    if [[ "${1:-}" == "moltis" && "${2:-}" == "sh" && "${3:-}" == "-lc" ]]; then
+      case "${4:-}" in
+        'id -G')
+          printf '%s\n' "${FAKE_CONTAINER_GROUP_IDS:-1001 999}"
+          exit 0
+          ;;
+        'stat -c "%g" /var/run/docker.sock')
+          printf '%s\n' "${FAKE_DOCKER_SOCKET_GID:-999}"
+          exit 0
+          ;;
+        'stat -c "%a" /var/run/docker.sock')
+          printf '%s\n' "${FAKE_DOCKER_SOCKET_MODE:-660}"
+          exit 0
+          ;;
+        'grep -Eq "(^|[[:space:]])host\.docker\.internal([[:space:]]|$)" /etc/hosts')
+          if [[ "${FAKE_HOST_DOCKER_INTERNAL_MAPPED:-true}" == "true" ]]; then
+            exit 0
+          fi
+          exit 1
+          ;;
+      esac
+    fi
     printf 'unsupported docker exec invocation: %s\n' "$*" >&2
     exit 1
     ;;
@@ -157,6 +179,11 @@ create_workspace_fixture() {
 provider = "ollama"
 base_url = "http://ollama:11434"
 model = "nomic-embed-text"
+
+[tools.browser]
+enabled = true
+sandbox_image = "browserless/chrome"
+container_host = "host.docker.internal"
 EOF
     git -C "$workspace_root" add runtime.txt
     git -C "$workspace_root" add config/moltis.toml
@@ -206,11 +233,13 @@ EOF
     "Mounts": [
       {"Destination": "/server", "Source": "$workspace_root", "RW": false},
       {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
-      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true}
+      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true},
+      {"Destination": "/var/run/docker.sock", "Source": "$fixture_root/docker.sock", "RW": false}
     ]
   }
 ]
 EOF
+    : >"$fixture_root/docker.sock"
 
     test_start "component_runtime_attestation_succeeds_for_live_provenance_contract"
     if ! PATH="$fake_bin:$PATH" \
@@ -240,10 +269,43 @@ EOF
        [[ "$(jq -r '.details.runtime_config_rw' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.tracked_runtime_toml' "$output_json")" != "$workspace_root_canonical/config/moltis.toml" ]] || \
        [[ "$(jq -r '.details.runtime_runtime_toml' "$output_json")" != "$runtime_config_dir_canonical/moltis.toml" ]] || \
+       [[ "$(jq -r '.details.browser_enabled' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.browser_sandbox_image' "$output_json")" != "browserless/chrome" ]] || \
+       [[ "$(jq -r '.details.browser_container_host' "$output_json")" != "host.docker.internal" ]] || \
+       [[ "$(jq -r '.details.docker_socket_gid' "$output_json")" != "999" ]] || \
+       [[ "$(jq -r '.details.host_docker_internal_mapped' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.expected_auth_provider' "$output_json")" != "openai-codex" ]] || \
        [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.auth_validation_path' "$output_json")" != "status" ]]; then
         test_fail "Runtime attestation success output does not reflect the expected provenance details"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    test_start "component_runtime_attestation_fails_when_browser_socket_gid_mismatches_live_groups"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        FAKE_CONTAINER_GROUP_IDS="1001 1000" \
+        FAKE_DOCKER_SOCKET_GID="999" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" >"$output_json" 2>"$fixture_root/stderr-browser-gid.log"
+    exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "BROWSER_DOCKER_SOCKET_GID_MISMATCH")' "$output_json" >/dev/null 2>&1; then
+        test_fail "Runtime attestation should fail when the docker.sock gid is not present in the live Moltis process groups"
         rm -rf "$fixture_root"
         return
     fi
@@ -285,7 +347,8 @@ EOF
     "Mounts": [
       {"Destination": "/server", "Source": "$fixture_root/untracked-root", "RW": false},
       {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
-      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true}
+      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true},
+      {"Destination": "/var/run/docker.sock", "Source": "$fixture_root/docker.sock", "RW": false}
     ]
   }
 ]
@@ -324,7 +387,8 @@ EOF
     "Mounts": [
       {"Destination": "/server", "Source": "$workspace_root", "RW": false},
       {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
-      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true}
+      {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true},
+      {"Destination": "/var/run/docker.sock", "Source": "$fixture_root/docker.sock", "RW": false}
     ]
   }
 ]

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -101,6 +101,19 @@ run_static_config_validation_tests() {
         test_fail "Moltis compose files must mount the tracked checkout as /server and use it as the working directory for live skill visibility"
     fi
 
+    test_start "static_moltis_browser_docker_contract_declares_host_gateway_and_socket_gid_alignment"
+    if rg -q 'group_add:' "$COMPOSE_PROD" && \
+       rg -q 'DOCKER_SOCKET_GID' "$COMPOSE_PROD" && \
+       rg -q 'host\.docker\.internal:host-gateway' "$COMPOSE_PROD" && \
+       rg -q 'group_add:' "$PROJECT_ROOT/docker-compose.yml" && \
+       rg -q 'DOCKER_SOCKET_GID' "$PROJECT_ROOT/docker-compose.yml" && \
+       rg -q 'host\.docker\.internal:host-gateway' "$PROJECT_ROOT/docker-compose.yml" && \
+       rg -q 'container_host = "host\.docker\.internal"' "$TOML_CONFIG"; then
+        test_pass
+    else
+        test_fail "Moltis browser Docker contract must align docker.sock gid access, provide host-gateway routing, and pin container_host away from 127.0.0.1"
+    fi
+
     test_start "static_compose_clawdiy_valid"
     if env CLAWDIY_IMAGE="ghcr.io/openclaw/openclaw:2026.3.11" docker compose -f "$COMPOSE_CLAWDIY" config --quiet >/dev/null 2>&1; then
         test_pass
@@ -137,6 +150,13 @@ PY
         test_pass
     else
         test_fail "Primary Moltis identity prompt must fail closed against internal activity/tool-progress leakage in Telegram and other user-facing messaging channels"
+    fi
+
+    test_start "static_browser_config_declares_container_host_for_docker_runtime"
+    if rg -Fq 'container_host = "host.docker.internal"' "$TOML_CONFIG"; then
+        test_pass
+    else
+        test_fail "Primary Moltis browser config must declare host-gateway container_host when Moltis itself runs in Docker"
     fi
 
     test_start "static_moltis_version_helper_enforces_tracked_nonlatest_version"
@@ -184,6 +204,16 @@ PY
         test_pass
     else
         test_fail "Authoritative Telegram remote UAT must fail on verification gates, internal activity leaks, contaminated pre-send activity, and /status model mismatches"
+    fi
+
+    test_start "static_runtime_attestation_and_deploy_guard_browser_sandbox_contract"
+    if rg -Fq 'BROWSER_DOCKER_SOCKET_GID_MISMATCH' "$RUNTIME_ATTESTATION_SCRIPT" && \
+       rg -Fq 'BROWSER_CONTAINER_HOST_INVALID' "$RUNTIME_ATTESTATION_SCRIPT" && \
+       rg -Fq 'read_toml_key' "$RUNTIME_ATTESTATION_SCRIPT" && \
+       rg -Fq 'DOCKER_SOCKET_GID' "$DEPLOY_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Runtime attestation and deploy control plane must guard the Docker browser sandbox contract before production traffic hits Telegram"
     fi
 
     test_start "static_config_has_no_hardcoded_secrets"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -247,8 +247,11 @@ test_deploy_script_verifies_live_moltis_runtime_contract() {
        ! grep -Fq "/server mount is missing" "$PROJECT_ROOT/scripts/deploy.sh" || \
        ! grep -Fq "/server/skills" "$PROJECT_ROOT/scripts/deploy.sh" || \
        ! grep -Fq "MOLTIS_RUNTIME_CONFIG_DIR" "$PROJECT_ROOT/scripts/deploy.sh" || \
-       ! grep -Fq "provider_keys.json.tmp.contract-check" "$PROJECT_ROOT/scripts/deploy.sh"; then
-        test_fail "deploy.sh must verify /server visibility, runtime config mount source, and writable runtime config behavior for Moltis"
+       ! grep -Fq "provider_keys.json.tmp.contract-check" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "DOCKER_SOCKET_GID" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "mounted docker.sock gid is not present" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "host.docker.internal is not mapped" "$PROJECT_ROOT/scripts/deploy.sh"; then
+        test_fail "deploy.sh must verify /server visibility, runtime config mount source, writable runtime config behavior, and the browser sandbox Docker contract for Moltis"
         return
     fi
 


### PR DESCRIPTION
## Summary
- align containerized Moltis browser sandbox with the official sibling-container contract
- pass the live docker.sock numeric GID into compose and verify it during deploy/attestation
- add host-gateway browser routing plus regression coverage and RCA

## Verification
- bash -n scripts/deploy.sh
- bash -n scripts/moltis-runtime-attestation.sh
- bash tests/component/test_moltis_runtime_attestation.sh
- bash tests/unit/test_deploy_workflow_guards.sh
- bash tests/static/test_config_validation.sh