### PR TITLE
fix(beads): rebuild unhealthy local runtimes in place

### DIFF
--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -11,6 +11,10 @@ BEADS_RESOLVE_MESSAGE=""
 BEADS_RESOLVE_RECOVERY_HINT=""
 BEADS_RESOLVE_ROOT_CLEANUP_NOTICE=""
 BEADS_RESOLVE_EXIT_CODE=0
+BEADS_RESOLVE_LAST_BD_OUTPUT=""
+BEADS_RESOLVE_LAST_BD_RC=0
+BEADS_RESOLVE_LAST_BD_TIMED_OUT="false"
+BEADS_RESOLVE_RUNTIME_PROBE_STATE="not_run"
 
 beads_resolve_usage() {
   cat <<'EOF'
@@ -517,6 +521,9 @@ beads_resolve_dispatch() {
   local has_local_runtime="false"
   local has_runtime_shell="false"
   local recovery_hint=""
+  local runtime_probe_state="not_run"
+  local runtime_recovery_hint=""
+  local runtime_repair_detail=""
   local root_cleanup_notice=""
   local migration_mode=""
   local migration_review_command=""
@@ -610,6 +617,17 @@ beads_resolve_dispatch() {
   if beads_resolve_has_runtime_shell "${beads_dir}"; then
     has_runtime_shell="true"
   fi
+  if [[ "${has_local_runtime}" == "true" ]]; then
+    beads_resolve_probe_local_runtime_health "${repo_root}" || true
+    runtime_probe_state="${BEADS_RESOLVE_RUNTIME_PROBE_STATE:-not_run}"
+  fi
+  if [[ -f "${issues_path}" ]]; then
+    runtime_recovery_hint="./scripts/beads-worktree-localize.sh --path $(printf '%q' "${repo_root}")"
+    runtime_repair_detail="Repair the local runtime in place from the tracked local foundation."
+  else
+    runtime_recovery_hint="/usr/local/bin/bd doctor --json && bd bootstrap"
+    runtime_repair_detail="Tracked .beads/issues.jsonl is retired here; repair the local runtime instead of restoring JSONL."
+  fi
 
   if [[ -f "${redirect_path}" ]]; then
     redirect_target="$(cat "${redirect_path}")"
@@ -647,6 +665,21 @@ beads_resolve_dispatch() {
     return 0
   fi
 
+  if [[ "${runtime_probe_state}" == "unhealthy" ]]; then
+    if beads_resolve_is_runtime_repair_command "$@"; then
+      beads_resolve_set_decision "allow_explicit_troubleshooting" "runtime_repair" 0
+      return 0
+    fi
+
+    beads_resolve_set_decision \
+      "block_missing_foundation" \
+      "$( [[ ! -f "${issues_path}" ]] && printf '%s' "runtime_only_worktree" || printf '%s' "dedicated_worktree" )" \
+      25 \
+      "bd: local Beads runtime exists in ${repo_root}, but plain bd cannot read it safely yet. ${runtime_repair_detail}" \
+      "${runtime_recovery_hint}"
+    return 0
+  fi
+
   if [[ "${has_local_runtime}" != "true" && "${has_runtime_shell}" == "true" ]]; then
     if beads_resolve_is_runtime_repair_command "$@"; then
       beads_resolve_set_decision "allow_explicit_troubleshooting" "runtime_repair" 0
@@ -657,8 +690,8 @@ beads_resolve_dispatch() {
       "block_missing_foundation" \
       "$( [[ ! -f "${issues_path}" ]] && printf '%s' "runtime_only_worktree" || printf '%s' "dedicated_worktree" )" \
       25 \
-      "bd: local Dolt-backed Beads runtime is incomplete in ${repo_root}. A runtime shell exists, but the named 'beads' database is not materialized yet. $( [[ ! -f "${issues_path}" ]] && printf '%s' "Tracked .beads/issues.jsonl is retired here; repair the local runtime instead of restoring JSONL." || printf '%s' "Repair the local runtime in place instead of rebuilding it from legacy artifacts." )" \
-      "/usr/local/bin/bd doctor --json && bd bootstrap"
+      "bd: local Dolt-backed Beads runtime is incomplete in ${repo_root}. A runtime shell exists, but the named 'beads' database is not materialized yet. ${runtime_repair_detail}" \
+      "${runtime_recovery_hint}"
     return 0
   fi
 
@@ -753,6 +786,105 @@ beads_resolve_find_system_bd() {
   return 1
 }
 
+beads_resolve_run_system_bd_probe() {
+  local repo_root="$1"
+  local capture_stderr="$2"
+  shift 2
+
+  local timeout_seconds="${BEADS_RESOLVE_BD_TIMEOUT_SECONDS:-8}"
+  local command_path=""
+  local stdout_file=""
+  local stderr_file=""
+  local timed_out_file=""
+  local command_pid=""
+  local watchdog_pid=""
+  local rc=0
+  local output=""
+
+  if [[ -z "${repo_root}" || ! -d "${repo_root}" ]]; then
+    return 1
+  fi
+
+  command_path="$(beads_resolve_find_system_bd "${repo_root}/bin/bd")" || return 1
+
+  stdout_file="$(mktemp)"
+  stderr_file="$(mktemp)"
+  timed_out_file="$(mktemp)"
+
+  (
+    cd "${repo_root}"
+    "${command_path}" "$@" >"${stdout_file}" 2>"${stderr_file}"
+  ) &
+  command_pid=$!
+
+  (
+    sleep "${timeout_seconds}"
+    if kill -0 "${command_pid}" 2>/dev/null; then
+      printf 'true\n' >"${timed_out_file}"
+      kill -TERM "${command_pid}" 2>/dev/null || true
+      sleep 1
+      kill -KILL "${command_pid}" 2>/dev/null || true
+    fi
+  ) &
+  watchdog_pid=$!
+
+  set +e
+  wait "${command_pid}"
+  rc=$?
+  set -e
+
+  kill "${watchdog_pid}" 2>/dev/null || true
+  wait "${watchdog_pid}" 2>/dev/null || true
+
+  BEADS_RESOLVE_LAST_BD_OUTPUT="$(cat "${stdout_file}")"
+  if [[ "${capture_stderr}" == "true" ]]; then
+    output="$(cat "${stderr_file}")"
+    if [[ -n "${output}" ]]; then
+      if [[ -n "${BEADS_RESOLVE_LAST_BD_OUTPUT}" ]]; then
+        BEADS_RESOLVE_LAST_BD_OUTPUT+=$'\n'
+      fi
+      BEADS_RESOLVE_LAST_BD_OUTPUT+="${output}"
+    fi
+  fi
+
+  BEADS_RESOLVE_LAST_BD_TIMED_OUT="false"
+  BEADS_RESOLVE_LAST_BD_RC="${rc}"
+  if [[ -s "${timed_out_file}" ]]; then
+    BEADS_RESOLVE_LAST_BD_TIMED_OUT="true"
+    BEADS_RESOLVE_LAST_BD_RC=124
+  fi
+
+  rm -f "${stdout_file}" "${stderr_file}" "${timed_out_file}"
+  return 0
+}
+
+beads_resolve_probe_local_runtime_health() {
+  local repo_root="$1"
+
+  BEADS_RESOLVE_RUNTIME_PROBE_STATE="not_run"
+  BEADS_RESOLVE_LAST_BD_OUTPUT=""
+  BEADS_RESOLVE_LAST_BD_RC=0
+  BEADS_RESOLVE_LAST_BD_TIMED_OUT="false"
+
+  if ! beads_resolve_run_system_bd_probe "${repo_root}" true status; then
+    BEADS_RESOLVE_RUNTIME_PROBE_STATE="unavailable"
+    return 1
+  fi
+
+  if [[ "${BEADS_RESOLVE_LAST_BD_TIMED_OUT}" == "true" ]]; then
+    BEADS_RESOLVE_RUNTIME_PROBE_STATE="unavailable"
+    return 0
+  fi
+
+  if [[ "${BEADS_RESOLVE_LAST_BD_RC}" -eq 0 ]]; then
+    BEADS_RESOLVE_RUNTIME_PROBE_STATE="healthy"
+  else
+    BEADS_RESOLVE_RUNTIME_PROBE_STATE="unhealthy"
+  fi
+
+  return 0
+}
+
 beads_resolve_render_env() {
   printf 'schema=%q\n' "${BEADS_RESOLVE_SCHEMA}"
   printf 'decision=%q\n' "${BEADS_RESOLVE_DECISION}"
@@ -803,6 +935,7 @@ beads_localize_worktree() {
   local recovery_path=""
   local artifact=""
   local has_local_runtime="false"
+  local runtime_probe_state="not_run"
   local -a stale_runtime_artifacts=(
     "metadata.json"
     "interactions.jsonl"
@@ -823,9 +956,11 @@ beads_localize_worktree() {
 
   if beads_resolve_has_local_runtime "${repo_root}/.beads"; then
     has_local_runtime="true"
+    beads_resolve_probe_local_runtime_health "${repo_root}" || true
+    runtime_probe_state="${BEADS_RESOLVE_RUNTIME_PROBE_STATE:-not_run}"
   fi
 
-  if [[ -f "${current_config}" && "${has_local_runtime}" == "true" && ! -f "${current_issues}" && ! -f "${current_redirect}" ]]; then
+  if [[ -f "${current_config}" && "${has_local_runtime}" == "true" && "${runtime_probe_state}" != "unhealthy" && ! -f "${current_issues}" && ! -f "${current_redirect}" ]]; then
     if [[ "${output_format}" == "env" ]]; then
       printf 'result=%q\n' "post_migration_runtime_only"
       printf 'repo_root=%q\n' "${repo_root}"
@@ -844,7 +979,7 @@ beads_localize_worktree() {
     beads_resolve_die "Cannot localize ${repo_root}: tracked .beads/config.yaml and .beads/issues.jsonl must exist locally first."
   fi
 
-  if [[ "${has_local_runtime}" == "true" && ! -f "${current_redirect}" ]]; then
+  if [[ "${has_local_runtime}" == "true" && "${runtime_probe_state}" != "unhealthy" && ! -f "${current_redirect}" ]]; then
     if [[ "${output_format}" == "env" ]]; then
       printf 'result=%q\n' "already_local"
       printf 'repo_root=%q\n' "${repo_root}"
@@ -865,7 +1000,7 @@ beads_localize_worktree() {
 
   system_bd="${BEADS_SYSTEM_BD:-}"
   if [[ -z "${system_bd}" ]]; then
-    system_bd="$(beads_resolve_find_system_bd "${DEFAULT_REPO_ROOT}/bin/bd")" || {
+    system_bd="$(beads_resolve_find_system_bd "${repo_root}/bin/bd")" || {
       beads_resolve_die "Could not find the system bd binary needed for localization."
     }
   fi
@@ -873,8 +1008,9 @@ beads_localize_worktree() {
   timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
   recovery_dir="${repo_root}/.beads/recovery"
 
-  if [[ ! -d "${current_dolt}/beads" && ! -d "${current_dolt}/beads/.dolt" ]] && \
-     [[ -d "${current_dolt}" || -e "${repo_root}/.beads/metadata.json" || -e "${repo_root}/.beads/interactions.jsonl" ]]; then
+  if [[ "${runtime_probe_state}" == "unhealthy" ]] || \
+     ([[ ! -d "${current_dolt}/beads" && ! -d "${current_dolt}/beads/.dolt" ]] && \
+      [[ -d "${current_dolt}" || -e "${repo_root}/.beads/metadata.json" || -e "${repo_root}/.beads/interactions.jsonl" ]]); then
     recovery_path="${recovery_dir}/runtime-pre-init-${timestamp}"
     mkdir -p "${recovery_path}"
     if [[ -d "${current_dolt}" ]]; then

--- a/scripts/beads-worktree-localize.sh
+++ b/scripts/beads-worktree-localize.sh
@@ -44,6 +44,7 @@ report_db_path=""
 report_message=""
 report_notice=""
 report_bootstrap_source=""
+report_runtime_repair_mode=""
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -124,10 +125,12 @@ classify_state() {
   local active_migration_mode=""
   local has_local_runtime="false"
   local has_runtime_shell="false"
+  local runtime_probe_state="not_run"
 
   report_db_path="${db_path}"
   report_notice=""
   report_bootstrap_source=""
+  report_runtime_repair_mode=""
 
   if beads_resolve_has_local_runtime "${beads_dir}"; then
     has_local_runtime="true"
@@ -140,6 +143,10 @@ classify_state() {
     if [[ "${has_local_runtime}" != "true" && -d "${dolt_path}" ]]; then
       report_db_path="${dolt_path}"
     fi
+  fi
+  if [[ "${has_local_runtime}" == "true" ]]; then
+    beads_resolve_probe_local_runtime_health "${target_path}" || true
+    runtime_probe_state="${BEADS_RESOLVE_RUNTIME_PROBE_STATE:-not_run}"
   fi
 
   active_migration_mode="$(detect_active_migration_mode 2>/dev/null || true)"
@@ -181,14 +188,14 @@ classify_state() {
     return 0
   fi
 
-  if [[ -f "${config_path}" && -f "${issues_path}" && "${has_local_runtime}" == "true" ]]; then
+  if [[ -f "${config_path}" && -f "${issues_path}" && "${has_local_runtime}" == "true" && "${runtime_probe_state}" != "unhealthy" ]]; then
     report_state="current"
     report_action="none"
     report_message="This worktree already has localized Beads ownership."
     return 0
   fi
 
-  if [[ -f "${config_path}" && "${has_local_runtime}" == "true" && ! -f "${issues_path}" ]]; then
+  if [[ -f "${config_path}" && "${has_local_runtime}" == "true" && "${runtime_probe_state}" != "unhealthy" && ! -f "${issues_path}" ]]; then
     report_state="post_migration_runtime_only"
     report_action="none"
     report_message="Tracked .beads/issues.jsonl is already retired for this worktree; use the local Beads runtime as the backlog source of truth."
@@ -199,17 +206,23 @@ classify_state() {
   if [[ -f "${config_path}" && ! -f "${issues_path}" ]]; then
     report_state="runtime_bootstrap_required"
     report_action="stop_and_report"
+    report_runtime_repair_mode="bootstrap_only"
     report_message="Tracked .beads/issues.jsonl is already retired for this worktree, but the local Dolt-backed Beads runtime is incomplete."
     report_notice="Run /usr/local/bin/bd doctor --json first, then bd bootstrap. Do not restore JSONL."
     return 0
   fi
 
   if [[ -f "${config_path}" && -f "${issues_path}" ]]; then
-    if [[ "${has_runtime_shell}" == "true" ]]; then
+    if [[ "${runtime_probe_state}" == "unhealthy" || "${has_runtime_shell}" == "true" ]]; then
       report_state="runtime_bootstrap_required"
       report_action="stop_and_report"
-      report_message="A local Dolt-backed Beads runtime shell exists, but the named 'beads' database is not materialized yet."
-      report_notice="Run /usr/local/bin/bd doctor --json first, then bd bootstrap. Do not rebuild from JSONL or restore retired tracker files."
+      report_runtime_repair_mode="rebuild_local_foundation"
+      if [[ "${runtime_probe_state}" == "unhealthy" ]]; then
+        report_message="A local named 'beads' database exists on disk, but plain bd cannot read it safely yet."
+      else
+        report_message="A local Dolt-backed Beads runtime shell exists, but the named 'beads' database is not materialized yet."
+      fi
+      report_notice="Run ./scripts/beads-worktree-localize.sh --path . to quarantine the partial runtime, bootstrap a fresh named DB, and reimport the tracked local backlog."
       return 0
     fi
 
@@ -259,6 +272,7 @@ materialize_local_db() {
   local recovery_path=""
   local timestamp=""
   local artifact=""
+  local runtime_probe_state="not_run"
   local -a stale_runtime_artifacts=(
     "metadata.json"
     "interactions.jsonl"
@@ -272,8 +286,14 @@ materialize_local_db() {
     system_bd="$(beads_resolve_find_system_bd "${REPO_ROOT}/bin/bd")" || die "Could not locate the system bd binary"
   fi
 
-  if [[ ! -d "${dolt_path}/beads" && ! -d "${dolt_path}/beads/.dolt" ]] && \
-     [[ -d "${dolt_path}" || -e "${beads_dir}/metadata.json" || -e "${beads_dir}/interactions.jsonl" ]]; then
+  if beads_resolve_has_local_runtime "${beads_dir}"; then
+    beads_resolve_probe_local_runtime_health "${target_path}" || true
+    runtime_probe_state="${BEADS_RESOLVE_RUNTIME_PROBE_STATE:-not_run}"
+  fi
+
+  if [[ "${runtime_probe_state}" == "unhealthy" ]] || \
+     ([[ ! -d "${dolt_path}/beads" && ! -d "${dolt_path}/beads/.dolt" ]] && \
+      [[ -d "${dolt_path}" || -e "${beads_dir}/metadata.json" || -e "${beads_dir}/interactions.jsonl" ]]); then
     timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
     recovery_path="${recovery_dir}/runtime-pre-init-${timestamp}"
     mkdir -p "${recovery_path}"
@@ -306,7 +326,11 @@ localize_state() {
       return 0
       ;;
     runtime_bootstrap_required)
-      return 1
+      if [[ "${report_runtime_repair_mode}" == "rebuild_local_foundation" ]]; then
+        materialize_local_db
+      else
+        return 1
+      fi
       ;;
     migratable_legacy)
       rm -f "${redirect_path}"
@@ -344,6 +368,7 @@ render_env() {
   printf 'message=%q\n' "${report_message}"
   printf 'notice=%q\n' "${report_notice}"
   printf 'bootstrap_source=%q\n' "${report_bootstrap_source}"
+  printf 'runtime_repair_mode=%q\n' "${report_runtime_repair_mode}"
 }
 
 render_human() {
@@ -354,6 +379,9 @@ render_human() {
   printf 'Message: %s\n' "${report_message}"
   if [[ -n "${report_bootstrap_source}" ]]; then
     printf 'Bootstrap Source: %s\n' "${report_bootstrap_source}"
+  fi
+  if [[ -n "${report_runtime_repair_mode}" ]]; then
+    printf 'Runtime Repair Mode: %s\n' "${report_runtime_repair_mode}"
   fi
   if [[ -n "${report_notice}" ]]; then
     printf 'Notice: %s\n' "${report_notice}"
@@ -366,7 +394,7 @@ main() {
   classify_state
 
   if [[ "${check_only}" != "true" ]]; then
-    if [[ "${report_action}" == "stop_and_report" ]]; then
+    if [[ "${report_action}" == "stop_and_report" && "${report_runtime_repair_mode}" != "rebuild_local_foundation" ]]; then
       render_human >&2
       exit 23
     fi

--- a/scripts/worktree-phase-a.sh
+++ b/scripts/worktree-phase-a.sh
@@ -136,19 +136,21 @@ phase_a_probe_localize_state() {
   phase_a_localize_action=""
   phase_a_localize_message=""
   phase_a_localize_notice=""
+  phase_a_localize_runtime_repair_mode=""
 
   set +e
   output="$("${SCRIPT_DIR}/beads-worktree-localize.sh" --check --format env --path "${worktree_path}" 2>/dev/null)"
   rc=$?
   set -e
 
-  unset schema worktree state action db_path message notice bootstrap_source
+  unset schema worktree state action db_path message notice bootstrap_source runtime_repair_mode
   eval "${output}"
 
   phase_a_localize_state="${state:-}"
   phase_a_localize_action="${action:-}"
   phase_a_localize_message="${message:-}"
   phase_a_localize_notice="${notice:-}"
+  phase_a_localize_runtime_repair_mode="${runtime_repair_mode:-}"
   return "${rc}"
 }
 
@@ -202,11 +204,16 @@ phase_a_prepare_beads_runtime() {
         if [[ "${bootstrap_attempted}" == "true" ]]; then
           phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
         fi
-        system_bd="$(phase_a_runtime_bootstrap_command)"
-        (
-          cd "${target_path}"
-          "${system_bd}" bootstrap >/dev/null
-        ) || phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
+        if [[ "${phase_a_localize_runtime_repair_mode}" == "rebuild_local_foundation" ]]; then
+          "${SCRIPT_DIR}/beads-worktree-localize.sh" --path "${target_path}" >/dev/null \
+            || phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
+        else
+          system_bd="$(phase_a_runtime_bootstrap_command)"
+          (
+            cd "${target_path}"
+            "${system_bd}" bootstrap >/dev/null
+          ) || phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
+        fi
         bootstrap_attempted="true"
         ;;
       *)

--- a/tests/unit/test_bd_dispatch.sh
+++ b/tests/unit/test_bd_dispatch.sh
@@ -45,8 +45,18 @@ fi
 
 if [[ "${args[0]:-}" == "import" ]]; then
   mkdir -p ".beads/dolt/beads/.dolt"
+  rm -f ".beads/dolt/beads/.fake-broken"
   : > ".beads/last-touched"
   printf 'IMPORTED=%s\n' "${args[1]:-}"
+  exit 0
+fi
+
+if [[ "${args[0]:-}" == "status" ]]; then
+  if [[ -e ".beads/dolt/beads/.fake-broken" ]]; then
+    printf 'Error: failed to open database: failed to initialize schema: failed to run dolt migrations: dolt migration "uuid_primary_keys" failed: migrate events to UUID PK: check column type: Error 1105 (HY000): no root value found in session\n' >&2
+    exit 1
+  fi
+  printf 'STATUS_OK\n'
   exit 0
 fi
 
@@ -146,6 +156,21 @@ EOF
 EOF
 }
 
+seed_unhealthy_named_runtime_foundation() {
+    local worktree_dir="$1"
+
+    mkdir -p "${worktree_dir}/.beads/dolt/beads/.dolt"
+    cat > "${worktree_dir}/.beads/config.yaml" <<'EOF'
+issue-prefix: "demo"
+auto-start-daemon: false
+EOF
+    cat > "${worktree_dir}/.beads/issues.jsonl" <<'EOF'
+{"id":"demo-1","title":"seed","status":"open","type":"task","priority":3}
+EOF
+    : > "${worktree_dir}/.beads/metadata.json"
+    : > "${worktree_dir}/.beads/dolt/beads/.fake-broken"
+}
+
 run_plain_bd() {
     local worktree_dir="$1"
     local fake_bin="$2"
@@ -197,6 +222,15 @@ assert_named_beads_runtime_present() {
     fi
     if [[ ! -f "${worktree_path}/.beads/last-touched" ]]; then
         test_fail "${message} (missing import marker)"
+    fi
+}
+
+assert_runtime_quarantine_present() {
+    local worktree_path="$1"
+    local message="$2"
+
+    if ! find "${worktree_path}/.beads/recovery" -maxdepth 2 -type d -name 'runtime-pre-init-*' | grep -q .; then
+        test_fail "${message} (missing runtime recovery backup)"
     fi
 }
 
@@ -575,8 +609,8 @@ test_localize_reports_runtime_bootstrap_required_for_broken_runtime_only_state()
     test_pass
 }
 
-test_plain_bd_blocks_broken_runtime_shell_with_bootstrap_guidance() {
-    test_start "plain_bd_blocks_broken_runtime_shell_with_bootstrap_guidance"
+test_plain_bd_blocks_broken_runtime_shell_with_localize_guidance() {
+    test_start "plain_bd_blocks_broken_runtime_shell_with_localize_guidance"
 
     local fixture_root repo_dir worktree_path fake_bin output rc
     fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
@@ -597,7 +631,7 @@ test_plain_bd_blocks_broken_runtime_shell_with_bootstrap_guidance() {
 
     assert_eq "25" "${rc}" "Runtime shell without a named beads DB must fail closed even when tracked JSONL still exists"
     assert_contains "${output}" "named 'beads' database is not materialized yet" "Dispatch must describe the missing named DB explicitly"
-    assert_contains "${output}" "bd bootstrap" "Dispatch must point operators to bootstrap repair for broken runtime shells"
+    assert_contains "${output}" "beads-worktree-localize.sh --path" "Dispatch must point operators to localized runtime rebuild when tracked foundation exists"
 
     rm -rf "${fixture_root}"
     test_pass
@@ -626,7 +660,8 @@ test_localize_reports_runtime_bootstrap_required_for_broken_runtime_shell() {
     assert_eq "23" "${rc}" "Localization helper must stop and report when a named DB is missing behind a Dolt runtime shell"
     assert_contains "${output}" "State: runtime_bootstrap_required" "Localization helper must expose runtime_bootstrap_required for broken runtime shells"
     assert_contains "${output}" "named 'beads' database is not materialized yet" "Localization helper must explain the named DB problem directly"
-    assert_contains "${output}" "bd bootstrap" "Localization helper must route broken runtime shells to bootstrap recovery"
+    assert_contains "${output}" "Runtime Repair Mode: rebuild_local_foundation" "Localization helper must expose the repairable rebuild mode for tracked foundation states"
+    assert_contains "${output}" "beads-worktree-localize.sh --path ." "Localization helper must route broken runtime shells to the in-place rebuild helper"
 
     rm -rf "${fixture_root}"
     test_pass
@@ -708,10 +743,10 @@ test_localize_bootstraps_missing_foundation_from_source_ref() {
     test_pass
 }
 
-test_localize_blocks_stale_dolt_shell_and_routes_to_bootstrap() {
-    test_start "localize_blocks_stale_dolt_shell_and_routes_to_bootstrap"
+test_localize_repairs_stale_dolt_shell_by_rebuilding_local_runtime() {
+    test_start "localize_repairs_stale_dolt_shell_by_rebuilding_local_runtime"
 
-    local fixture_root repo_dir worktree_path fake_bin output rc
+    local fixture_root repo_dir worktree_path fake_bin output
     fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
     repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
     seed_repo_local_bd_tools "${repo_dir}"
@@ -723,17 +758,65 @@ test_localize_blocks_stale_dolt_shell_and_routes_to_bootstrap() {
     : > "${worktree_path}/.beads/metadata.json"
     fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
 
+    output="$(run_localize "${worktree_path}" "${fake_bin}" --path "${worktree_path}")"
+
+    assert_contains "${output}" "State: current" "Localization should converge stale Dolt shells to a healthy localized state"
+    assert_named_beads_runtime_present "${worktree_path}" "Localization should rebuild stale runtime shells in place"
+    assert_runtime_quarantine_present "${worktree_path}" "Localization should preserve the stale runtime shell in recovery before rebuilding"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_plain_bd_blocks_unhealthy_named_runtime_with_localize_guidance() {
+    test_start "plain_bd_blocks_unhealthy_named_runtime_with_localize_guidance"
+
+    local fixture_root repo_dir worktree_path fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "${fixture_root}" "moltinger")"
+    seed_repo_local_bd_tools "${repo_dir}"
+    worktree_path="${fixture_root}/moltinger-unhealthy-named-runtime"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/unhealthy-named-runtime" "main"
+    worktree_path="$(canonicalize_path "${worktree_path}")"
+    seed_unhealthy_named_runtime_foundation "${worktree_path}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
     output="$(
         set +e
-        run_localize "${worktree_path}" "${fake_bin}" --path "${worktree_path}" 2>&1
+        run_plain_bd "${worktree_path}" "${fake_bin}" status 2>&1
         printf '\n__RC__=%s\n' "$?"
     )"
     rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
 
-    assert_eq "23" "${rc}" "Localization must fail closed when a stale Dolt shell hides a missing named beads DB"
-    assert_contains "${output}" "State: runtime_bootstrap_required" "Localization must classify stale shells as runtime_bootstrap_required"
-    assert_contains "${output}" "named 'beads' database is not materialized yet" "Localization must explain the missing named DB directly"
-    assert_contains "${output}" "bd bootstrap" "Localization must route stale-shell repair through bootstrap"
+    assert_eq "25" "${rc}" "Partially materialized named DBs must fail closed instead of passing through to plain bd"
+    assert_contains "${output}" "plain bd cannot read it safely yet" "Dispatch must explain that the local runtime exists but is unhealthy"
+    assert_contains "${output}" "beads-worktree-localize.sh --path" "Dispatch must route unhealthy named DBs through localized rebuild"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_localize_rebuilds_unhealthy_named_runtime_in_place() {
+    test_start "localize_rebuilds_unhealthy_named_runtime_in_place"
+
+    local fixture_root repo_dir worktree_path fake_bin output
+    fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "${fixture_root}" "moltinger")"
+    seed_repo_local_bd_tools "${repo_dir}"
+    worktree_path="${fixture_root}/moltinger-unhealthy-runtime-localize"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/unhealthy-runtime-localize" "main"
+    worktree_path="$(canonicalize_path "${worktree_path}")"
+    seed_unhealthy_named_runtime_foundation "${worktree_path}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    output="$(run_localize "${worktree_path}" "${fake_bin}" --path "${worktree_path}")"
+
+    assert_contains "${output}" "State: current" "Localization should converge unhealthy named DBs to a healthy localized state"
+    assert_named_beads_runtime_present "${worktree_path}" "Localization should reimport the tracked backlog after unhealthy runtime repair"
+    assert_runtime_quarantine_present "${worktree_path}" "Localization should quarantine the unhealthy runtime before rebuilding"
+    if [[ -e "${worktree_path}/.beads/dolt/beads/.fake-broken" ]]; then
+        test_fail "Localization should remove the unhealthy named DB marker during rebuild"
+    fi
 
     rm -rf "${fixture_root}"
     test_pass
@@ -765,11 +848,13 @@ run_all_tests() {
     test_localize_recognizes_post_migration_runtime_only_state
     test_plain_bd_blocks_broken_runtime_only_foundation_with_bootstrap_guidance
     test_localize_reports_runtime_bootstrap_required_for_broken_runtime_only_state
-    test_plain_bd_blocks_broken_runtime_shell_with_bootstrap_guidance
+    test_plain_bd_blocks_broken_runtime_shell_with_localize_guidance
     test_localize_reports_runtime_bootstrap_required_for_broken_runtime_shell
     test_localize_materializes_local_db_and_removes_redirect
     test_localize_bootstraps_missing_foundation_from_source_ref
-    test_localize_blocks_stale_dolt_shell_and_routes_to_bootstrap
+    test_localize_repairs_stale_dolt_shell_by_rebuilding_local_runtime
+    test_plain_bd_blocks_unhealthy_named_runtime_with_localize_guidance
+    test_localize_rebuilds_unhealthy_named_runtime_in_place
     generate_report
 }
 

--- a/tests/unit/test_worktree_phase_a.sh
+++ b/tests/unit/test_worktree_phase_a.sh
@@ -23,19 +23,28 @@ if [[ "${1:-}" == "--no-daemon" ]]; then
   shift
 fi
 
-if [[ "${1:-}" == "--db" ]]; then
-  db_path="${2:-}"
-  shift 2
-  if [[ "${1:-}" == "info" ]]; then
-    mkdir -p "$(dirname "${db_path}")"
-    : > "${db_path}"
-    exit 0
+  if [[ "${1:-}" == "--db" ]]; then
+    db_path="${2:-}"
+    shift 2
+    if [[ "${1:-}" == "info" ]]; then
+      mkdir -p "$(dirname "${db_path}")"
+      : > "${db_path}"
+      exit 0
+    fi
+    if [[ "${1:-}" == "import" ]]; then
+      mkdir -p .beads/dolt/beads/.dolt
+      rm -f .beads/dolt/beads/.fake-broken
+      : > .beads/last-touched
+      exit 0
+    fi
   fi
-  if [[ "${1:-}" == "import" ]]; then
-    mkdir -p .beads/dolt/beads/.dolt
-    : > .beads/last-touched
-    exit 0
+
+if [[ "${1:-}" == "status" ]]; then
+  if [[ -e ".beads/dolt/beads/.fake-broken" ]]; then
+    printf 'simulated broken named db\n' >&2
+    exit 1
   fi
+  exit 0
 fi
 
 if [[ "${1:-}" == "list" ]]; then
@@ -77,6 +86,16 @@ assert_file_missing() {
     if [[ -e "$path" ]]; then
         test_fail "$message (unexpected path: $path)"
     fi
+}
+
+seed_unhealthy_named_runtime_fixture() {
+    local repo_dir="$1"
+
+    mkdir -p "${repo_dir}/.beads/dolt/beads/.dolt"
+    printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
+    printf '{"id":"molt-1","title":"fixture"}\n' > "${repo_dir}/.beads/issues.jsonl"
+    printf '{"role":"maintainer"}\n' > "${repo_dir}/.beads/metadata.json"
+    : > "${repo_dir}/.beads/dolt/beads/.fake-broken"
 }
 
 test_phase_a_create_from_base_anchors_new_branch_to_main() {
@@ -207,6 +226,45 @@ test_phase_a_create_bootstraps_runtime_shell_when_named_db_missing() {
     test_pass
 }
 
+test_phase_a_create_rebuilds_unhealthy_named_runtime() {
+    test_start "worktree_phase_a_create_rebuilds_unhealthy_named_runtime"
+
+    local fixture_root repo_dir fake_bin target_path output
+    fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    target_path="${fixture_root}/moltinger-unhealthy-runtime"
+
+    mkdir -p "${repo_dir}/.beads"
+    seed_unhealthy_named_runtime_fixture "${repo_dir}"
+    (
+        cd "${repo_dir}"
+        git add .beads/config.yaml .beads/issues.jsonl .beads/metadata.json .beads/dolt/beads/.fake-broken
+        git commit -m "fixture: track unhealthy named runtime" >/dev/null
+    )
+
+    output="$(run_phase_a_create "$fake_bin" \
+        --canonical-root "$repo_dir" \
+        --base-ref main \
+        --branch feat/unhealthy-runtime \
+        --path "$target_path" \
+        --format env)"
+
+    assert_contains "$output" 'result=created_from_base' "Phase A should still succeed after rebuilding an unhealthy named runtime"
+    if [[ ! -f "${target_path}/.beads/last-touched" ]]; then
+        test_fail "Phase A should reimport tracked issues after unhealthy runtime repair"
+    fi
+    if [[ -e "${target_path}/.beads/dolt/beads/.fake-broken" ]]; then
+        test_fail "Phase A should not leave the unhealthy named runtime marker behind"
+    fi
+    if ! find "${target_path}/.beads/recovery" -maxdepth 2 -type d -name 'runtime-pre-init-*' | grep -q .; then
+        test_fail "Phase A should quarantine the unhealthy runtime before rebuilding it"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair() {
     test_start "worktree_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair"
 
@@ -264,6 +322,7 @@ run_all_tests() {
     test_phase_a_create_from_base_anchors_new_branch_to_main
     test_phase_a_create_blocks_existing_branch_on_wrong_base
     test_phase_a_create_bootstraps_runtime_shell_when_named_db_missing
+    test_phase_a_create_rebuilds_unhealthy_named_runtime
     test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair
     generate_report
 }


### PR DESCRIPTION
## Summary
- add a real runtime health probe to Beads repo-layer dispatch/localize flows
- treat partially materialized named DBs as unhealthy instead of silently accepting them as current
- rebuild repairable JSONL-backed runtimes in place via quarantine + bootstrap + import
- teach Phase A to use the localized rebuild path for repairable `runtime_bootstrap_required` states

## Validation
- `bash tests/unit/test_bd_dispatch.sh`
- `bash tests/unit/test_worktree_phase_a.sh`
- live preserved worktree recovery validated on `/Users/rl/coding/moltinger/moltinger-main-telegram-browser-tavily-timeout`

## Tracker
- `moltinger-main-beads-bootstrap-uuid-primary-keys-fix-n1q`
