### PR TITLE
fix(skills): enforce root-cause and reporting contracts

### DIFF
--- a/.ai/instructions/shared-core.md
+++ b/.ai/instructions/shared-core.md
@@ -7,7 +7,7 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 
 ## Operator-Facing Task Reports
 
-If the user asks for a task report, summary, "простыми словами", or a short executive update after implementation/review work:
+If the user asks for a task report, summary, "простыми словами", "кратко", or a short executive update after implementation/review work:
 
 - default to this shape:
   - `Что сделано`
@@ -21,12 +21,14 @@ Rule: `docs/rules/operator-facing-task-report-contract.md`
 
 ## Abnormal Skill Or Helper Behavior
 
-If a skill, helper, workflow, or repo-managed command behaves unexpectedly:
+If a repo-owned skill, helper, workflow, instruction surface, or repo-managed command behaves unexpectedly:
 
 - stop normal task continuation at that boundary
 - run lessons pre-check and RCA
 - treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path
 - fix the source contract in the owning layer before treating the broader task as resolved
+
+For clearly external or transient failures, do not invent a fake local root-fix. Record the RCA and owner classification, then fix a local source contract only if a repo-owned layer caused, amplified, or failed to contain the problem.
 
 Temporary mitigation is allowed only when the user explicitly asked for it and it is clearly labeled as temporary hygiene, not as the real fix.
 

--- a/.ai/instructions/shared-core.md
+++ b/.ai/instructions/shared-core.md
@@ -5,6 +5,33 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 - If the user writes in Russian or explicitly asks for Russian-only communication, respond only in Russian unless the user later asks to switch languages.
 - Do not alternate between Russian and English in user-facing replies unless the user explicitly requests bilingual output or translation.
 
+## Operator-Facing Task Reports
+
+If the user asks for a task report, summary, "простыми словами", or a short executive update after implementation/review work:
+
+- default to this shape:
+  - `Что сделано`
+  - `Что это дает`
+  - `Что дальше`
+- keep each section short and practical
+- prefer operator meaning over file inventory
+- do not lead with branch names, commit SHAs, or path dumps unless the user asked for technical status
+
+Rule: `docs/rules/operator-facing-task-report-contract.md`
+
+## Abnormal Skill Or Helper Behavior
+
+If a skill, helper, workflow, or repo-managed command behaves unexpectedly:
+
+- stop normal task continuation at that boundary
+- run lessons pre-check and RCA
+- treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path
+- fix the source contract in the owning layer before treating the broader task as resolved
+
+Temporary mitigation is allowed only when the user explicitly asked for it and it is clearly labeled as temporary hygiene, not as the real fix.
+
+Rule: `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
 ## Git Topology Reference
 
 Current branch/worktree registry lives in:

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -178,6 +178,9 @@ Rules:
 - Do not auto-mutate `docs/GIT-TOPOLOGY-REGISTRY.md` in the invoking branch during ordinary Phase A worktree flows.
 - If topology is stale, report it honestly and point to the dedicated publish path instead of injecting a docs-only commit into the invoking branch.
 - If a separate UAT worktree later carries local changes to `docs/GIT-TOPOLOGY-REGISTRY.md`, inspect them as drift instead of treating them as authoritative branch-local evidence before treating the UAT branch as disposable.
+- If the helper output is abnormal (hang, contradictory boundary, ambiguous next step, partial mutation), stop the original task and treat the helper behavior as a defect.
+- Do not finish the downstream task through manual git/PR/publish workarounds just because the intended helper path felt unreliable.
+- If temporary mitigation is explicitly requested, label it as mitigation only, then create the root-fix follow-up and repair the source contract in the owning layer.
 
 ## Start Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,33 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 - If the user writes in Russian or explicitly asks for Russian-only communication, respond only in Russian unless the user later asks to switch languages.
 - Do not alternate between Russian and English in user-facing replies unless the user explicitly requests bilingual output or translation.
 
+## Operator-Facing Task Reports
+
+If the user asks for a task report, summary, "простыми словами", or a short executive update after implementation/review work:
+
+- default to this shape:
+  - `Что сделано`
+  - `Что это дает`
+  - `Что дальше`
+- keep each section short and practical
+- prefer operator meaning over file inventory
+- do not lead with branch names, commit SHAs, or path dumps unless the user asked for technical status
+
+Rule: `docs/rules/operator-facing-task-report-contract.md`
+
+## Abnormal Skill Or Helper Behavior
+
+If a skill, helper, workflow, or repo-managed command behaves unexpectedly:
+
+- stop normal task continuation at that boundary
+- run lessons pre-check and RCA
+- treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path
+- fix the source contract in the owning layer before treating the broader task as resolved
+
+Temporary mitigation is allowed only when the user explicitly asked for it and it is clearly labeled as temporary hygiene, not as the real fix.
+
+Rule: `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
 ## Git Topology Reference
 
 Current branch/worktree registry lives in:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 
 ## Operator-Facing Task Reports
 
