### PR TITLE
fix(beads): preserve hook bootstrap source

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -13,21 +13,22 @@ auto_localize_beads_state() {
   local localize_output=""
   local state=""
   local action=""
-  local bootstrap_source="origin/main"
+  local requested_bootstrap_source="origin/main"
 
   [[ -x "${BEADS_LOCALIZE_SCRIPT}" ]] || return 0
 
   set +e
-  check_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --format env --bootstrap-source "${bootstrap_source}" 2>/dev/null)"
+  check_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --format env --bootstrap-source "${requested_bootstrap_source}" 2>/dev/null)"
   check_rc=$?
   set -e
 
   if [[ "${check_rc}" -eq 0 ]]; then
+    unset state action bootstrap_source
     eval "${check_output}"
     state="${state:-}"
     action="${action:-}"
     if [[ "${state}" == "migratable_legacy" || "${state}" == "partial_foundation" || "${state}" == "bootstrap_required" || "${action}" == "localize_in_place" || "${action}" == "rebuild_local_foundation" || "${action}" == "bootstrap_and_localize" ]]; then
-      if localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --bootstrap-source "${bootstrap_source}" 2>&1)"; then
+      if localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --bootstrap-source "${requested_bootstrap_source}" 2>&1)"; then
         printf '%s\n' "${localize_output}" >&2
       else
         printf '%s\n' "${localize_output}" >&2
@@ -38,7 +39,7 @@ auto_localize_beads_state() {
 
   if [[ "${check_rc}" -eq 23 ]]; then
     set +e
-    localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --bootstrap-source "${bootstrap_source}" 2>&1)"
+    localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --bootstrap-source "${requested_bootstrap_source}" 2>&1)"
     set -e
     printf '%s\n' "${localize_output}" >&2
     echo "[beads] automatic localization skipped: this worktree still needs manual Beads repair." >&2

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -13,21 +13,22 @@ auto_localize_beads_state() {
   local localize_output=""
   local state=""
   local action=""
-  local bootstrap_source="origin/main"
+  local requested_bootstrap_source="origin/main"
 
   [[ -x "${BEADS_LOCALIZE_SCRIPT}" ]] || return 0
 
   set +e
-  check_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --format env --bootstrap-source "${bootstrap_source}" 2>/dev/null)"
+  check_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --format env --bootstrap-source "${requested_bootstrap_source}" 2>/dev/null)"
   check_rc=$?
   set -e
 
   if [[ "${check_rc}" -eq 0 ]]; then
+    unset state action bootstrap_source
     eval "${check_output}"
     state="${state:-}"
     action="${action:-}"
     if [[ "${state}" == "migratable_legacy" || "${state}" == "partial_foundation" || "${state}" == "bootstrap_required" || "${action}" == "localize_in_place" || "${action}" == "rebuild_local_foundation" || "${action}" == "bootstrap_and_localize" ]]; then
-      if localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --bootstrap-source "${bootstrap_source}" 2>&1)"; then
+      if localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --bootstrap-source "${requested_bootstrap_source}" 2>&1)"; then
         printf '%s\n' "${localize_output}" >&2
       else
         printf '%s\n' "${localize_output}" >&2
@@ -38,7 +39,7 @@ auto_localize_beads_state() {
 
   if [[ "${check_rc}" -eq 23 ]]; then
     set +e
-    localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --bootstrap-source "${bootstrap_source}" 2>&1)"
+    localize_output="$("${BEADS_LOCALIZE_SCRIPT}" --path "${PROJECT_ROOT}" --check --bootstrap-source "${requested_bootstrap_source}" 2>&1)"
     set -e
     printf '%s\n' "${localize_output}" >&2
     echo "[beads] automatic localization skipped: this worktree still needs manual Beads repair." >&2

