### PR TITLE
fix(browser): add writable profile contract for sibling sandbox

### DIFF
--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -491,6 +491,8 @@ allowed_domains = []              # Empty = all domains allowed
 memory_limit_percent = 90
 chrome_args = []
 sandbox_image = "browserless/chrome"
+profile_dir = "/tmp/moltis-browser-profile/shared"  # Host-visible path shared with sibling browser sandboxes so Chrome profile state is writable
+persist_profile = false           # Keep browser profiles ephemeral in Docker mode; only the shared writable path contract persists
 container_host = "host.docker.internal"  # Moltis runs in Docker; sibling browser container must be reached via host gateway, not 127.0.0.1
 # allowed_domains = [
 #     "docs.example.com",         # Exact match

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,7 @@ services:
       # Writable live config/state directory. Prepared from ./config by deploy workflow.
       - ${MOLTIS_RUNTIME_CONFIG_DIR:-/opt/moltinger-state/config-runtime}:/home/moltis/.config/moltis
       - moltis-data:/home/moltis/.moltis
+      - /tmp/moltis-browser-profile:/tmp/moltis-browser-profile
       - /var/run/docker.sock:/var/run/docker.sock:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - ./config:/home/moltis/.config/moltis
       # Persistent data (sessions, memory, logs)
       - ./data:/home/moltis/.moltis
+      - /tmp/moltis-browser-profile:/tmp/moltis-browser-profile
       # Docker socket for sandbox execution (WARNING: root access)
       - /var/run/docker.sock:/var/run/docker.sock
     extra_hosts:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,8 @@ MOLTIS_REPO_SKILLS_SOURCE_ROOT="${MOLTIS_REPO_SKILLS_SOURCE_ROOT:-/server/skills
 MOLTIS_RUNTIME_SKILLS_ROOT="${MOLTIS_RUNTIME_SKILLS_ROOT:-/home/moltis/.moltis/skills}"
 MOLTIS_RUNTIME_SKILLS_MANIFEST="${MOLTIS_RUNTIME_SKILLS_MANIFEST:-/home/moltis/.moltis/.repo-managed-skills.txt}"
 MOLTIS_STOP_TIMEOUT_SECONDS="${MOLTIS_STOP_TIMEOUT_SECONDS:-45}"
+CANONICAL_MOLTIS_BROWSER_PROFILE_DIR="${CANONICAL_MOLTIS_BROWSER_PROFILE_DIR:-/tmp/moltis-browser-profile}"
+CANONICAL_MOLTIS_BROWSER_PROFILE_SHARED_DIR="${CANONICAL_MOLTIS_BROWSER_PROFILE_SHARED_DIR:-$CANONICAL_MOLTIS_BROWSER_PROFILE_DIR/shared}"
 
 HEALTH_CHECK_TIMEOUT="${HEALTH_CHECK_TIMEOUT:-300}"
 HEALTH_CHECK_INTERVAL="${HEALTH_CHECK_INTERVAL:-10}"