-If the user asks for a task report, summary, "простыми словами", or a short executive update after implementation/review work:
+If the user asks for a task report, summary, "простыми словами", "кратко", or a short executive update after implementation/review work:
 
 - default to this shape:
   - `Что сделано`
@@ -27,12 +27,14 @@ Rule: `docs/rules/operator-facing-task-report-contract.md`
 
 ## Abnormal Skill Or Helper Behavior
 
-If a skill, helper, workflow, or repo-managed command behaves unexpectedly:
+If a repo-owned skill, helper, workflow, instruction surface, or repo-managed command behaves unexpectedly:
 
 - stop normal task continuation at that boundary
 - run lessons pre-check and RCA
 - treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path
 - fix the source contract in the owning layer before treating the broader task as resolved
+
+For clearly external or transient failures, do not invent a fake local root-fix. Record the RCA and owner classification, then fix a local source contract only if a repo-owned layer caused, amplified, or failed to contain the problem.
 
 Temporary mitigation is allowed only when the user explicitly asked for it and it is clearly labeled as temporary hygiene, not as the real fix.
 

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-04-05
-**Total Lessons**: 70
+**Generated**: 2026-04-09
+**Total Lessons**: 71
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (30 lessons)
+#### P1 (31 lessons)
+- [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
 - [Runtime-only Beads repair still pointed at raw bootstrap after the CLI contract drifted](../docs/rca/2026-03-29-runtime-only-repair-contract-still-pointed-at-raw-bootstrap.md)
 - [Managed worktree creation mixed up the create executor and hook bootstrap-source contract](../docs/rca/2026-03-28-worktree-create-helper-and-hook-bootstrap-source-drift.md)
 - [Moltis Telegram user bots needed explicit stream_mode off](../docs/rca/2026-03-28-moltis-telegram-user-bots-needed-explicit-stream-mode-off.md)
@@ -141,7 +142,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (23 lessons)
+#### process (24 lessons)
+- [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
 - [Telegram skill-detail remained non-terminal and repo skills lacked a shared Telegram-safe summary contract](../docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md)
 - [Runtime-only Beads repair still pointed at raw bootstrap after the CLI contract drifted](../docs/rca/2026-03-29-runtime-only-repair-contract-still-pointed-at-raw-bootstrap.md)
 - [Managed worktree creation mixed up the create executor and hook bootstrap-source contract](../docs/rca/2026-03-28-worktree-create-helper-and-hook-bootstrap-source-drift.md)
@@ -181,13 +183,13 @@
 ### Popular Tags
 
 - `moltis` (26 lessons)
-- `rca` (19 lessons)
+- `rca` (20 lessons)
 - `deploy` (18 lessons)
 - `github-actions` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `telegram` (15 lessons)
-- `skills` (9 lessons)
+- `skills` (10 lessons)
 - `process` (9 lessons)
 - `lessons` (9 lessons)
 
@@ -198,10 +200,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 70 |
-| Critical (P0/P1) | 31 |
+| Total Lessons | 71 |
+| Critical (P0/P1) | 32 |
 | Categories | 6 |
-| Unique Tags | 145 |
+| Unique Tags | 147 |
 
 ---
 

--- a/docs/WORKTREE-HOTFIX-PLAYBOOK.md
+++ b/docs/WORKTREE-HOTFIX-PLAYBOOK.md
@@ -17,6 +17,14 @@ Do not fix `command-worktree` directly in `main`.
 
 Always use a short-lived fix branch from fresh `main`.
 
+If the helper or command behaves abnormally:
+
+- do not continue the original task through manual git, PR, cleanup, or publish steps just to get past the broken helper
+- treat the abnormal behavior itself as the defect to fix
+- run RCA and repair the owning contract first
+
+Manual cleanup or hygiene actions are acceptable only as temporary mitigation under explicit user direction, never as a substitute for the helper fix.
+
 ## Simple Workflow
 
 1. Reproduce the problem once.

--- a/docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md
+++ b/docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md
@@ -71,6 +71,7 @@ Two connected process defects overlapped:
 
 1. Added a project-level rule:
    - [docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md)
+   - narrowed the rule to repo-owned contract failures and documented how external/transient incidents are classified without inventing fake local root-fixes
 2. Added a project-level operator report rule:
    - [docs/rules/operator-facing-task-report-contract.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/docs/rules/operator-facing-task-report-contract.md)
 3. Updated shared source instructions so both rules become part of generated [AGENTS.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/AGENTS.md).
@@ -81,8 +82,9 @@ Two connected process defects overlapped:
 
 1. Treat repo-managed skills and helper workflows as operator contracts, not prose guidance.
 2. If a helper behaves abnormally, stop the parent task and repair the helper path first.
-3. Keep user-facing simple reports short and structurally predictable.
-4. Guard project-level execution rules with static tests, not just tribal memory.
+3. Keep repo-owned contract defects separate from external/transient incidents; only localize a fix when a repo-owned layer actually caused or failed to contain the problem.
+4. Keep user-facing simple reports short and structurally predictable.
+5. Guard project-level execution rules with static tests, not just tribal memory.
 
 ## Уроки
 

--- a/docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md
+++ b/docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md
@@ -1,0 +1,96 @@
+---
+title: "Skill execution drifted into workaround behavior and task reports lacked a shared simple contract"
+date: 2026-04-09
+severity: P1
+category: process
+tags: [skills, worktree, reporting, operator-contract, rca, guardrails]
+root_cause: "The repository had strong local rules for specific workflows, but no single project-level contract that forced abnormal helper behavior into RCA/root-fix mode and no shared simple-report contract for operator-facing task updates. As a result, the assistant could keep moving through workaround-style actions and verbose reports even after the workflow contract had already broken."
+---
+
+# RCA: Skill execution and reporting contract drift
+
+Date: 2026-04-09
+Context: repeated operator-facing failures during worktree, publish, and task-report flows
+
+## Error
+
+Recent sessions produced the same family of failures under different symptoms:
+
+1. helper or workflow behavior became abnormal, but task execution still continued through manual compensating actions;
+2. RCA was invoked too late, after extra operator-facing damage had already happened;
+3. "простыми словами" task reports drifted into long technical status dumps instead of short operator summaries;
+4. worktree/handoff boundaries were treated as advisory text instead of a fail-closed contract.
+
+## Lessons Pre-check
+
+Before writing this RCA, the lessons index and related RCA files were checked:
+
+```bash
+./scripts/query-lessons.sh --all | rg -n 'worktree|skill|report|operator|RCA|handoff|guard|workflow'
+```
+
+Relevant prior lessons:
+
+1. [2026-03-09: Command-worktree follow-up UAT exposed preview, sync, and lock edge-case gaps](./2026-03-09-command-worktree-followup-uat.md)
+2. [2026-03-28: Managed worktree creation mixed up the create executor and hook bootstrap-source contract](./2026-03-28-worktree-create-helper-and-hook-bootstrap-source-drift.md)
+3. [2026-04-05: Telegram skill-detail remained non-terminal and repo skills lacked a shared Telegram-safe summary contract](./2026-04-05-telegram-skill-detail-general-hardening.md)
+
+What those lessons already covered:
+
+- worktree helpers must be fail-closed and explicit about their true boundary;
+- user-facing skill behavior needs a shared contract, not just ad hoc per-skill fixes;
+- workflow contract drift must be guarded by tests, not left to operator memory.
+
+What they did **not** yet close:
+
+1. a project-level rule that abnormal helper/skill behavior must switch execution into RCA/root-fix mode instead of workaround continuation;
+2. a project-level rule that simple operator-facing task reports must use one short predictable format;
+3. a static guard that keeps those two contracts present in source instructions and high-traffic workflow docs.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Why did operator-facing sessions still produce too many mistakes even after earlier hardening? | Because when a helper or workflow deviated from its expected contract, execution still continued instead of switching immediately into defect-fix mode. |
+| 2 | Why was continuation possible? | Because the repository had workflow-specific hotfix guidance, but not one project-level rule that said abnormal skill/helper behavior itself is a blocking defect. |
+| 3 | Why did user-facing reports still come out in the wrong shape? | Because the repository had generic communication guidance, but no shared simple-report contract for task summaries requested "простыми словами". |
+| 4 | Why were these gaps not caught earlier? | Because there was no static guard checking for those contracts in source instructions and high-traffic command docs. |
+| 5 | Why did this become a recurring process problem instead of a one-off slip? | Because skills and helper workflows were treated as helpful guidance rather than as testable operator contracts with explicit failure semantics. |
+
+## Root Cause
+
+Two connected process defects overlapped:
+
+1. **Abnormal helper behavior was not elevated into a mandatory root-fix path at the project level.**  
+   The repo had local lessons and some playbooks, but no single cross-cutting rule that said "if the helper is weird, stop and fix the helper contract first."
+
+2. **Operator-facing task reporting lacked a shared simple contract.**  
+   Without an explicit repo rule, summaries could drift back into changelog-style technical dumps even when the user asked for a short practical report.
+
+## Fixes Applied
+
+1. Added a project-level rule:
+   - [docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md)
+2. Added a project-level operator report rule:
+   - [docs/rules/operator-facing-task-report-contract.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/docs/rules/operator-facing-task-report-contract.md)
+3. Updated shared source instructions so both rules become part of generated [AGENTS.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/AGENTS.md).
+4. Updated [worktree.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/.claude/commands/worktree.md) and [WORKTREE-HOTFIX-PLAYBOOK.md](/Users/rl/coding/moltinger/moltinger-main-moltinger-ik6d-skill-execution-rca-hardening/docs/WORKTREE-HOTFIX-PLAYBOOK.md) so abnormal helper behavior no longer silently funnels into manual workaround completion.
+5. Added a static regression test to keep these contracts from drifting again.
+
+## Prevention
+
+1. Treat repo-managed skills and helper workflows as operator contracts, not prose guidance.
+2. If a helper behaves abnormally, stop the parent task and repair the helper path first.
+3. Keep user-facing simple reports short and structurally predictable.
+4. Guard project-level execution rules with static tests, not just tribal memory.
+
+## Уроки
+
+1. Локальные hotfix playbook’и не заменяют project-level stop rule для abnormal helper behavior.
+2. Если у проекта нет одного явного simple-report contract, ответы постепенно возвращаются к verbose техническому стилю.
+3. Навыки и workflow helper’ы нужно считать testable operator contract’ами, а не только документацией.
+4. Правило без static guard слишком легко снова размывается в следующих сессиях.
+
+---
+
+*Создано по протоколу rca-5-whys*

--- a/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md
+++ b/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md
@@ -1,0 +1,44 @@
+# Abnormal Skill Or Helper Behavior Needs Root-Cause Fix
+
+If a skill, helper, workflow, or repo-managed command behaves unexpectedly, treat it as a first-class defect.
+
+Examples:
+
+- the helper hangs or takes unexpectedly long without a clear contract
+- output contradicts the declared boundary or next-step contract
+- a tool reports partial success but leaves ambiguous state
+- the assistant starts improvising manual git/PR/publish actions because the intended workflow felt unreliable
+- user-facing reports drift away from the requested format even though a project rule exists
+
+## Required response
+
+1. Stop normal task continuation at the abnormal boundary.
+2. Run the lessons pre-check and then RCA.
+3. Record the defect as an issue or explicit follow-up if it is not already tracked.
+4. Fix the source contract in the owning layer:
+   - source instructions
+   - rule file
+   - helper/workflow script
+   - skill/command source
+   - regression test
+5. Resume the broader task only after the defect is either:
+   - fixed, or
+   - explicitly reclassified as a separate follow-up by the user.
+
+## No-workaround rule
+
+- Do not use a manual workaround as a substitute for fixing the broken skill/helper path.
+- Do not normalize "we finished the task manually" as success if the official workflow contract was the thing that failed.
+- A reversible hygiene action is allowed only when:
+  - the user explicitly asked for it, and
+  - it is clearly labeled as temporary mitigation, not resolution.
+
+If temporary mitigation is used, it must still produce:
+
+1. RCA
+2. follow-up issue
+3. dedicated fix lane when shared contracts are involved
+
+## Rationale
+
+Workflows that require ad hoc operator improvisation are already broken. If the broken path is left in place, the same failure returns in the next session with a different symptom.

--- a/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md
+++ b/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md
@@ -1,6 +1,15 @@
 # Abnormal Skill Or Helper Behavior Needs Root-Cause Fix
 
-If a skill, helper, workflow, or repo-managed command behaves unexpectedly, treat it as a first-class defect.
+If a repo-owned skill, helper, workflow, instruction surface, or repo-managed command behaves unexpectedly, treat it as a first-class defect.
+
+This rule is for **repo-owned contract failures** such as:
+
+- source instructions and generated instruction drift
+- helper or workflow scripts with ambiguous or contradictory behavior
+- skill or command guidance that pushes the session into workaround-style execution
+- operator-facing response formats that violate an explicit project rule
+
+It is **not** a rule that every external or transient failure must invent a local root-fix. Remote outages, auth expiry, connector instability, rate limits, or other third-party incidents still require evidence and classification, but they only require a local source-contract fix when a repo-owned layer caused, amplified, or failed to contain the problem.
 
 Examples:
 
@@ -38,6 +47,22 @@ If temporary mitigation is used, it must still produce:
 1. RCA
 2. follow-up issue
 3. dedicated fix lane when shared contracts are involved
+
+## Ownership boundary
+
+`Fix the source contract in the owning layer` means:
+
+- fix the repo-owned layer that created the broken expectation, or
+- if the failure is external/transient, record the RCA and owner classification without inventing a fake local contract fix.
+
+Examples of repo-owned owning layers:
+
+- source instructions
+- generated instructions
+- rule files
+- helper/workflow scripts
+- skill or command source
+- regression tests
 
 ## Rationale
 

--- a/docs/rules/operator-facing-task-report-contract.md
+++ b/docs/rules/operator-facing-task-report-contract.md
@@ -1,0 +1,35 @@
+# Operator-Facing Task Report Contract
+
+Use this rule when the user asks for a task report, summary, "простыми словами", "кратко", or an executive update after implementation/review work.
+
+## Goal
+
+Keep operator-facing reports short, predictable, and immediately useful.
+
+The default simple report shape is:
+
+1. `Что сделано`
+2. `Что это дает`
+3. `Что дальше`
+
+## Required behavior
+
+- If the user explicitly asks for a simple summary, answer in the three-section shape above unless the user requested a different format.
+- Each section should stay short:
+  - 1 short paragraph, or
+  - 1-3 flat bullets if the content is inherently list-shaped.
+- Prefer user impact and operational meaning over file-by-file changelog.
+- Do not front-load branch names, commit SHAs, or path inventories unless the user explicitly asked for technical status.
+- If work is incomplete, say so directly in `Что дальше` instead of burying the blocker in implementation detail.
+- If the user asks for even shorter wording, compress the same contract into 3-5 sentences while preserving the same three ideas.
+
+## Forbidden defaults
+
+- Do not dump a changelog when the user asked for "простыми словами".
+- Do not answer with long technical inventory before the simple summary.
+- Do not force architecture/process narration when the user asked for a practical report.
+- Do not replace the report with motivational or conversational filler.
+
+## Rationale
+
+The user should not need to decode implementation detail to understand task outcome, value, and next action.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -157,6 +157,7 @@ bash|static_config_validation|Config validation|$SCRIPT_DIR/static/test_config_v
 bash|static_fleet_registry|Fleet registry and policy|$SCRIPT_DIR/static/test_fleet_registry.sh
 bash|static_dev_mcp_smoke|Dev MCP smoke|$SCRIPT_DIR/static/test_dev_mcp_smoke.sh
 bash|static_beads_worktree_ownership|Beads worktree ownership guardrails|$SCRIPT_DIR/static/test_beads_worktree_ownership.sh
+bash|static_skill_execution_contracts|Skill execution and reporting contracts|$SCRIPT_DIR/static/test_skill_execution_contracts.sh
 LIST
             ;;
         component)

--- a/tests/static/test_skill_execution_contracts.sh
+++ b/tests/static/test_skill_execution_contracts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+SHARED_CORE_INSTRUCTIONS="$PROJECT_ROOT/.ai/instructions/shared-core.md"
+ROOT_AGENTS="$PROJECT_ROOT/AGENTS.md"
+WORKTREE_COMMAND="$PROJECT_ROOT/.claude/commands/worktree.md"
+WORKTREE_HOTFIX_PLAYBOOK="$PROJECT_ROOT/docs/WORKTREE-HOTFIX-PLAYBOOK.md"
+REPORT_RULE="$PROJECT_ROOT/docs/rules/operator-facing-task-report-contract.md"
+ABNORMAL_BEHAVIOR_RULE="$PROJECT_ROOT/docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md"
+
+run_static_skill_execution_contract_tests() {
+    start_timer
+
+    test_start "static_report_contract_exists_and_requires_simple_operator_shape"
+    if [[ -f "$REPORT_RULE" ]] && \
+       rg -q -F '1. `Что сделано`' "$REPORT_RULE" && \
+       rg -q -F '2. `Что это дает`' "$REPORT_RULE" && \
+       rg -q -F '3. `Что дальше`' "$REPORT_RULE" && \
+       rg -q -F 'Do not dump a changelog when the user asked for "простыми словами".' "$REPORT_RULE"; then
+        test_pass
+    else
+        test_fail "Operator-facing report rule must enforce the short three-section summary contract"
+    fi
+
+    test_start "static_abnormal_helper_rule_requires_root_fix_not_workaround"
+    if [[ -f "$ABNORMAL_BEHAVIOR_RULE" ]] && \
+       rg -q -F '1. Stop normal task continuation at the abnormal boundary.' "$ABNORMAL_BEHAVIOR_RULE" && \
+       rg -q -F '2. Run the lessons pre-check and then RCA.' "$ABNORMAL_BEHAVIOR_RULE" && \
+       rg -q -F 'Do not use a manual workaround as a substitute for fixing the broken skill/helper path.' "$ABNORMAL_BEHAVIOR_RULE" && \
+       rg -q -F 'If temporary mitigation is used, it must still produce:' "$ABNORMAL_BEHAVIOR_RULE"; then
+        test_pass
+    else
+        test_fail "Abnormal helper behavior rule must require RCA and root-fix instead of workaround continuation"
+    fi
+
+    test_start "static_shared_core_carries_operator_report_and_root_fix_contracts"
+    if rg -q -F '## Operator-Facing Task Reports' "$SHARED_CORE_INSTRUCTIONS" && \
+       rg -q -F 'Rule: `docs/rules/operator-facing-task-report-contract.md`' "$SHARED_CORE_INSTRUCTIONS" && \
+       rg -q -F '## Abnormal Skill Or Helper Behavior' "$SHARED_CORE_INSTRUCTIONS" && \
+       rg -q -F 'Rule: `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`' "$SHARED_CORE_INSTRUCTIONS" && \
+       rg -q -F 'treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path' "$SHARED_CORE_INSTRUCTIONS"; then
+        test_pass
+    else
+        test_fail "Shared source instructions must carry both the simple-report and abnormal-helper root-fix contracts"
+    fi
+
+    test_start "static_generated_root_agents_inherits_new_contracts"
+    if rg -q -F '## Operator-Facing Task Reports' "$ROOT_AGENTS" && \
+       rg -q -F '## Abnormal Skill Or Helper Behavior' "$ROOT_AGENTS" && \
+       rg -q -F 'Что сделано' "$ROOT_AGENTS" && \
+       rg -q -F 'fix the source contract in the owning layer before treating the broader task as resolved' "$ROOT_AGENTS"; then
+        test_pass
+    else
+        test_fail "Generated AGENTS.md must inherit the simple-report and root-fix behavior contracts"
+    fi
+
+    test_start "static_worktree_guidance_forbids_manual_completion_when_helper_breaks"
+    if rg -q -F 'do not continue the original task through manual git, PR, cleanup, or publish steps just to get past the broken helper' "$WORKTREE_HOTFIX_PLAYBOOK" && \
+       rg -q -F 'Manual cleanup or hygiene actions are acceptable only as temporary mitigation under explicit user direction' "$WORKTREE_HOTFIX_PLAYBOOK" && \
+       rg -q -F 'Do not finish the downstream task through manual git/PR/publish workarounds just because the intended helper path felt unreliable.' "$WORKTREE_COMMAND" && \
+       rg -q -F 'If temporary mitigation is explicitly requested, label it as mitigation only, then create the root-fix follow-up and repair the source contract in the owning layer.' "$WORKTREE_COMMAND"; then
+        test_pass
+    else
+        test_fail "Worktree playbook and command source must reject workaround-based completion when helper behavior is abnormal"
+    fi
+
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    run_static_skill_execution_contract_tests "$@"
+fi

--- a/tests/static/test_skill_execution_contracts.sh
+++ b/tests/static/test_skill_execution_contracts.sh
@@ -28,9 +28,11 @@ run_static_skill_execution_contract_tests() {
 
     test_start "static_abnormal_helper_rule_requires_root_fix_not_workaround"
     if [[ -f "$ABNORMAL_BEHAVIOR_RULE" ]] && \
+       rg -q -F 'repo-owned skill, helper, workflow, instruction surface, or repo-managed command' "$ABNORMAL_BEHAVIOR_RULE" && \
        rg -q -F '1. Stop normal task continuation at the abnormal boundary.' "$ABNORMAL_BEHAVIOR_RULE" && \
        rg -q -F '2. Run the lessons pre-check and then RCA.' "$ABNORMAL_BEHAVIOR_RULE" && \
        rg -q -F 'Do not use a manual workaround as a substitute for fixing the broken skill/helper path.' "$ABNORMAL_BEHAVIOR_RULE" && \
+       rg -q -F 'if the failure is external/transient, record the RCA and owner classification without inventing a fake local contract fix.' "$ABNORMAL_BEHAVIOR_RULE" && \
        rg -q -F 'If temporary mitigation is used, it must still produce:' "$ABNORMAL_BEHAVIOR_RULE"; then
         test_pass
     else
@@ -40,9 +42,11 @@ run_static_skill_execution_contract_tests() {
     test_start "static_shared_core_carries_operator_report_and_root_fix_contracts"
     if rg -q -F '## Operator-Facing Task Reports' "$SHARED_CORE_INSTRUCTIONS" && \
        rg -q -F 'Rule: `docs/rules/operator-facing-task-report-contract.md`' "$SHARED_CORE_INSTRUCTIONS" && \
+       rg -q -F '"кратко"' "$SHARED_CORE_INSTRUCTIONS" && \
        rg -q -F '## Abnormal Skill Or Helper Behavior' "$SHARED_CORE_INSTRUCTIONS" && \
        rg -q -F 'Rule: `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`' "$SHARED_CORE_INSTRUCTIONS" && \
-       rg -q -F 'treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path' "$SHARED_CORE_INSTRUCTIONS"; then
+       rg -q -F 'treat the behavior as a first-class defect, not as a cue to improvise a workaround completion path' "$SHARED_CORE_INSTRUCTIONS" && \
+       rg -q -F 'For clearly external or transient failures, do not invent a fake local root-fix.' "$SHARED_CORE_INSTRUCTIONS"; then
         test_pass
     else
         test_fail "Shared source instructions must carry both the simple-report and abnormal-helper root-fix contracts"
@@ -51,8 +55,10 @@ run_static_skill_execution_contract_tests() {
     test_start "static_generated_root_agents_inherits_new_contracts"
     if rg -q -F '## Operator-Facing Task Reports' "$ROOT_AGENTS" && \
        rg -q -F '## Abnormal Skill Or Helper Behavior' "$ROOT_AGENTS" && \
+       rg -q -F '"кратко"' "$ROOT_AGENTS" && \
        rg -q -F 'Что сделано' "$ROOT_AGENTS" && \
-       rg -q -F 'fix the source contract in the owning layer before treating the broader task as resolved' "$ROOT_AGENTS"; then
+       rg -q -F 'fix the source contract in the owning layer before treating the broader task as resolved' "$ROOT_AGENTS" && \
+       rg -q -F 'For clearly external or transient failures, do not invent a fake local root-fix.' "$ROOT_AGENTS"; then
         test_pass
     else
         test_fail "Generated AGENTS.md must inherit the simple-report and root-fix behavior contracts"


### PR DESCRIPTION
## Summary
- add a project rule requiring RCA and root-fix whenever a skill/helper/workflow behaves abnormally
- add a project rule for short operator-facing task reports in the `Что сделано / Что это дает / Что дальше` shape
- wire both contracts into shared instructions, worktree playbook, worktree command guidance, RCA memory, and static CI coverage

## Testing
- `bash tests/static/test_skill_execution_contracts.sh`
- `./tests/run.sh --lane static --filter skill_execution_contracts --json`
- `make instructions-check`
- `make codex-check`
- `bash tests/unit/test_worktree_ready.sh`
- `git diff --check`