--- a/docs/rca/2026-03-27-beads-hook-bootstrap-source-clobber.md
+++ b/docs/rca/2026-03-27-beads-hook-bootstrap-source-clobber.md
@@ -1,0 +1,62 @@
+---
+title: "Git hooks clobbered their own bootstrap-source contract after eval of helper env output"
+date: 2026-03-27
+severity: P1
+category: process
+tags: [beads, git-hooks, worktree, bootstrap, rca]
+root_cause: "The tracked git hooks reused the variable name `bootstrap_source` both for the operator-requested source ref and for helper-emitted env output. After `eval` of `scripts/beads-worktree-localize.sh --format env`, the hook overwrote its own requested source ref with `bootstrap_source=''` from helper output and then called the mutating localize step with an empty required argument."
+---
+
+# RCA: Git hooks clobbered their own bootstrap-source contract after eval of helper env output
+
+Date: 2026-03-27  
+Context: fresh managed worktree creation emitted `[beads-worktree-localize] --bootstrap-source requires a value` even though the hook source looked like it always passed `origin/main`
+
+## Error
+
+Fresh worktree creation through `scripts/worktree-phase-a.sh create-from-base` produced a false bootstrap error during `post-checkout`:
+
+```text
+[beads-worktree-localize] --bootstrap-source requires a value
+```
+
+The worktree could still end up healthy, which made the failure noisy, misleading, and hard to trust.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Why did the hook claim `--bootstrap-source` was missing? | Because the mutating localize call was made with an empty `--bootstrap-source` value. |
+| 2 | Why was that value empty if the hook initialized it to `origin/main`? | Because the hook later ran `eval` on helper env output that included `bootstrap_source=''`. |
+| 3 | Why did `eval` overwrite the hook's own variable? | Because both the hook and the helper used the same variable name, `bootstrap_source`, in the same shell scope. |
+| 4 | Why did that turn into a user-visible worktree error? | Because the hook reused the clobbered variable for the second localize call instead of preserving the operator-requested source ref separately. |
+| 5 | Why did this survive earlier hardening? | Because tests covered the helper contract and runtime repair paths, but did not cover hook behavior when helper env output reused operator-facing variable names. |
+
+## Root Cause
+
+The git hook implementation mixed two different data channels into one shell variable name:
+
+- operator intent: the requested bootstrap source ref (`origin/main`)
+- helper env contract: `bootstrap_source` emitted by `beads-worktree-localize.sh`
+
+Once `eval` imported the helper output, the hook lost its requested source ref and passed an empty required value into the next localize call.
+
+## Fixes Applied
+
+1. Renamed the hook-owned variable to `requested_bootstrap_source` in:
+   - `.githooks/post-checkout`
+   - `.githooks/post-merge`
+2. Explicitly `unset` helper-owned env variable names before `eval` to keep the hook state predictable.
+3. Added unit regression coverage in `tests/unit/test_beads_git_hooks.sh`.
+4. Registered the new regression in `tests/run.sh` under the `component` lane.
+
+## Prevention
+
+1. Do not reuse helper env keys as operator-owned shell variables in hooks or shell orchestration.
+2. Treat `eval` of helper `key=value` output as a contract boundary and namespace caller-owned variables separately.
+3. Any hook that reuses helper env output must have at least one regression that proves a required caller argument survives the `eval` step.
+
+## Related Lessons
+
+- `docs/rca/2026-03-26-worktree-create-misread-local-ownership-as-runtime-ready.md`
+- `docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md`

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -175,6 +175,7 @@ bash|component_codex_cli_update_delivery|Codex CLI update delivery component|$SC
 bash|component_codex_profile_launch|Codex profile launch component|$SCRIPT_DIR/component/test_codex_profile_launch.sh
 bash|component_codex_session_path_repair|Codex session path repair component|$SCRIPT_DIR/component/test_codex_session_path_repair.sh
 bash|component_beads_worktree_audit|Beads worktree audit component|$SCRIPT_DIR/unit/test_beads_worktree_audit.sh
+bash|component_beads_git_hooks|Beads git hook bootstrap-source component|$SCRIPT_DIR/unit/test_beads_git_hooks.sh
 bash|component_deploy_workflow_guards|Deploy workflow guard component|$SCRIPT_DIR/unit/test_deploy_workflow_guards.sh
 bash|component_codex_advisory_e2e|Codex advisory E2E component|$SCRIPT_DIR/component/test_codex_advisory_e2e.sh
 bash|component_codex_telegram_consent_e2e|Codex Telegram consent E2E component|$SCRIPT_DIR/component/test_codex_telegram_consent_e2e.sh

