### PR TITLE
fix: serialize Moltis recreate rollout

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,6 +30,7 @@ services:
     image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-0.10.18}
     container_name: moltis
     restart: unless-stopped
+    stop_grace_period: 45s
     working_dir: /server
 
     # Security: Drop all capabilities, add only what's needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-0.10.18}
     container_name: moltis
     restart: unless-stopped
+    stop_grace_period: 45s
     working_dir: /server
     # SECURITY: privileged mode required for Docker-in-Docker sandbox execution
     # See SECURITY NOTICE above for details

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -265,8 +265,10 @@ make logs
 # Check container status
 docker inspect moltis
 
-# Force recreate
-docker compose -p moltinger -f docker-compose.prod.yml up -d --force-recreate moltis
+# Safer recreate path for fixed-name Moltis container
+docker stop --time 45 moltis || true
+docker rm -f moltis || true
+docker compose -p moltinger -f docker-compose.prod.yml up -d moltis
 ```
 
 ### Health check failing

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-03-27
-**Total Lessons**: 52
+**Total Lessons**: 53
 
 ---
 
@@ -14,8 +14,9 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (22 lessons)
+#### P1 (23 lessons)
 - [Moltis repo-managed codex-update skill existed in git but never became a live runtime skill](../docs/rca/2026-03-27-moltis-repo-skill-discovery-contract-drift.md)
+- [Tracked Moltis deploy failed when docker compose force-recreate hit a slow-stop container race](../docs/rca/2026-03-27-moltis-deploy-force-recreate-race-on-slow-stop.md)
 - [Managed worktree creation misread local Beads ownership as runtime readiness](../docs/rca/2026-03-26-worktree-create-misread-local-ownership-as-runtime-ready.md)
 - [Beads worktree localization used stale bootstrap contracts and recreated the failure during Phase A](../docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md)
 - [Half-initialized Beads Dolt runtime was misclassified as a healthy local worktree state](../docs/rca/2026-03-24-beads-half-initialized-dolt-runtime-misclassified-as-healthy.md)
@@ -77,7 +78,8 @@
 ### By Category
 
 
-#### cicd (22 lessons)
+#### cicd (23 lessons)
+- [Tracked Moltis deploy failed when docker compose force-recreate hit a slow-stop container race](../docs/rca/2026-03-27-moltis-deploy-force-recreate-race-on-slow-stop.md)
 - [Tracked Moltis deploy cancelled by manual GitOps confirmation guard during CI workflow](../docs/rca/2026-03-20-tracked-moltis-deploy-cancelled-by-manual-gitops-guard.md)
 - [Tracked Moltis deploy failed because backup restore-check logs polluted deploy.sh JSON stdout contract](../docs/rca/2026-03-20-tracked-deploy-json-contract-broken-by-restore-check-stdout.md)
 - [Tracked Moltis deploy failed on legacy prometheus container-name conflict and opaque non-JSON failure envelope](../docs/rca/2026-03-20-tracked-deploy-failed-on-legacy-prometheus-container-name-conflict.md)
@@ -143,11 +145,11 @@
 ### Popular Tags
 
 - `gitops` (16 lessons)
+- `deploy` (14 lessons)
 - `github-actions` (13 lessons)
-- `deploy` (13 lessons)
-- `cicd` (11 lessons)
+- `cicd` (12 lessons)
+- `moltis` (11 lessons)
 - `rca` (10 lessons)
-- `moltis` (10 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
 - `git-worktree` (8 lessons)
@@ -160,8 +162,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 52 |
-| Critical (P0/P1) | 23 |
+| Total Lessons | 53 |
+| Critical (P0/P1) | 24 |
 | Categories | 5 |
 | Unique Tags | 120 |
 

--- a/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
+++ b/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
@@ -123,9 +123,14 @@ If the feature targets another version, replace the tag, but still pull it expli
 
 ## 6. Recreate the live container with the explicit version
 
+Do not rely on raw `up --force-recreate` against the existing fixed-name container.  
+First stop it with an extended grace window, then remove it, then create the new one:
+
 ```bash
 cd /opt/moltinger-active