@@ -435,6 +437,22 @@ container_mount_rw() {
     docker inspect "$container" 2>/dev/null | \
         jq -r --arg destination "$destination" '.[0].Mounts[]? | select(.Destination == $destination) | .RW' | \
         head -n 1
+}
+
+dir_mode_allows_other_write_exec() {
+    local path="$1"
+    local mode last_digit
+
+    mode="$(stat -c '%a' "$path" 2>/dev/null || true)"
+    if [[ -z "$mode" ]]; then
+        mode="$(stat -f '%Mp%Lp' "$path" 2>/dev/null || true)"
+    fi
+    [[ -n "$mode" ]] || return 1
+
+    last_digit="${mode: -1}"
+    [[ -n "$last_digit" ]] || return 1
+
+    (( (10#$last_digit & 2) == 2 && (10#$last_digit & 1) == 1 ))
 }
 
 list_repo_skill_names() {
@@ -1503,6 +1521,7 @@ verify_deployment() {
         local expected_workspace expected_runtime_config
         local actual_workspace_source actual_runtime_config_source
         local actual_runtime_config_rw working_dir
+        local browser_profile_dir browser_profile_root actual_browser_profile_source actual_browser_profile_rw
         local tracked_runtime_toml runtime_runtime_toml
 
         working_dir="$(docker inspect --format '{{.Config.WorkingDir}}' "$TARGET_CONTAINER" 2>/dev/null || echo "")"
@@ -1575,6 +1594,49 @@ verify_deployment() {
         ' >/dev/null 2>&1; then
             record_verification_failure "Moltis runtime contract mismatch: host.docker.internal is not mapped inside the live container for sibling browser connectivity"
         fi
+
+        browser_profile_dir="$(awk '
+            /^\[tools\.browser\][[:space:]]*$/ { in_section = 1; next }
+            /^\[/ { if (in_section) exit }
+            in_section && /^[[:space:]]*profile_dir[[:space:]]*=/ {
+                gsub(/#.*/, "", $0)
+                sub(/^[[:space:]]*profile_dir[[:space:]]*=[[:space:]]*"/, "", $0)
+                sub(/".*$/, "", $0)
+                print $0
+                exit
+            }
+        ' "$tracked_runtime_toml")"
+        if [[ -n "$browser_profile_dir" ]]; then
+            browser_profile_root="$(dirname "$browser_profile_dir")"
+            actual_browser_profile_source="$(container_mount_source "$TARGET_CONTAINER" "$browser_profile_root")"
+            if [[ -z "$actual_browser_profile_source" ]]; then
+                log_error "Moltis browser contract mismatch: browser profile root mount '$browser_profile_root' is missing"
+                return 1
+            fi
+            actual_browser_profile_source="$(canonicalize_existing_path "$actual_browser_profile_source" || printf '%s\n' "$actual_browser_profile_source")"
+            browser_profile_root="$(canonicalize_existing_path "$browser_profile_root" || printf '%s\n' "$browser_profile_root")"
+            browser_profile_dir="$(canonicalize_existing_path "$browser_profile_dir" || printf '%s\n' "$browser_profile_dir")"
+            if [[ "$actual_browser_profile_source" != "$browser_profile_root" ]]; then
+                log_error "Moltis browser contract mismatch: browser profile source is '$actual_browser_profile_source', expected '$browser_profile_root'"
+                return 1
+            fi
+
+            actual_browser_profile_rw="$(container_mount_rw "$TARGET_CONTAINER" "$browser_profile_root")"
+            if [[ "$actual_browser_profile_rw" != "true" ]]; then
+                log_error "Moltis browser contract mismatch: browser profile mount '$browser_profile_root' must be writable"
+                return 1
+            fi
+
+            if [[ ! -d "$browser_profile_root" || ! -d "$browser_profile_dir" ]]; then
+                log_error "Moltis browser contract mismatch: browser profile root or shared dir is missing on host"
+                return 1
+            fi
+
+            if ! dir_mode_allows_other_write_exec "$browser_profile_root" || ! dir_mode_allows_other_write_exec "$browser_profile_dir"; then
+                log_error "Moltis browser contract mismatch: browser profile root/shared dir must be writable for arbitrary non-root browser users"
+                return 1
+            fi
+        fi
     fi
 
     if verification_failure_recorded; then
@@ -1582,6 +1644,74 @@ verify_deployment() {
     fi
 
     log_success "Deployment verification passed for target $TARGET"
+    return 0
+}
+
+prepare_moltis_browser_profile_dir() {
+    if [[ "$TARGET" != "moltis" ]]; then
+        return 0
+    fi
+
+    mkdir -p "$CANONICAL_MOLTIS_BROWSER_PROFILE_SHARED_DIR"
+    chmod 0777 "$CANONICAL_MOLTIS_BROWSER_PROFILE_DIR" "$CANONICAL_MOLTIS_BROWSER_PROFILE_SHARED_DIR"
+    log_success "Prepared shared Moltis browser profile dir: $CANONICAL_MOLTIS_BROWSER_PROFILE_SHARED_DIR"
+    return 0
+}
+
+prepull_moltis_browser_sandbox_image() {
+    if [[ "$TARGET" != "moltis" ]]; then
+        return 0
+    fi
+
+    local browser_contract browser_enabled sandbox_image
+    browser_contract="$(awk '
+        BEGIN {
+            in_section = 0
+            enabled = "true"
+            image = "browserless/chrome"
+        }
+        /^\[tools\.browser\][[:space:]]*$/ {
+            in_section = 1
+            next
+        }
+        /^\[/ {
+            if (in_section) {
+                exit
+            }
+        }
+        in_section {
+            if ($0 ~ /^[[:space:]]*enabled[[:space:]]*=[[:space:]]*(true|false)/) {
+                gsub(/#.*/, "", $0)
+                sub(/^[[:space:]]*enabled[[:space:]]*=[[:space:]]*/, "", $0)
+                gsub(/[[:space:]]+$/, "", $0)
+                enabled = $0
+            }
+            if ($0 ~ /^[[:space:]]*sandbox_image[[:space:]]*=[[:space:]]*"/) {
+                gsub(/#.*/, "", $0)
+                sub(/^[[:space:]]*sandbox_image[[:space:]]*=[[:space:]]*"/, "", $0)
+                sub(/".*$/, "", $0)
+                image = $0
+            }
+        }
+        END {
+            print enabled "|" image
+        }
+    ' "$PROJECT_ROOT/config/moltis.toml")"
+    browser_enabled="${browser_contract%%|*}"
+    sandbox_image="${browser_contract#*|}"
+
+    if [[ "$browser_enabled" != "true" ]]; then
+        log_info "Tracked Moltis browser tool is disabled; skipping sandbox image pre-pull"
+        return 0
+    fi
+
+    if [[ -z "$sandbox_image" || "$sandbox_image" == "null" ]]; then
+        sandbox_image="browserless/chrome"
+    fi
+
+    log_info "Pre-pulling Moltis browser sandbox image: $sandbox_image"
+    docker pull "$sandbox_image" >/dev/null
+    log_success "Moltis browser sandbox image ready: $sandbox_image"
     return 0
 }
 
@@ -1637,6 +1767,8 @@ cmd_deploy() {
     check_prerequisites "deploy"
     backup_current_state
     pull_images
+    prepare_moltis_browser_profile_dir
+    prepull_moltis_browser_sandbox_image
     deploy_containers
 
     if verify_deployment; then

--- a/scripts/manifest.json
+++ b/scripts/manifest.json
@@ -963,6 +963,22 @@
       "gitops": true,
       "ci": true
     },
+    "moltis-browser-canary.sh": {
+      "version": "1.0.0",
+      "description": "Run a tracked browser navigation canary and require live browser-tool proof in Moltis logs",
+      "entrypoint": true,
+      "requires": [
+        "bash",
+        "docker",
+        "grep",
+        "mktemp"
+      ],
+      "provides": [
+        "moltis-browser-canary"
+      ],
+      "gitops": true,
+      "ci": true
+    },
     "moltis-search-memory-diagnostics.sh": {
       "version": "1.0.0",
       "description": "Emit tracked Tavily search and memory diagnostics from config and optional runtime logs",

--- a/scripts/moltis-browser-canary.sh
+++ b/scripts/moltis-browser-canary.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Run a tracked browser navigation canary and verify that the live runtime
+# actually used the browser tool instead of only producing a plausible answer.
+
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]-$0}"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+MOLTIS_URL="${MOLTIS_URL:-http://localhost:13131}"
+MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
+SMOKE_SCRIPT="${MOLTIS_BROWSER_CANARY_SMOKE_SCRIPT:-$PROJECT_ROOT/scripts/test-moltis-api.sh}"
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+CANARY_PROMPT="${MOLTIS_BROWSER_CANARY_PROMPT:-Используй browser, а не web_fetch. Открой https://docs.moltis.org/ и ответь только точным заголовком страницы без пояснений.}"
+EXPECTED_REPLY="${MOLTIS_BROWSER_CANARY_EXPECTED_REPLY:-Introduction - Moltis Documentation}"
+CHAT_WAIT_MS="${MOLTIS_BROWSER_CANARY_CHAT_WAIT_MS:-30000}"
+TEST_TIMEOUT="${MOLTIS_BROWSER_CANARY_TEST_TIMEOUT:-30}"
+REQUIRED_LOG="${MOLTIS_BROWSER_CANARY_REQUIRED_LOG:-tool execution succeeded tool=browser}"
+REJECT_LOG_RE="${MOLTIS_BROWSER_CANARY_REJECT_LOG_RE:-browser container failed readiness check|tool execution failed tool=browser|browser launch failed}"
+
+timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+require_file() {
+    local path="$1"
+    if [[ ! -f "$path" ]]; then
+        echo "moltis-browser-canary.sh: missing required file: $path" >&2
+        exit 1
+    fi
+}
+
+main() {
+    local started_at smoke_log recent_logs
+
+    require_file "$SMOKE_SCRIPT"
+    started_at="$(timestamp)"
+    smoke_log="$(mktemp "${TMPDIR:-/tmp}/moltis-browser-canary.XXXXXX")"
+    trap 'rm -f "${smoke_log:-}"' EXIT
+
+    if ! CHAT_WAIT_MS="$CHAT_WAIT_MS" \
+        TEST_TIMEOUT="$TEST_TIMEOUT" \
+        EXPECTED_REPLY_TEXT="$EXPECTED_REPLY" \
+        bash "$SMOKE_SCRIPT" "$CANARY_PROMPT" >"$smoke_log" 2>&1; then
+        cat "$smoke_log" >&2 || true
+        echo "moltis-browser-canary.sh: browser smoke failed before browser-tool proof" >&2
+        exit 1
+    fi
+
+    recent_logs="$("$DOCKER_BIN" logs --since "$started_at" "$MOLTIS_CONTAINER" 2>&1 || true)"
+    if [[ -z "$recent_logs" ]]; then
+        cat "$smoke_log" >&2 || true
+        echo "moltis-browser-canary.sh: no recent Moltis logs were captured after the canary start time" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq "$REQUIRED_LOG" <<<"$recent_logs"; then
+        cat "$smoke_log" >&2 || true
+        printf '%s\n' "$recent_logs" >&2
+        echo "moltis-browser-canary.sh: browser canary did not produce '$REQUIRED_LOG' in live logs" >&2
+        exit 1
+    fi
+
+    if grep -Eq "$REJECT_LOG_RE" <<<"$recent_logs"; then
+        cat "$smoke_log" >&2 || true
+        printf '%s\n' "$recent_logs" >&2
+        echo "moltis-browser-canary.sh: browser canary matched a browser failure signature in live logs" >&2
+        exit 1
+    fi
+
+    cat <<EOF
+[OK] Moltis browser canary passed
+container=$MOLTIS_CONTAINER
+base_url=$MOLTIS_URL
+started_at=$started_at
+expected_reply=$EXPECTED_REPLY
+required_log=$REQUIRED_LOG
+EOF
+}
+
+main "$@"

--- a/scripts/moltis-runtime-attestation.sh
+++ b/scripts/moltis-runtime-attestation.sh
@@ -22,6 +22,13 @@ AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS="${AUTH_PROVIDER_CANARY_TIMEOUT_SECONDS:-25
 BROWSER_ENABLED=""
 BROWSER_SANDBOX_IMAGE=""
 BROWSER_CONTAINER_HOST=""
+BROWSER_PROFILE_DIR=""
+BROWSER_PERSIST_PROFILE=""
+BROWSER_PROFILE_ROOT=""
+BROWSER_PROFILE_SOURCE=""
+BROWSER_PROFILE_RW=""
+BROWSER_PROFILE_ROOT_WRITABLE=""
+BROWSER_PROFILE_SHARED_WRITABLE=""
 DOCKER_SOCKET_SOURCE=""
 DOCKER_SOCKET_GID=""
 DOCKER_SOCKET_MODE=""
@@ -123,6 +130,22 @@ read_toml_key() {
             exit
         }
     ' "$toml_file"
+}
+
+dir_mode_allows_other_write_exec() {
+    local path="$1"
+    local mode last_digit
+
+    mode="$(stat -c '%a' "$path" 2>/dev/null || true)"
+    if [[ -z "$mode" ]]; then
+        mode="$(stat -f '%Mp%Lp' "$path" 2>/dev/null || true)"
+    fi
+    [[ -n "$mode" ]] || return 1
+
+    last_digit="${mode: -1}"
+    [[ -n "$last_digit" ]] || return 1
+
+    (( (10#$last_digit & 2) == 2 && (10#$last_digit & 1) == 1 ))
 }
 
 read_env_file_value() {
@@ -587,6 +610,8 @@ fi
 BROWSER_ENABLED="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "enabled" || true)"
 BROWSER_SANDBOX_IMAGE="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "sandbox_image" || true)"
 BROWSER_CONTAINER_HOST="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "container_host" || true)"
+BROWSER_PROFILE_DIR="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "profile_dir" || true)"
+BROWSER_PERSIST_PROFILE="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "persist_profile" || true)"
 
 if browser_contract_required; then
     DOCKER_SOCKET_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "/var/run/docker.sock")"
@@ -615,6 +640,44 @@ if browser_contract_required; then
             fail_with "BROWSER_CONTAINER_HOST_MAPPING_MISSING" "tools.browser.container_host points to host.docker.internal but the hostname is not mapped inside the live Moltis container"
         fi
         HOST_DOCKER_INTERNAL_MAPPED="true"
+    fi
+
+    if [[ -n "$BROWSER_PROFILE_DIR" ]]; then
+        local_browser_profile_root="$(dirname "$BROWSER_PROFILE_DIR")"
+        expected_browser_profile_root="$(canonicalize_existing_path "$local_browser_profile_root" || printf '%s\n' "$local_browser_profile_root")"
+        expected_browser_profile_shared_dir="$(canonicalize_existing_path "$BROWSER_PROFILE_DIR" || printf '%s\n' "$BROWSER_PROFILE_DIR")"
+
+        BROWSER_PROFILE_SOURCE="$(container_mount_source "$MOLTIS_CONTAINER" "$local_browser_profile_root")"
+        if [[ -z "$BROWSER_PROFILE_SOURCE" ]]; then
+            fail_with "BROWSER_PROFILE_MOUNT_MISSING" "Moltis browser profile root '$local_browser_profile_root' is not mounted into the live container"
+        fi
+        BROWSER_PROFILE_SOURCE="$(canonicalize_existing_path "$BROWSER_PROFILE_SOURCE" || printf '%s\n' "$BROWSER_PROFILE_SOURCE")"
+        if [[ "$BROWSER_PROFILE_SOURCE" != "$expected_browser_profile_root" ]]; then
+            fail_with "BROWSER_PROFILE_SOURCE_MISMATCH" "Live browser profile source '$BROWSER_PROFILE_SOURCE' does not match tracked root '$expected_browser_profile_root'"
+        fi
+
+        BROWSER_PROFILE_RW="$(container_mount_rw "$MOLTIS_CONTAINER" "$local_browser_profile_root")"
+        if [[ "$BROWSER_PROFILE_RW" != "true" ]]; then
+            fail_with "BROWSER_PROFILE_MOUNT_NOT_WRITABLE" "Browser profile mount '$local_browser_profile_root' must be writable"
+        fi
+
+        if [[ ! -d "$expected_browser_profile_root" ]]; then
+            fail_with "BROWSER_PROFILE_ROOT_MISSING" "Tracked browser profile root is missing on the host: $expected_browser_profile_root"
+        fi
+        if [[ ! -d "$expected_browser_profile_shared_dir" ]]; then
+            fail_with "BROWSER_PROFILE_SHARED_DIR_MISSING" "Tracked browser shared profile dir is missing on the host: $expected_browser_profile_shared_dir"
+        fi
+        if ! dir_mode_allows_other_write_exec "$expected_browser_profile_root"; then
+            fail_with "BROWSER_PROFILE_ROOT_PERMISSION_MISMATCH" "Browser profile root '$expected_browser_profile_root' is not writable/traversable for arbitrary non-root users"
+        fi
+        if ! dir_mode_allows_other_write_exec "$expected_browser_profile_shared_dir"; then
+            fail_with "BROWSER_PROFILE_SHARED_PERMISSION_MISMATCH" "Browser shared profile dir '$expected_browser_profile_shared_dir' is not writable/traversable for arbitrary non-root users"
+        fi
+
+        BROWSER_PROFILE_ROOT="$expected_browser_profile_root"
+        BROWSER_PROFILE_DIR="$expected_browser_profile_shared_dir"
+        BROWSER_PROFILE_ROOT_WRITABLE="true"
+        BROWSER_PROFILE_SHARED_WRITABLE="true"
     fi
 fi
 
@@ -699,6 +762,13 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
         --arg browser_enabled "$BROWSER_ENABLED" \
         --arg browser_sandbox_image "$BROWSER_SANDBOX_IMAGE" \
         --arg browser_container_host "$BROWSER_CONTAINER_HOST" \
+        --arg browser_profile_dir "$BROWSER_PROFILE_DIR" \
+        --arg browser_profile_root "$BROWSER_PROFILE_ROOT" \
+        --arg browser_profile_source "$BROWSER_PROFILE_SOURCE" \
+        --arg browser_profile_rw "$BROWSER_PROFILE_RW" \
+        --arg browser_persist_profile "$BROWSER_PERSIST_PROFILE" \
+        --arg browser_profile_root_writable "$BROWSER_PROFILE_ROOT_WRITABLE" \
+        --arg browser_profile_shared_writable "$BROWSER_PROFILE_SHARED_WRITABLE" \
         --arg docker_socket_source "$DOCKER_SOCKET_SOURCE" \
         --arg docker_socket_gid "$DOCKER_SOCKET_GID" \
         --arg docker_socket_mode "$DOCKER_SOCKET_MODE" \
@@ -742,6 +812,13 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
             browser_enabled: (if $browser_enabled == "" then null else ($browser_enabled == "true") end),
             browser_sandbox_image: (if $browser_sandbox_image == "" then null else $browser_sandbox_image end),
             browser_container_host: (if $browser_container_host == "" then null else $browser_container_host end),
+            browser_profile_dir: (if $browser_profile_dir == "" then null else $browser_profile_dir end),
+            browser_profile_root: (if $browser_profile_root == "" then null else $browser_profile_root end),
+            browser_profile_source: (if $browser_profile_source == "" then null else $browser_profile_source end),
+            browser_profile_rw: (if $browser_profile_rw == "" then null else $browser_profile_rw end),
+            browser_persist_profile: (if $browser_persist_profile == "" then null else $browser_persist_profile end),
+            browser_profile_root_writable: (if $browser_profile_root_writable == "" then null else ($browser_profile_root_writable == "true") end),
+            browser_profile_shared_writable: (if $browser_profile_shared_writable == "" then null else ($browser_profile_shared_writable == "true") end),
             docker_socket_source: (if $docker_socket_source == "" then null else $docker_socket_source end),
             docker_socket_gid: (if $docker_socket_gid == "" then null else $docker_socket_gid end),
             docker_socket_mode: (if $docker_socket_mode == "" then null else $docker_socket_mode end),
@@ -777,6 +854,13 @@ runtime_runtime_toml=${RUNTIME_RUNTIME_TOML:-unknown}
 browser_enabled=${BROWSER_ENABLED:-unknown}
 browser_sandbox_image=${BROWSER_SANDBOX_IMAGE:-none}
 browser_container_host=${BROWSER_CONTAINER_HOST:-none}
+browser_profile_dir=${BROWSER_PROFILE_DIR:-none}
+browser_profile_root=${BROWSER_PROFILE_ROOT:-none}
+browser_profile_source=${BROWSER_PROFILE_SOURCE:-none}
+browser_profile_rw=${BROWSER_PROFILE_RW:-unknown}
+browser_persist_profile=${BROWSER_PERSIST_PROFILE:-unknown}
+browser_profile_root_writable=${BROWSER_PROFILE_ROOT_WRITABLE:-skipped}
+browser_profile_shared_writable=${BROWSER_PROFILE_SHARED_WRITABLE:-skipped}
 docker_socket_source=${DOCKER_SOCKET_SOURCE:-none}
 docker_socket_gid=${DOCKER_SOCKET_GID:-none}
 docker_socket_mode=${DOCKER_SOCKET_MODE:-none}

--- a/tests/component/test_moltis_browser_canary.sh
+++ b/tests/component/test_moltis_browser_canary.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+CANARY_SCRIPT="$PROJECT_ROOT/scripts/moltis-browser-canary.sh"
+
+create_fake_browser_canary_bin() {
+    local fixture_root="$1"
+    local fake_bin="$fixture_root/bin"
+
+    mkdir -p "$fake_bin"
+
+    cat >"$fake_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "logs" ]]; then
+    shift
+    if [[ "${1:-}" == "--since" ]]; then
+        shift 2
+    fi
+    printf '%s\n' "${FAKE_DOCKER_LOGS:-}"
+    exit 0
+fi
+
+printf 'unsupported fake docker command: %s\n' "${1:-}" >&2
+exit 1
+EOF
+
+    chmod +x "$fake_bin/docker"
+    printf '%s\n' "$fake_bin"
+}
+
+run_component_moltis_browser_canary_tests() {
+    start_timer
+
+    local fixture_root fake_bin fake_smoke stdout_log stderr_log
+    fixture_root="$(secure_temp_dir moltis-browser-canary)"
+    fake_bin="$(create_fake_browser_canary_bin "$fixture_root")"
+    fake_smoke="$fixture_root/fake-smoke.sh"
+    stdout_log="$fixture_root/stdout.log"
+    stderr_log="$fixture_root/stderr.log"
+
+    cat >"$fake_smoke" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${FAKE_SMOKE_STDOUT:-smoke ok}"
+if [[ "${FAKE_SMOKE_EXIT_CODE:-0}" -ne 0 ]]; then
+    exit "${FAKE_SMOKE_EXIT_CODE}"
+fi
+EOF
+    chmod +x "$fake_smoke"
+
+    test_start "component_moltis_browser_canary_passes_when_smoke_and_live_browser_log_match"
+    if ! PATH="$fake_bin:$PATH" \
+        DOCKER_BIN="docker" \
+        MOLTIS_BROWSER_CANARY_SMOKE_SCRIPT="$fake_smoke" \
+        FAKE_SMOKE_EXIT_CODE="0" \
+        FAKE_DOCKER_LOGS=$'INFO tool execution succeeded tool=browser\nINFO navigated to URL' \
+        bash "$CANARY_SCRIPT" >"$stdout_log" 2>"$stderr_log"; then
+        test_fail "Browser canary should pass when smoke succeeds and live logs prove browser tool execution"
+        rm -rf "$fixture_root"
+        return
+    fi
+
+    if ! grep -Fq '[OK] Moltis browser canary passed' "$stdout_log"; then
+        test_fail "Browser canary success output must include the OK marker"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    test_start "component_moltis_browser_canary_fails_when_live_logs_still_contain_browser_errors"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        DOCKER_BIN="docker" \
+        MOLTIS_BROWSER_CANARY_SMOKE_SCRIPT="$fake_smoke" \
+        FAKE_SMOKE_EXIT_CODE="0" \
+        FAKE_DOCKER_LOGS=$'INFO tool execution succeeded tool=browser\nWARN browser launch failed: failed to connect to containerized browser' \
+        bash "$CANARY_SCRIPT" >"$stdout_log" 2>"$stderr_log"
+    local exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       ! grep -Fq 'browser canary matched a browser failure signature' "$stderr_log"; then
+        test_fail "Browser canary must fail closed when live logs still contain browser failure signatures"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    rm -rf "$fixture_root"
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    run_component_moltis_browser_canary_tests
+fi

--- a/tests/component/test_moltis_runtime_attestation.sh
+++ b/tests/component/test_moltis_runtime_attestation.sh
@@ -96,6 +96,14 @@ case "${1:-}" in
           fi
           exit 1
           ;;
+        'test -d /server &&
+            test -d /server/skills &&
+            test -f /home/moltis/.config/moltis/moltis.toml &&
+            tmp_path="/home/moltis/.config/moltis/provider_keys.json.tmp.contract-check.$$" &&
+            : > "$tmp_path" &&
+            rm -f "$tmp_path"')
+          exit 0
+          ;;
       esac
     fi
     printf 'unsupported docker exec invocation: %s\n' "$*" >&2
@@ -168,13 +176,14 @@ EOF
 
 create_workspace_fixture() {
     local workspace_root="$1"
+    local browser_profile_dir="$2"
 
     mkdir -p "$workspace_root/data" "$workspace_root/skills" "$workspace_root/config"
     git -C "$workspace_root" init -q
     git -C "$workspace_root" config user.name "Codex Test"
     git -C "$workspace_root" config user.email "codex@example.com"
     printf 'runtime\n' >"$workspace_root/runtime.txt"
-    cat >"$workspace_root/config/moltis.toml" <<'EOF'
+    cat >"$workspace_root/config/moltis.toml" <<EOF
 [memory]
 provider = "ollama"
 base_url = "http://ollama:11434"
@@ -183,6 +192,8 @@ model = "nomic-embed-text"
 [tools.browser]
 enabled = true
 sandbox_image = "browserless/chrome"
+profile_dir = "$browser_profile_dir"
+persist_profile = false
 container_host = "host.docker.internal"
 EOF
     git -C "$workspace_root" add runtime.txt
@@ -193,20 +204,25 @@ EOF
 run_component_moltis_runtime_attestation_tests() {
     start_timer
 
-    local fixture_root fake_bin workspace_root workspace_root_canonical active_root runtime_config_dir runtime_config_dir_canonical runtime_home_dir mounts_file output_json live_sha
+    local fixture_root fake_bin workspace_root workspace_root_canonical active_root runtime_config_dir runtime_config_dir_canonical runtime_home_dir mounts_file output_json live_sha browser_profile_root browser_profile_dir browser_profile_root_canonical browser_profile_dir_canonical
     fixture_root="$(secure_temp_dir moltis-runtime-attestation)"
     fake_bin="$(create_fake_runtime_bin "$fixture_root")"
     workspace_root="$fixture_root/deploy-root"
     active_root="$fixture_root/moltis-active"
     runtime_config_dir="$fixture_root/runtime-config"
     runtime_home_dir="$fixture_root/runtime-home"
+    browser_profile_root="$fixture_root/browser-profile"
+    browser_profile_dir="$browser_profile_root/shared"
     mounts_file="$fixture_root/mounts.json"
     output_json="$fixture_root/output.json"
 
-    mkdir -p "$runtime_config_dir" "$runtime_home_dir"
-    create_workspace_fixture "$workspace_root"
+    mkdir -p "$runtime_config_dir" "$runtime_home_dir" "$browser_profile_dir"
+    chmod 0777 "$browser_profile_root" "$browser_profile_dir"
+    create_workspace_fixture "$workspace_root" "$browser_profile_dir"
     workspace_root_canonical="$(cd "$workspace_root" && pwd -P)"
     runtime_config_dir_canonical="$(cd "$runtime_config_dir" && pwd -P)"
+    browser_profile_root_canonical="$(cd "$browser_profile_root" && pwd -P)"
+    browser_profile_dir_canonical="$(cd "$browser_profile_dir" && pwd -P)"
     live_sha="$(git -C "$workspace_root" rev-parse HEAD)"
     cp "$workspace_root/config/moltis.toml" "$runtime_config_dir/moltis.toml"
 
@@ -234,6 +250,7 @@ EOF
       {"Destination": "/server", "Source": "$workspace_root", "RW": false},
       {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
       {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true},
+      {"Destination": "$browser_profile_root", "Source": "$browser_profile_root", "RW": true},
       {"Destination": "/var/run/docker.sock", "Source": "$fixture_root/docker.sock", "RW": false}
     ]
   }
@@ -272,12 +289,47 @@ EOF
        [[ "$(jq -r '.details.browser_enabled' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.browser_sandbox_image' "$output_json")" != "browserless/chrome" ]] || \
        [[ "$(jq -r '.details.browser_container_host' "$output_json")" != "host.docker.internal" ]] || \
+       [[ "$(jq -r '.details.browser_profile_dir' "$output_json")" != "$browser_profile_dir_canonical" ]] || \
+       [[ "$(jq -r '.details.browser_profile_root' "$output_json")" != "$browser_profile_root_canonical" ]] || \
+       [[ "$(jq -r '.details.browser_profile_source' "$output_json")" != "$browser_profile_root_canonical" ]] || \
+       [[ "$(jq -r '.details.browser_profile_rw' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.browser_persist_profile' "$output_json")" != "false" ]] || \
+       [[ "$(jq -r '.details.browser_profile_root_writable' "$output_json")" != "true" ]] || \
+       [[ "$(jq -r '.details.browser_profile_shared_writable' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.docker_socket_gid' "$output_json")" != "999" ]] || \
        [[ "$(jq -r '.details.host_docker_internal_mapped' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.expected_auth_provider' "$output_json")" != "openai-codex" ]] || \
        [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.auth_validation_path' "$output_json")" != "status" ]]; then
         test_fail "Runtime attestation success output does not reflect the expected provenance details"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    test_start "component_runtime_attestation_fails_when_browser_profile_root_is_not_world_writable"
+    chmod 0755 "$browser_profile_root"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" >"$output_json" 2>"$fixture_root/stderr-browser-profile.log"
+    exit_code=$?
+    set -e
+    chmod 0777 "$browser_profile_root"
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "BROWSER_PROFILE_ROOT_PERMISSION_MISMATCH")' "$output_json" >/dev/null 2>&1; then
+        test_fail "Runtime attestation should fail when the browser profile root is not writable for arbitrary non-root browser users"
         rm -rf "$fixture_root"
         return
     fi
@@ -348,6 +400,7 @@ EOF
       {"Destination": "/server", "Source": "$fixture_root/untracked-root", "RW": false},
       {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
       {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true},
+      {"Destination": "$browser_profile_root", "Source": "$browser_profile_root", "RW": true},
       {"Destination": "/var/run/docker.sock", "Source": "$fixture_root/docker.sock", "RW": false}
     ]
   }
@@ -388,6 +441,7 @@ EOF
       {"Destination": "/server", "Source": "$workspace_root", "RW": false},
       {"Destination": "/home/moltis/.config/moltis", "Source": "$runtime_config_dir", "RW": true},
       {"Destination": "/home/moltis/.moltis", "Source": "$runtime_home_dir", "RW": true},
+      {"Destination": "$browser_profile_root", "Source": "$browser_profile_root", "RW": true},
       {"Destination": "/var/run/docker.sock", "Source": "$fixture_root/docker.sock", "RW": false}
     ]
   }

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -108,17 +108,24 @@ run_static_config_validation_tests() {
         test_fail "Moltis compose files must mount the tracked checkout as /server and use it as the working directory for Git-tracked scripts, docs, and repo-managed skill sources"
     fi
 
-    test_start "static_moltis_browser_docker_contract_declares_host_gateway_and_socket_gid_alignment"
-    if rg -q 'group_add:' "$COMPOSE_PROD" && \
-       rg -q 'DOCKER_SOCKET_GID' "$COMPOSE_PROD" && \
+    test_start "static_moltis_browser_docker_contract_matches_official_sibling_container_requirements"
+    if rg -q 'container_host = "host\.docker\.internal"' "$TOML_CONFIG" && \
+       rg -q '^profile_dir = "/tmp/moltis-browser-profile/shared"' "$TOML_CONFIG" && \
+       rg -q '^persist_profile = false' "$TOML_CONFIG" && \
+       rg -q 'DOCKER_SOCKET_GID:-999' "$COMPOSE_PROD" && \
+       rg -q '/tmp/moltis-browser-profile:/tmp/moltis-browser-profile' "$COMPOSE_PROD" && \
+       rg -q '/tmp/moltis-browser-profile:/tmp/moltis-browser-profile' "$PROJECT_ROOT/docker-compose.yml" && \
        rg -q 'host\.docker\.internal:host-gateway' "$COMPOSE_PROD" && \
-       rg -q 'group_add:' "$PROJECT_ROOT/docker-compose.yml" && \
-       rg -q 'DOCKER_SOCKET_GID' "$PROJECT_ROOT/docker-compose.yml" && \
        rg -q 'host\.docker\.internal:host-gateway' "$PROJECT_ROOT/docker-compose.yml" && \
-       rg -q 'container_host = "host\.docker\.internal"' "$TOML_CONFIG"; then
+       rg -q 'DOCKER_SOCKET_GID=\$docker_socket_gid' "$DEPLOY_SCRIPT" && \
+       rg -q 'prepare_moltis_browser_profile_dir' "$DEPLOY_SCRIPT" && \
+       rg -q 'chmod 0777 "\$CANONICAL_MOLTIS_BROWSER_PROFILE_DIR" "\$CANONICAL_MOLTIS_BROWSER_PROFILE_SHARED_DIR"' "$DEPLOY_SCRIPT" && \
+       rg -q 'prepull_moltis_browser_sandbox_image' "$DEPLOY_SCRIPT" && \
+       rg -q 'docker pull "\$sandbox_image"' "$DEPLOY_SCRIPT" && \
+       rg -q '^sandbox_image = "browserless/chrome"' "$TOML_CONFIG"; then
         test_pass
     else
-        test_fail "Moltis browser Docker contract must align docker.sock gid access, provide host-gateway routing, and pin container_host away from 127.0.0.1"
+        test_fail "Browser-in-Docker contract must keep the shared profile_dir contract, keep persist_profile disabled, pre-pull the tracked browserless/chrome image, set container_host, inject the live Docker socket GID, and publish host.docker.internal for sibling browser containers"
     fi
 
     test_start "static_compose_clawdiy_valid"
@@ -216,11 +223,12 @@ PY
     test_start "static_runtime_attestation_and_deploy_guard_browser_sandbox_contract"
     if rg -Fq 'BROWSER_DOCKER_SOCKET_GID_MISMATCH' "$RUNTIME_ATTESTATION_SCRIPT" && \
        rg -Fq 'BROWSER_CONTAINER_HOST_INVALID' "$RUNTIME_ATTESTATION_SCRIPT" && \
-       rg -Fq 'read_toml_key' "$RUNTIME_ATTESTATION_SCRIPT" && \
+       rg -Fq 'BROWSER_PROFILE_ROOT_PERMISSION_MISMATCH' "$RUNTIME_ATTESTATION_SCRIPT" && \
+       rg -Fq 'BROWSER_PROFILE_SHARED_PERMISSION_MISMATCH' "$RUNTIME_ATTESTATION_SCRIPT" && \
        rg -Fq 'DOCKER_SOCKET_GID' "$DEPLOY_SCRIPT"; then
         test_pass
     else
-        test_fail "Runtime attestation and deploy control plane must guard the Docker browser sandbox contract before production traffic hits Telegram"
+        test_fail "Runtime attestation and deploy control plane must guard docker.sock access, host-gateway routing, and writable browser profile storage before production traffic hits Telegram"
     fi
 
     test_start "static_config_has_no_hardcoded_secrets"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -261,6 +261,53 @@ test_deploy_script_verifies_live_moltis_runtime_contract() {
     test_pass
 }
 
+test_deploy_script_exports_live_docker_socket_gid_for_browser_sandbox() {
+    test_start "Deploy should export the live Docker socket GID for browser sandbox access"
+
+    if [[ ! -f "$PROJECT_ROOT/scripts/deploy.sh" || ! -f "$PROJECT_ROOT/docker-compose.prod.yml" || ! -f "$PROJECT_ROOT/config/moltis.toml" ]]; then
+        test_skip "Missing deploy, compose, or config files"
+        return
+    fi
+
+    if ! grep -Fq 'DOCKER_SOCKET_GID=$docker_socket_gid' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'profile_dir = "/tmp/moltis-browser-profile/shared"' "$PROJECT_ROOT/config/moltis.toml" || \
+       ! grep -Fq 'persist_profile = false' "$PROJECT_ROOT/config/moltis.toml" || \
+       ! grep -Fq '/tmp/moltis-browser-profile:/tmp/moltis-browser-profile' "$PROJECT_ROOT/docker-compose.prod.yml" || \
+       ! grep -Fq 'host.docker.internal:host-gateway' "$PROJECT_ROOT/docker-compose.prod.yml" || \
+       ! grep -Fq 'prepare_moltis_browser_profile_dir' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'container_host = "host.docker.internal"' "$PROJECT_ROOT/config/moltis.toml"; then
+        test_fail "Browser sandbox access requires the tracked shared profile_dir, explicit non-persistent profile intent, deploy-time permission prep, live socket GID injection, and host.docker.internal exposure for sibling browser containers"
+        return
+    fi
+
+    test_pass
+}
+
+test_deploy_script_prepulls_tracked_browser_sandbox_image() {
+    test_start "Deploy should pre-pull the tracked browser sandbox image before Moltis comes up"
+
+    if [[ ! -f "$PROJECT_ROOT/scripts/deploy.sh" || ! -f "$PROJECT_ROOT/config/moltis.toml" ]]; then
+        test_skip "Missing deploy or config files"
+        return
+    fi
+
+    if ! grep -Fq 'prepull_moltis_browser_sandbox_image()' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq "awk '" "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'docker pull "$sandbox_image"' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       ! grep -Fq 'sandbox_image = "browserless/chrome"' "$PROJECT_ROOT/config/moltis.toml"; then
+        test_fail "Deploy must parse the tracked browser contract with shell-only tooling and pre-pull browserless/chrome so the first browser run is not spent on a cold pull"
+        return
+    fi
+
+    if grep -Fq 'import tomllib' "$PROJECT_ROOT/scripts/deploy.sh" || \
+       grep -Fq 'import tomli' "$PROJECT_ROOT/scripts/deploy.sh"; then
+        test_fail "Deploy must not depend on Python TOML modules in the remote rollout path"
+        return
+    fi
+
+    test_pass
+}
+
 test_deploy_script_force_recreates_moltis_runtime_on_rollout() {
     test_start "Deploy rollout should force-recreate Moltis so runtime config changes are applied"
 
@@ -1273,6 +1320,8 @@ run_all_tests() {
     test_moltis_env_workflows_use_shared_render_script
     test_tracked_deploy_workflows_use_shared_script_entrypoint
     test_deploy_script_verifies_live_moltis_runtime_contract
+    test_deploy_script_exports_live_docker_socket_gid_for_browser_sandbox
+    test_deploy_script_prepulls_tracked_browser_sandbox_image
     test_deploy_script_force_recreates_moltis_runtime_on_rollout
     test_tracked_deploy_workflows_pass_remote_args_without_inline_shell_string
     test_ssh_tracked_deploy_wrapper_dry_run_quotes_unsafe_refs


### PR DESCRIPTION
## Summary
- add a writable shared browser profile contract for the sibling browser sandbox
- prepare and verify the browser profile mount during deploy and runtime attestation
- add a browser canary plus regression coverage so browser recovery is only considered complete after an exercised proof

## Why
Production Telegram runs are still timing out on browser launch and leaking activity logs because the browser sandbox path was only partially restored. Official Moltis browser/sandbox guidance requires the browser container path to be usable end-to-end, and live evidence showed the stock browser image only recovered once the host-visible profile contract was made explicit and writable.

## Validation
- bash -n scripts/deploy.sh scripts/moltis-runtime-attestation.sh scripts/moltis-browser-canary.sh tests/component/test_moltis_runtime_attestation.sh tests/component/test_moltis_browser_canary.sh tests/static/test_config_validation.sh tests/unit/test_deploy_workflow_guards.sh
- bash tests/component/test_moltis_runtime_attestation.sh
- bash tests/component/test_moltis_browser_canary.sh
- bash tests/static/test_config_validation.sh
- bash tests/unit/test_deploy_workflow_guards.sh
- git diff --check