--- a/tests/unit/test_beads_git_hooks.sh
+++ b/tests/unit/test_beads_git_hooks.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+source "$SCRIPT_DIR/../lib/git_topology_fixture.sh"
+
+copy_hook_assets() {
+    local repo_dir="$1"
+
+    mkdir -p "${repo_dir}/.githooks" "${repo_dir}/scripts"
+    cp "${PROJECT_ROOT}/.githooks/_repo-local-path.sh" "${repo_dir}/.githooks/_repo-local-path.sh"
+    cp "${PROJECT_ROOT}/.githooks/post-checkout" "${repo_dir}/.githooks/post-checkout"
+    cp "${PROJECT_ROOT}/.githooks/post-merge" "${repo_dir}/.githooks/post-merge"
+    chmod +x \
+        "${repo_dir}/.githooks/_repo-local-path.sh" \
+        "${repo_dir}/.githooks/post-checkout" \
+        "${repo_dir}/.githooks/post-merge"
+}
+
+write_fake_localize_script() {
+    local repo_dir="$1"
+
+    cat > "${repo_dir}/scripts/beads-worktree-localize.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_path=""
+output_format="human"
+check_only="false"
+bootstrap_source="__unset__"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path)
+      target_path="${2:-}"
+      shift 2
+      ;;
+    --format)
+      output_format="${2:-}"
+      shift 2
+      ;;
+    --check)
+      check_only="true"
+      shift
+      ;;
+    --bootstrap-source)
+      bootstrap_source="${2:-}"
+      if [[ -z "${bootstrap_source}" ]]; then
+        echo "[fake-localize] --bootstrap-source requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ "${check_only}" == "true" && "${output_format}" == "env" ]]; then
+  printf 'schema=%q\n' "beads-localize/v1"
+  printf 'worktree=%q\n' "${target_path}"
+  printf 'state=%q\n' "partial_foundation"
+  printf 'action=%q\n' "rebuild_local_foundation"
+  printf 'db_path=%q\n' "${target_path}/.beads/dolt"
+  printf 'message=%q\n' "fixture"
+  printf 'notice=%q\n' ""
+  printf 'bootstrap_source=%q\n' ""
+  exit 0
+fi
+
+if [[ "${bootstrap_source}" == "__unset__" ]]; then
+  echo "[fake-localize] expected --bootstrap-source on the mutation call" >&2
+  exit 2
+fi
+
+printf 'applied bootstrap_source=%s\n' "${bootstrap_source}"
+EOF
+
+    cat > "${repo_dir}/scripts/git-topology-registry.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+
+    chmod +x \
+        "${repo_dir}/scripts/beads-worktree-localize.sh" \
+        "${repo_dir}/scripts/git-topology-registry.sh"
+}
+
+prepare_hook_fixture_repo() {
+    local fixture_root="$1"
+    local repo_dir=""
+
+    repo_dir="$(git_topology_fixture_create_named_repo "${fixture_root}" "hook-fixture")"
+    copy_hook_assets "${repo_dir}"
+    write_fake_localize_script "${repo_dir}"
+
+    (
+        cd "${repo_dir}"
+        git config core.hooksPath .githooks
+    )
+
+    printf '%s\n' "${repo_dir}"
+}
+
+assert_not_contains_text() {
+    local haystack="$1"
+    local needle="$2"
+    local message="$3"
+
+    if printf '%s\n' "${haystack}" | rg -q --fixed-strings -- "${needle}"; then
+        test_fail "${message}"
+    fi
+}
+
+run_hook_script() {
+    local repo_dir="$1"
+    local hook_name="$2"
+
+    (
+        cd "${repo_dir}"
+        "./.githooks/${hook_name}" 2>&1
+    )
+}
+
+test_post_checkout_hook_preserves_requested_bootstrap_source() {
+    test_start "beads_git_hooks_post_checkout_preserves_requested_bootstrap_source"
+
+    local fixture_root repo_dir output rc
+    fixture_root="$(mktemp -d /tmp/beads-git-hooks-unit.XXXXXX)"
+    repo_dir="$(prepare_hook_fixture_repo "${fixture_root}")"
+
+    output="$(
+        set +e
+        run_hook_script "${repo_dir}" "post-checkout"
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "${rc}" "Post-checkout hook should stay non-blocking when helper env output includes bootstrap_source=''"
+    assert_contains "${output}" 'applied bootstrap_source=origin/main' "Post-checkout hook should preserve its requested bootstrap source after eval"
+    assert_not_contains_text "${output}" '--bootstrap-source requires a value' "Post-checkout hook must not clobber bootstrap_source from helper env output"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_post_merge_hook_preserves_requested_bootstrap_source() {
+    test_start "beads_git_hooks_post_merge_preserves_requested_bootstrap_source"
+
+    local fixture_root repo_dir output rc
+    fixture_root="$(mktemp -d /tmp/beads-git-hooks-unit.XXXXXX)"
+    repo_dir="$(prepare_hook_fixture_repo "${fixture_root}")"
+
+    output="$(
+        set +e
+        run_hook_script "${repo_dir}" "post-merge"
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "${rc}" "Post-merge hook should stay non-blocking when helper env output includes bootstrap_source=''"
+    assert_contains "${output}" 'applied bootstrap_source=origin/main' "Post-merge hook should preserve its requested bootstrap source after eval"
+    assert_not_contains_text "${output}" '--bootstrap-source requires a value' "Post-merge hook must not clobber bootstrap_source from helper env output"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+run_all_tests() {
+    start_timer
+
+    if [[ "${OUTPUT_JSON}" != "true" ]]; then
+        echo ""
+        echo "========================================="
+        echo "  Beads Git Hook Unit Tests"
+        echo "========================================="
+        echo ""
+    fi
+
+    test_post_checkout_hook_preserves_requested_bootstrap_source
+    test_post_merge_hook_preserves_requested_bootstrap_source
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_all_tests
+fi


### PR DESCRIPTION
## Summary
- preserve caller-owned bootstrap source in `.githooks/post-checkout` and `.githooks/post-merge`
- avoid helper env variable clobber when `beads-worktree-localize --check --format env` returns `bootstrap_source=''`
- add regression coverage for both hooks and record the RCA

## Validation
- `bash tests/unit/test_beads_git_hooks.sh`
- `bash tests/unit/test_worktree_phase_a.sh`
- `./tests/run.sh --lane component --filter component_beads_git_hooks`
- live repro: `scripts/worktree-phase-a.sh create-from-base` no longer emits `--bootstrap-source requires a value`

## Follow-up
- preserved broken lane repair remains separate: `moltinger-main-beads-runtime-bootstrap-root-cause-fix-1ki`