-MOLTIS_VERSION=0.10.18 docker compose -p moltinger -f docker-compose.prod.yml up -d --force-recreate --no-deps moltis
+docker stop --time 45 moltis || true
+docker rm -f moltis || true
+MOLTIS_VERSION=0.10.18 docker compose -p moltinger -f docker-compose.prod.yml up -d --no-deps moltis
 ```
 
 Then verify immediately:

--- a/docs/rca/2026-03-27-moltis-deploy-force-recreate-race-on-slow-stop.md
+++ b/docs/rca/2026-03-27-moltis-deploy-force-recreate-race-on-slow-stop.md
@@ -1,0 +1,81 @@
+---
+title: "Tracked Moltis deploy failed when docker compose force-recreate hit a slow-stop container race"
+date: 2026-03-27
+severity: P1
+category: cicd
+tags: [cicd, deploy, docker-compose, moltis, production, docker, rollout]
+root_cause: "Tracked deploy relied on docker compose force-recreate against a fixed-name Moltis container without an explicit stop grace or pre-stop/remove step; Moltis exceeded Docker's default 10s stop timeout, was SIGKILLed, and compose then failed against the disappearing old container"
+---
+
+# RCA: Tracked Moltis deploy failed when docker compose force-recreate hit a slow-stop container race
+
+**Дата:** 2026-03-27  
+**Статус:** Resolved  
+**Влияние:** production run `23666558828` завершился `failure`; после неудачного recreate контейнер `moltis` временно отсутствовал и потребовалось ручное восстановление сервиса.
+
+## Ошибка
+
+Падение произошло в workflow `Deploy Moltis`, job `Deploy to Production`, step `Run tracked Moltis deploy control plane`.
+
+Ключевые строки:
+
+- GitHub Actions log:
+  - `Container watchtower Recreate`
+  - `Container moltis Recreate`
+  - `Container ollama-fallback Recreate`
+  - `Container watchtower Recreated`
+  - `Container ollama-fallback Recreated`
+  - `Container moltis Error response from daemon: No such container: 0b531284aa96_moltis`
+- Docker daemon log around `2026-03-27T20:45:46Z`:
+  - `Container failed to exit within 10s of signal 15 - using the force`
+  - followed by task delete for the old `moltis` container id `0b531284...`
+
+После этого `docker inspect moltis` на сервере возвращал `No such object: moltis`, пока сервис не был поднят вручную.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему production deploy завершился `failure`? | `docker compose up -d --remove-orphans --force-recreate` упал на сервисе `moltis` | run `23666558828`, failed step log |
+| 2 | Почему `docker compose` упал на `moltis`? | Compose пытался recreate old container, который уже исчез во время force-stop path | `No such container: 0b531284aa96_moltis` |
+| 3 | Почему old container исчез во время recreate? | Docker не дождался завершения Moltis за дефолтные `10s`, отправил `SIGKILL`, после чего old container был удалён | `journalctl -u docker.service` at `20:45:46Z` |
+| 4 | Почему deploy зависел от этого хрупкого recreate path? | `deploy.sh` целиком полагался на `docker compose up --force-recreate` для fixed-name Moltis container и не делал отдельный deterministic stop/remove | `scripts/deploy.sh` before fix |
+| 5 | Почему это стало системной проблемой? | В compose файлах не был задан более длинный `stop_grace_period`, хотя Docker Compose по умолчанию ждёт только `10s` до `SIGKILL` | official Docker docs for `stop_grace_period`; `docker inspect moltis` showed no explicit stop timeout |
+
+## Корневая причина
+
+Rollback/skill-discovery логика здесь была не при чём. Корень сбоя был в rollout contract:
+
+1. `deploy.sh` использовал `docker compose up --force-recreate` прямо по fixed-name `moltis` container.
+2. Moltis не завершился за Docker default `10s`.
+3. Docker принудительно убил old container.
+4. Compose споткнулся об уже исчезнувший old container и оборвал deploy.
+
+Итог: upgrade logic уже была корректной, но сам control-plane не переживал slow-stop lifecycle у Moltis.
+
+## Принятые меры
+
+1. В `scripts/deploy.sh` добавлен `prepare_moltis_container_for_rollout`:
+   - детерминированно останавливает `moltis` с расширенным timeout;
+   - затем удаляет existing fixed-name container до `compose up`;
+   - только после этого запускает rollout.
+2. В `docker-compose.prod.yml` и `docker-compose.yml` для `moltis` задан `stop_grace_period: 45s`.
+3. Добавлены регрессионные guard-тесты:
+   - `tests/unit/test_deploy_workflow_guards.sh`
+   - `tests/static/test_config_validation.sh`
+4. Обновлены ручные runbook/troubleshooting docs, чтобы не советовать хрупкий raw `up --force-recreate` без pre-stop/remove.
+
+## Проверка после исправления
+
+| Проверка | Результат | Evidence |
+|----------|-----------|----------|
+| `bash -n scripts/deploy.sh` | pass | local validation |
+| `./tests/run.sh --lane static --filter 'config_validation|deploy_workflow_guards'` | pass | 111/111 |
+| `./tests/run.sh --lane component --filter 'moltis_repo_skills_sync|moltis_runtime_attestation|moltis_codex_update'` | pass | 17/17 |
+| Server health after manual recovery | pass | `moltis` healthy, `/health` => `200` |
+
+## Уроки
+
+1. Для fixed-name production containers `force-recreate` нельзя считать безопасным по умолчанию, если service может завершаться дольше Docker default timeout.
+2. Если deploy требует recreate, сначала нужно стабилизировать stop contract: явный `stop_grace_period` и deterministic pre-stop/remove path.
+3. Ошибка уровня Docker lifecycle должна документироваться отдельно от application-level rollback, иначе легко начать чинить не тот слой.

--- a/docs/rca/INDEX.md
+++ b/docs/rca/INDEX.md
@@ -1,23 +1,23 @@
 # RCA Index
 
 **Last Updated**: 2026-03-27
-**Version**: 1.11.0
+**Version**: 1.12.0
 
 ## Statistics
 
 | Metric | Value |
 |--------|-------|
-| Total RCA | 19 |
+| Total RCA | 20 |
 | Avg Resolution Time | N/A |
-| This Month | 19 |
+| This Month | 20 |
 
 ## By Category
 
 | Category | Count | Percentage |
 |----------|-------|------------|
-| generic | 4 | 21% |
-| process | 9 | 47% |
-| cicd | 4 | 21% |
+| generic | 4 | 20% |
+| process | 9 | 45% |
+| cicd | 5 | 25% |
 | security | 1 | 5% |
 | shell | 1 | 5% |
 
@@ -26,7 +26,7 @@
 | Severity | Count | Description |
 |----------|-------|-------------|
 | P0 | 1 | Critical - blocks release |
-| P1 | 6 | High - production impact |
+| P1 | 7 | High - production impact |
 | P2 | 7 | Medium - process issue |
 | P3 | 4 | Low - minor issue |
 | P4 | 1 | Backlog |
@@ -35,6 +35,7 @@
 
 | ID | Date | Category | Severity | Status | Root Cause | Fix |
 |----|------|----------|----------|--------|------------|-----|
+| RCA-020 | 2026-03-27 | cicd | P1 | resolved | Tracked deploy relied on docker compose `force-recreate` for a fixed-name Moltis container without an explicit stop grace or pre-stop/remove step, so Docker hit the default 10s stop timeout and compose failed against the disappearing old container | added deterministic pre-stop/remove rollout + `stop_grace_period: 45s` + static/unit guards |
 | RCA-019 | 2026-03-27 | process | P1 | resolved | Project docs, config, and deploy checks treated repo-mounted `/server/skills` plus `search_paths` as a live Moltis skill contract, while official runtime discovery used data-dir-backed default paths | added repo-skill runtime sync + authenticated `/api/skills` deploy proof + official contract research/doc updates |
 | RCA-018 | 2026-03-14 | cicd | P1 | resolved | Clawdiy deploy treated transient OpenClaw startup `unhealthy` as terminal failure even though the container later recovered and served `/health` | extended Clawdiy startup health grace, increased deploy wait timeout, and taught deploy verification to tolerate transient startup unhealthy states |
 | RCA-017 | 2026-03-14 | process | P1 | resolved | Clawdiy model selection was completed in live runtime state but not mirrored into tracked `config/clawdiy/openclaw.json` | pinned the Codex OAuth / `gpt-5.4` baseline in tracked config + static guard + runbook update |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,6 +31,7 @@ MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="${MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST:-$CAN
 MOLTIS_REPO_SKILLS_SOURCE_ROOT="${MOLTIS_REPO_SKILLS_SOURCE_ROOT:-/server/skills}"
 MOLTIS_RUNTIME_SKILLS_ROOT="${MOLTIS_RUNTIME_SKILLS_ROOT:-/home/moltis/.moltis/skills}"
 MOLTIS_RUNTIME_SKILLS_MANIFEST="${MOLTIS_RUNTIME_SKILLS_MANIFEST:-/home/moltis/.moltis/.repo-managed-skills.txt}"
+MOLTIS_STOP_TIMEOUT_SECONDS="${MOLTIS_STOP_TIMEOUT_SECONDS:-45}"
 
 HEALTH_CHECK_TIMEOUT="${HEALTH_CHECK_TIMEOUT:-300}"
 HEALTH_CHECK_INTERVAL="${HEALTH_CHECK_INTERVAL:-10}"
@@ -859,6 +860,54 @@ resolve_container_name_conflicts() {
     done < <(managed_container_names_for_target)
 }
 
+prepare_moltis_container_for_rollout() {
+    local stop_timeout="${MOLTIS_STOP_TIMEOUT_SECONDS:-45}"
+    local container_id=""
+
+    if [[ "$TARGET" != "moltis" ]]; then
+        return 0
+    fi
+
+    if [[ ! "$stop_timeout" =~ ^[0-9]+$ ]] || (( stop_timeout < 1 )); then
+        log_error "MOLTIS_STOP_TIMEOUT_SECONDS must be a positive integer; got '$stop_timeout'"
+        exit 2
+    fi
+
+    container_id="$(docker ps -aq --filter "name=^/${TARGET_CONTAINER}$" | head -1 || true)"
+    [[ -n "$container_id" ]] || return 0
+
+    if docker ps -q --filter "id=$container_id" | grep -q .; then
+        log_json_stderr INFO "Stopping existing Moltis container '$TARGET_CONTAINER' with ${stop_timeout}s grace before rollout"
+        if [[ "$OUTPUT_JSON" == "true" ]]; then
+            if ! docker stop --time "$stop_timeout" "$TARGET_CONTAINER" 1>&2; then
+                log_error "Failed to stop existing Moltis container: $TARGET_CONTAINER"
+                exit 1
+            fi
+        else
+            if ! docker stop --time "$stop_timeout" "$TARGET_CONTAINER"; then
+                log_error "Failed to stop existing Moltis container: $TARGET_CONTAINER"
+                exit 1
+            fi
+        fi
+    fi
+
+    container_id="$(docker ps -aq --filter "name=^/${TARGET_CONTAINER}$" | head -1 || true)"
+    [[ -n "$container_id" ]] || return 0
+
+    log_json_stderr INFO "Removing existing Moltis container '$TARGET_CONTAINER' before rollout"
+    if [[ "$OUTPUT_JSON" == "true" ]]; then
+        if ! docker rm -f "$TARGET_CONTAINER" 1>&2; then
+            log_error "Failed to remove existing Moltis container: $TARGET_CONTAINER"
+            exit 1
+        fi
+    else
+        if ! docker rm -f "$TARGET_CONTAINER"; then
+            log_error "Failed to remove existing Moltis container: $TARGET_CONTAINER"
+            exit 1
+        fi
+    fi
+}
+
 ensure_clawdiy_runtime_paths() {
     local required_paths=(
         "$PROJECT_ROOT/data/clawdiy"
@@ -1334,6 +1383,9 @@ deploy_containers() {
     if [[ "$TARGET" == "moltis" ]]; then
         # Moltis loads runtime config at process start, so bind-mounted config
         # changes must force a recreate to avoid stale live state.
+        # Pre-stop/remove the fixed-name container to avoid compose recreate
+        # races when Moltis takes longer than Docker's default 10s stop grace.
+        prepare_moltis_container_for_rollout
         deploy_args+=(--force-recreate)
     fi
 

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -496,11 +496,24 @@ PY
     test_start "static_deploy_script_scopes_moltis_rollout_to_core_and_sidecars"
     if [[ -f "$DEPLOY_SCRIPT" ]] && \
        rg -Fq 'TARGET_AUXILIARY_SERVICES=("watchtower" "ollama")' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'prepare_moltis_container_for_rollout' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'docker stop --time "$stop_timeout" "$TARGET_CONTAINER"' "$DEPLOY_SCRIPT" && \
+       rg -Fq 'docker rm -f "$TARGET_CONTAINER"' "$DEPLOY_SCRIPT" && \
        rg -Fq 'deploy_args+=(--force-recreate)' "$DEPLOY_SCRIPT" && \
        rg -Fq 'compose_cmd normal "${deploy_args[@]}" "${deploy_services[@]}"' "$DEPLOY_SCRIPT"; then
         test_pass
     else
-        test_fail "Moltis deploy path must target only moltis + required sidecars and force-recreate the runtime so config changes take effect immediately"
+        test_fail "Moltis deploy path must target only moltis + required sidecars, pre-stop/remove the fixed-name Moltis container, and then force-recreate the runtime so config changes take effect immediately"
+    fi
+
+    test_start "static_moltis_compose_uses_extended_stop_grace_period"
+    if [[ -f "$PROJECT_ROOT/docker-compose.prod.yml" ]] && \
+       [[ -f "$PROJECT_ROOT/docker-compose.yml" ]] && \
+       rg -Fq 'stop_grace_period: 45s' "$PROJECT_ROOT/docker-compose.prod.yml" && \
+       rg -Fq 'stop_grace_period: 45s' "$PROJECT_ROOT/docker-compose.yml"; then
+        test_pass
+    else
+        test_fail "Moltis compose files must grant Moltis a longer stop_grace_period so deploys do not depend on Docker's 10s default stop timeout"
     fi
 
     test_start "static_deploy_workflow_uses_shared_host_automation_entrypoint"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -269,10 +269,13 @@ test_deploy_script_force_recreates_moltis_runtime_on_rollout() {
         return
     fi
 
-    if ! grep -Fq 'deploy_args+=(--force-recreate)' "$PROJECT_ROOT/scripts/deploy.sh" || \
+    if ! grep -Fq 'prepare_moltis_container_for_rollout' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'docker stop --time "$stop_timeout" "$TARGET_CONTAINER"' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'docker rm -f "$TARGET_CONTAINER"' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'deploy_args+=(--force-recreate)' "$PROJECT_ROOT/scripts/deploy.sh" || \
        ! grep -Fq 'compose_cmd normal "${deploy_args[@]}" "${deploy_services[@]}"' "$PROJECT_ROOT/scripts/deploy.sh" || \
        ! grep -Fq 'bind-mounted config' "$PROJECT_ROOT/scripts/deploy.sh"; then
-        test_fail "deploy.sh must force-recreate Moltis during deploy so updated runtime config is not left pending until a manual restart"
+        test_fail "deploy.sh must pre-stop/remove Moltis deterministically and then force-recreate it so updated runtime config is not left pending until a manual restart"
         return
     fi
 


### PR DESCRIPTION
## Summary
- pre-stop and remove the fixed-name Moltis container before tracked rollout
- add a longer Moltis stop grace period in compose files
- document the incident in RCA and update deploy troubleshooting guidance

## Testing
- bash -n scripts/deploy.sh
- bash -n tests/unit/test_deploy_workflow_guards.sh
- bash -n tests/static/test_config_validation.sh
- ./tests/run.sh --lane static --filter 'config_validation|deploy_workflow_guards'
- ./tests/run.sh --lane component --filter 'moltis_repo_skills_sync|moltis_runtime_attestation|moltis_codex_update'