### PR TITLE
fix: harden gpt-5.4 codex runtime persistence

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -125,7 +125,7 @@ route:
           repeat_interval: 1h
         # GLM down - warning level
         - matchers:
-            - alertname="GLMProviderDown"
+            - alertname="PrimaryLLMProviderDown"
           receiver: 'llm-failover-alerts'
           group_wait: 2m
           repeat_interval: 2h

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -268,17 +268,17 @@ groups:
       # CIRCUIT BREAKER & FAILOVER ALERTS (Fallback LLM Feature)
       # ====================================================================
 
-      # GLM provider unavailable
-      - alert: GLMProviderDown
-        expr: llm_provider_available{provider="glm"} == 0
+      # Primary OpenAI Codex OAuth provider unavailable
+      - alert: PrimaryLLMProviderDown
+        expr: llm_provider_available{provider="openai-codex"} == 0
         for: 1m
         labels:
           severity: warning
           service: moltis
           component: llm-failover
         annotations:
-          summary: "GLM (Z.ai) provider is unavailable"
-          description: "Primary LLM provider GLM has been unavailable for more than 1 minute. Fallback to Ollama may be active."
+          summary: "Primary OpenAI Codex provider is unavailable"
+          description: "Primary LLM provider openai-codex has been unavailable for more than 1 minute. Fallback to Ollama may be active."
 
       # Circuit breaker opened (failover active)
       - alert: CircuitBreakerOpen
@@ -290,7 +290,7 @@ groups:
           component: llm-failover
         annotations:
           summary: "Circuit breaker is OPEN - using fallback provider"
-          description: "Circuit breaker has opened due to GLM failures. System is now using Ollama fallback. Check GLM API status."
+          description: "Circuit breaker has opened due to openai-codex failures. System is now using Ollama fallback. Check Moltis OAuth auth status."
 
       # Circuit breaker half-open (testing recovery)
       - alert: CircuitBreakerHalfOpen
@@ -302,12 +302,12 @@ groups:
           component: llm-failover
         annotations:
           summary: "Circuit breaker is HALF-OPEN - testing recovery"
-          description: "Circuit breaker is testing if GLM provider has recovered. If successful, will return to CLOSED state."
+          description: "Circuit breaker is testing if the primary openai-codex provider has recovered. If successful, will return to CLOSED state."
 
       # Critical: Both providers down
       - alert: AllLLMProvidersDown
         expr: |
-          (llm_provider_available{provider="glm"} == 0) and (llm_provider_available{provider="ollama"} == 0)
+          (llm_provider_available{provider="openai-codex"} == 0) and (llm_provider_available{provider="ollama"} == 0)
         for: 30s
         labels:
           severity: critical
@@ -315,7 +315,7 @@ groups:
           component: llm-failover
         annotations:
           summary: "CRITICAL: All LLM providers are unavailable"
-          description: "Both GLM and Ollama providers are down. Moltis cannot process LLM requests. Immediate intervention required."
+          description: "Both openai-codex and Ollama providers are down. Moltis cannot process LLM requests. Immediate intervention required."
 
       # Fallback triggered (counter increased)
       - alert: LLMFallbackTriggered

--- a/docs/SECRETS-MANAGEMENT.md
+++ b/docs/SECRETS-MANAGEMENT.md
@@ -215,6 +215,9 @@ bash /opt/moltinger-active/scripts/prepare-moltis-runtime-config.sh \
 ```
 
 This keeps `moltis.toml` under GitOps while preserving OAuth/provider state across deploys.
+If `provider_keys.json` already exists, the helper also reasserts the tracked
+`providers.openai-codex.model` as the first runtime preference so a stale
+`gpt-5.4-mini` choice does not survive into the next restart.
 
 ---
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -118,9 +118,9 @@ GLM-5 (Z.ai) -> Ollama Gemini -> Google Gemini
 
 | State | Meaning | Active provider |
 |-------|---------|-----------------|
-| `CLOSED` | normal operation | GLM-5 |
+| `CLOSED` | normal operation | OpenAI Codex (`gpt-5.4`) |
 | `OPEN` | failover active | Ollama |
-| `HALF-OPEN` | testing primary recovery | GLM-5 probe |
+| `HALF-OPEN` | testing primary recovery | OpenAI Codex auth probe |
 
 ### Primary Checks
 
@@ -135,13 +135,13 @@ cat /tmp/moltis-llm-state.json | jq .
 Force failover:
 
 ```bash
-echo '{"state":"OPEN","primary_provider":"glm","active_provider":"ollama","consecutive_failures":3,"last_check":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","last_failover":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' > /tmp/moltis-llm-state.json
+echo '{"state":"open","failure_count":3,"success_count":0,"last_failure_time":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","last_state_change":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","active_provider":"ollama","fallback_provider":"ollama"}' > /tmp/moltis-llm-state.json
 ```
 
-Force recovery to GLM:
+Force recovery to OpenAI Codex:
 
 ```bash
-echo '{"state":"CLOSED","primary_provider":"glm","active_provider":"glm","consecutive_failures":0,"last_check":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","last_failover":null}' > /tmp/moltis-llm-state.json
+echo '{"state":"closed","failure_count":0,"success_count":0,"last_failure_time":null,"last_state_change":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","active_provider":"openai-codex","fallback_provider":"ollama"}' > /tmp/moltis-llm-state.json
 ```
 
 Restart Ollama:

--- a/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
+++ b/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
@@ -111,6 +111,14 @@ What this must preserve:
 - `provider_keys.json`
 - `credentials.json`
 
+Additional invariant:
+
+- if `provider_keys.json` already exists, `prepare-moltis-runtime-config.sh` must keep
+  the tracked `providers.openai-codex.model` first in
+  `provider_keys.json["openai-codex"].models`
+- this preserves OAuth/provider state while preventing runtime model preference drift
+  back to `gpt-5.4-mini`
+
 ## 5. Pull the exact image version explicitly
 
 Do not skip this.
@@ -408,6 +416,34 @@ Likely cause:
 Fix:
 
 - open the model selector and manually switch the session to `GPT 5.4 (Codex/OAuth)`
+
+### Symptom: `auth status` is valid, but live chat still runs `openai-codex::gpt-5.4-mini`
+
+Likely cause:
+
+- runtime-managed `/opt/moltinger-state/config-runtime/provider_keys.json` still prefers
+  `gpt-5.4-mini` ahead of tracked `providers.openai-codex.model = "gpt-5.4"`
+
+Inspect:
+
+```bash
+jq -r '."openai-codex".models' /opt/moltinger-state/config-runtime/provider_keys.json
+docker logs --since 2m moltis 2>&1 | grep -E 'chat.send|openai-codex stream_with_tools request model='
+```
+
+Fix:
+
+```bash
+cd /opt/moltinger-active
+bash ./scripts/prepare-moltis-runtime-config.sh ./config /opt/moltinger-state/config-runtime
+docker restart moltis
+```
+
+Expected proof:
+
+- `jq -r '."openai-codex".models[0]' .../provider_keys.json` returns `gpt-5.4`
+- `docker exec moltis moltis auth status` still shows `openai-codex [valid ...]`
+- live canary reports `provider=openai-codex`, `model=openai-codex::gpt-5.4`
 
 ### Symptom: Traefik looks healthy, but chat still fails
 

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -198,6 +198,11 @@ check_http_health() {
 # LLM PROVIDER HEALTH CHECKS (Circuit Breaker Support)
 # ========================================================================
 
+# Production chain defaults: OpenAI Codex OAuth -> Ollama -> Z.ai.
+PRIMARY_PROVIDER="${PRIMARY_PROVIDER:-openai-codex}"
+FALLBACK_PROVIDER="${FALLBACK_PROVIDER:-ollama}"
+MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
+
 # GLM API configuration
 GLM_API_HOST="${GLM_API_HOST:-https://api.z.ai}"
 GLM_API_KEY="${GLM_API_KEY:-}"
@@ -208,6 +213,30 @@ GLM_HEALTH_TIMEOUT="${GLM_HEALTH_TIMEOUT:-10}"
 OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-gemini-3-flash-preview:cloud}"
 OLLAMA_HEALTH_TIMEOUT="${OLLAMA_HEALTH_TIMEOUT:-10}"
+
+# OpenAI Codex OAuth configuration
+OPENAI_CODEX_HEALTH_TIMEOUT="${OPENAI_CODEX_HEALTH_TIMEOUT:-10}"
+
+check_openai_codex_health() {
+    local timeout="${1:-$OPENAI_CODEX_HEALTH_TIMEOUT}"
+    local auth_output provider_line
+
+    if ! command -v docker >/dev/null 2>&1; then
+        log_warn "docker is unavailable, cannot validate openai-codex auth state"
+        return 2
+    fi
+
+    auth_output="$(timeout "$timeout" docker exec "$MOLTIS_CONTAINER" moltis auth status 2>/dev/null || true)"
+    provider_line="$(printf '%s\n' "$auth_output" | grep -F 'openai-codex' | tail -1 || true)"
+
+    if [[ -n "$provider_line" ]] && grep -Fq '[valid' <<<"$provider_line"; then
+        log_info "OpenAI Codex auth is healthy"
+        return 0
+    fi
+
+    log_error "OpenAI Codex auth is not valid"
+    return 1
+}
 
 # Check GLM (Z.ai) API health
 check_glm_health() {
@@ -279,26 +308,63 @@ check_ollama_health() {
 
 # Get current LLM provider status for JSON output
 get_llm_provider_status() {
-    local glm_status="unknown"
-    local ollama_status="unknown"
+    local primary_status="unknown"
+    local fallback_status="unknown"
 
-    if [[ -n "$GLM_API_KEY" ]]; then
-        if check_glm_health > /dev/null 2>&1; then
-            glm_status="healthy"
-        else
-            glm_status="unhealthy"
-        fi
+    if check_primary_provider_health > /dev/null 2>&1; then
+        primary_status="healthy"
     else
-        glm_status="not_configured"
+        primary_status="unhealthy"
     fi
 
-    if check_ollama_health > /dev/null 2>&1; then
-        ollama_status="healthy"
+    if check_fallback_provider_health > /dev/null 2>&1; then
+        fallback_status="healthy"
     else
-        ollama_status="unhealthy"
+        fallback_status="unhealthy"
     fi
 
-    echo "{\"glm\":\"$glm_status\",\"ollama\":\"$ollama_status\"}"
+    jq -nc \
+        --arg primary_provider "$PRIMARY_PROVIDER" \
+        --arg primary_status "$primary_status" \
+        --arg fallback_provider "$FALLBACK_PROVIDER" \
+        --arg fallback_status "$fallback_status" \
+        '[{"key": $primary_provider, "value": $primary_status}, {"key": $fallback_provider, "value": $fallback_status}] | from_entries'
+}
+
+check_primary_provider_health() {
+    case "$PRIMARY_PROVIDER" in
+        openai-codex)
+            check_openai_codex_health "$@"
+            ;;
+        glm|zai)
+            check_glm_health "$@"
+            ;;
+        ollama)
+            check_ollama_health "$@"
+            ;;
+        *)
+            log_warn "Unknown primary provider health contract: $PRIMARY_PROVIDER"
+            return 2
+            ;;
+    esac
+}
+
+check_fallback_provider_health() {
+    case "$FALLBACK_PROVIDER" in
+        ollama)
+            check_ollama_health "$@"
+            ;;
+        glm|zai)
+            check_glm_health "$@"
+            ;;
+        openai-codex)
+            check_openai_codex_health "$@"
+            ;;
+        *)
+            log_warn "Unknown fallback provider health contract: $FALLBACK_PROVIDER"
+            return 2
+            ;;
+    esac
 }
 
 # ========================================================================
@@ -329,8 +395,8 @@ init_circuit_breaker() {
     "success_count": 0,
     "last_failure_time": null,
     "last_state_change": "$(get_timestamp)",
-    "active_provider": "glm",
-    "fallback_provider": "ollama"
+    "active_provider": "$PRIMARY_PROVIDER",
+    "fallback_provider": "$FALLBACK_PROVIDER"
 }
 EOF
 )
@@ -427,25 +493,25 @@ record_failure() {
         "$CB_STATE_CLOSED")
             if [[ $failure_count -ge $CIRCUIT_BREAKER_FAILURE_THRESHOLD ]]; then
                 log_error "Failure threshold reached, opening circuit"
-                update_circuit_breaker "$CB_STATE_OPEN" "ollama" "$failure_count" 0
+                update_circuit_breaker "$CB_STATE_OPEN" "$FALLBACK_PROVIDER" "$failure_count" 0
                 # Update last_failure_time
                 local updated_state
                 updated_state=$(cat "$CIRCUIT_BREAKER_STATE_FILE" | jq --arg ts "$(get_timestamp)" '.last_failure_time = $ts')
                 echo "$updated_state" > "$CIRCUIT_BREAKER_STATE_FILE"
             else
-                update_circuit_breaker "$CB_STATE_CLOSED" "glm" "$failure_count" 0
+                update_circuit_breaker "$CB_STATE_CLOSED" "$PRIMARY_PROVIDER" "$failure_count" 0
             fi
             ;;
         "$CB_STATE_HALF_OPEN")
             log_error "Failure in HALF-OPEN state, returning to OPEN"
-            update_circuit_breaker "$CB_STATE_OPEN" "ollama" "$failure_count" 0
+            update_circuit_breaker "$CB_STATE_OPEN" "$FALLBACK_PROVIDER" "$failure_count" 0
             local updated_state
             updated_state=$(cat "$CIRCUIT_BREAKER_STATE_FILE" | jq --arg ts "$(get_timestamp)" '.last_failure_time = $ts')
             echo "$updated_state" > "$CIRCUIT_BREAKER_STATE_FILE"
             ;;
         "$CB_STATE_OPEN")
             # Already open, just update failure count
-            update_circuit_breaker "$CB_STATE_OPEN" "ollama" "$failure_count" 0
+            update_circuit_breaker "$CB_STATE_OPEN" "$FALLBACK_PROVIDER" "$failure_count" 0
             ;;
     esac
 }
@@ -467,14 +533,14 @@ record_success() {
         "$CB_STATE_HALF_OPEN")
             if [[ $success_count -ge $CIRCUIT_BREAKER_SUCCESS_THRESHOLD ]]; then
                 log_info "Success threshold reached, closing circuit"
-                update_circuit_breaker "$CB_STATE_CLOSED" "glm" 0 "$success_count"
+                update_circuit_breaker "$CB_STATE_CLOSED" "$PRIMARY_PROVIDER" 0 "$success_count"
             else
-                update_circuit_breaker "$CB_STATE_HALF_OPEN" "glm" 0 "$success_count"
+                update_circuit_breaker "$CB_STATE_HALF_OPEN" "$PRIMARY_PROVIDER" 0 "$success_count"
             fi
             ;;
         "$CB_STATE_CLOSED")
             # Reset failure count on success
-            update_circuit_breaker "$CB_STATE_CLOSED" "glm" 0 "$success_count"
+            update_circuit_breaker "$CB_STATE_CLOSED" "$PRIMARY_PROVIDER" 0 "$success_count"
             ;;
         "$CB_STATE_OPEN")
             # Should not happen - successes in OPEN state are from fallback
@@ -507,7 +573,7 @@ check_recovery_timeout() {
 
     if [[ $elapsed -ge $CIRCUIT_BREAKER_RECOVERY_TIMEOUT ]]; then
         log_info "Recovery timeout reached ($elapsed >= $CIRCUIT_BREAKER_RECOVERY_TIMEOUT), transitioning to HALF-OPEN"
-        update_circuit_breaker "$CB_STATE_HALF_OPEN" "glm" 0 0
+        update_circuit_breaker "$CB_STATE_HALF_OPEN" "$PRIMARY_PROVIDER" 0 0
         return 0
     fi
 
@@ -529,7 +595,7 @@ evaluate_llm_health() {
 
     case "$state" in
         "$CB_STATE_CLOSED"|"$CB_STATE_HALF_OPEN")
-            if check_glm_health > /dev/null 2>&1; then
+            if check_primary_provider_health > /dev/null 2>&1; then
                 record_success
             else
                 record_failure
@@ -537,9 +603,9 @@ evaluate_llm_health() {
             ;;
         "$CB_STATE_OPEN")
             # In OPEN state, check if Ollama fallback is healthy
-            if ! check_ollama_health > /dev/null 2>&1; then
-                log_error "FALLBACK CRITICAL: Both GLM and Ollama are unavailable!"
-                send_alert "CRITICAL: No LLM Provider Available" "Both GLM and Ollama are down"
+            if ! check_fallback_provider_health > /dev/null 2>&1; then
+                log_error "FALLBACK CRITICAL: Both $PRIMARY_PROVIDER and $FALLBACK_PROVIDER are unavailable!"
+                send_alert "CRITICAL: No LLM Provider Available" "Both $PRIMARY_PROVIDER and $FALLBACK_PROVIDER are down"
             fi
             ;;
     esac
@@ -607,15 +673,15 @@ export_prometheus_metrics() {
     active_provider=$(echo "$cb_state" | jq -r '.active_provider')
 
     # Check current provider availability
-    local glm_available=0
-    local ollama_available=0
+    local primary_available=0
+    local fallback_available=0
 
-    if check_glm_health > /dev/null 2>&1; then
-        glm_available=1
+    if check_primary_provider_health > /dev/null 2>&1; then
+        primary_available=1
     fi
 
-    if check_ollama_health > /dev/null 2>&1; then
-        ollama_available=1
+    if check_fallback_provider_health > /dev/null 2>&1; then
+        fallback_available=1
     fi
 
     # Get fallback counter
@@ -635,8 +701,8 @@ export_prometheus_metrics() {
     cat > "$PROMETHEUS_METRICS_FILE.tmp" << EOF
 # HELP llm_provider_available Whether the LLM provider is available (1=available, 0=unavailable)
 # TYPE llm_provider_available gauge
-llm_provider_available{provider="glm"} $glm_available
-llm_provider_available{provider="ollama"} $ollama_available
+llm_provider_available{provider="$PRIMARY_PROVIDER"} $primary_available
+llm_provider_available{provider="$FALLBACK_PROVIDER"} $fallback_available
 
 # HELP llm_fallback_triggered_total Total number of times fallback was triggered
 # TYPE llm_fallback_triggered_total counter
@@ -654,7 +720,7 @@ moltis_circuit_failures $failure_count
 # TYPE moltis_circuit_successes gauge
 moltis_circuit_successes $success_count
 
-# HELP moltis_active_provider Currently active LLM provider (1=glm, 0=ollama)
+# HELP moltis_active_provider Currently active LLM provider
 # TYPE moltis_active_provider gauge
 moltis_active_provider{provider="$active_provider"} 1
 EOF
@@ -676,8 +742,8 @@ show_prometheus_metrics() {
     state=$(echo "$cb_state" | jq -r '.state')
 
     echo "# LLM Provider Metrics"
-    echo "llm_provider_available{provider=\"glm\"} $(check_glm_health > /dev/null 2>&1 && echo 1 || echo 0)"
-    echo "llm_provider_available{provider=\"ollama\"} $(check_ollama_health > /dev/null 2>&1 && echo 1 || echo 0)"
+    echo "llm_provider_available{provider=\"$PRIMARY_PROVIDER\"} $(check_primary_provider_health > /dev/null 2>&1 && echo 1 || echo 0)"
+    echo "llm_provider_available{provider=\"$FALLBACK_PROVIDER\"} $(check_fallback_provider_health > /dev/null 2>&1 && echo 1 || echo 0)"
     echo "llm_fallback_triggered_total $(get_fallback_counter)"
     echo "moltis_circuit_state $(state_to_numeric "$state")"
 }

--- a/scripts/moltis-runtime-attestation.sh
+++ b/scripts/moltis-runtime-attestation.sh
@@ -205,6 +205,21 @@ oauth_tokens_have_refresh_token() {
         "$oauth_tokens_file" >/dev/null 2>&1
 }
 
+provider_keys_first_model_for_provider() {
+    local runtime_config_dir="$1"
+    local provider="$2"
+    local provider_keys_file="$runtime_config_dir/provider_keys.json"
+
+    [[ -f "$provider_keys_file" ]] || return 1
+
+    jq -r \
+        --arg provider "$provider" \
+        '
+        (.[$provider].models // [])
+        | if type == "array" and length > 0 then .[0] else "" end
+        ' "$provider_keys_file" 2>/dev/null
+}
+
 run_auth_provider_canary() {
     local base_url="$1"
     local password="$2"
@@ -357,6 +372,8 @@ emit_failure_json() {
         --arg auth_validation_path "${AUTH_VALIDATION_PATH:-}" \
         --arg auth_canary_attempted "${AUTH_CANARY_ATTEMPTED:-}" \
         --arg auth_canary_succeeded "${AUTH_CANARY_SUCCEEDED:-}" \
+        --arg expected_auth_model "${EXPECTED_AUTH_MODEL:-}" \
+        --arg auth_provider_model_preference "${AUTH_PROVIDER_MODEL_PREFERENCE:-}" \
         '{
           status: $status,
           target: $target,
@@ -372,6 +389,8 @@ emit_failure_json() {
             recorded_git_sha: (if $recorded_git_sha == "" then null else $recorded_git_sha end),
             live_git_sha: (if $live_git_sha == "" then null else $live_git_sha end),
             expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
+            expected_auth_model: (if $expected_auth_model == "" then null else $expected_auth_model end),
+            auth_provider_model_preference: (if $auth_provider_model_preference == "" then null else $auth_provider_model_preference end),
             auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
             auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
             auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end),
@@ -485,6 +504,8 @@ AUTH_CANARY_SUCCEEDED=""
 AUTH_CANARY_OUTPUT=""
 TRACKED_RUNTIME_TOML=""
 RUNTIME_RUNTIME_TOML=""
+EXPECTED_AUTH_MODEL=""
+AUTH_PROVIDER_MODEL_PREFERENCE=""
 
 if [[ ! -L "$ACTIVE_PATH" ]]; then
     fail_with "ACTIVE_ROOT_NOT_SYMLINK" "Active deploy root is not a symlink: $ACTIVE_PATH"
@@ -606,6 +627,16 @@ if [[ ! -f "$TRACKED_RUNTIME_TOML" || ! -f "$RUNTIME_RUNTIME_TOML" ]]; then
 fi
 if ! cmp -s "$TRACKED_RUNTIME_TOML" "$RUNTIME_RUNTIME_TOML"; then
     fail_with "RUNTIME_CONFIG_FILE_MISMATCH" "Runtime moltis.toml diverges from tracked config/moltis.toml"
+fi
+
+if [[ -n "$EXPECTED_AUTH_PROVIDER" ]]; then
+    EXPECTED_AUTH_MODEL="$(read_toml_key "$TRACKED_RUNTIME_TOML" "[providers.${EXPECTED_AUTH_PROVIDER}]" "model" || true)"
+    if [[ -n "$EXPECTED_AUTH_MODEL" ]]; then
+        AUTH_PROVIDER_MODEL_PREFERENCE="$(provider_keys_first_model_for_provider "$EXPECTED_RUNTIME_CONFIG" "$EXPECTED_AUTH_PROVIDER" || true)"
+        if [[ -n "$AUTH_PROVIDER_MODEL_PREFERENCE" && "$AUTH_PROVIDER_MODEL_PREFERENCE" != "$EXPECTED_AUTH_MODEL" ]]; then
+            fail_with "AUTH_PROVIDER_MODEL_PREFERENCE_MISMATCH" "Expected auth provider '$EXPECTED_AUTH_PROVIDER' to prefer model '$EXPECTED_AUTH_MODEL', but runtime provider_keys.json prefers '$AUTH_PROVIDER_MODEL_PREFERENCE'"
+        fi
+    fi
 fi
 
 BROWSER_ENABLED="$(read_toml_key "$RUNTIME_RUNTIME_TOML" "[tools.browser]" "enabled" || true)"
@@ -797,6 +828,8 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
         --arg auth_validation_path "$AUTH_VALIDATION_PATH" \
         --arg auth_canary_attempted "$AUTH_CANARY_ATTEMPTED" \
         --arg auth_canary_succeeded "$AUTH_CANARY_SUCCEEDED" \
+        --arg expected_auth_model "$EXPECTED_AUTH_MODEL" \
+        --arg auth_provider_model_preference "$AUTH_PROVIDER_MODEL_PREFERENCE" \
         '{
           status: $status,
           target: $target,
@@ -842,6 +875,8 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
             container_group_ids: (if $container_group_ids == "" then null else ($container_group_ids | split(" ")) end),
             host_docker_internal_mapped: (if $host_docker_internal_mapped == "" then null else ($host_docker_internal_mapped == "true") end),
             expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
+            expected_auth_model: (if $expected_auth_model == "" then null else $expected_auth_model end),
+            auth_provider_model_preference: (if $auth_provider_model_preference == "" then null else $auth_provider_model_preference end),
             auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
             auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
             auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end),
@@ -885,6 +920,8 @@ docker_socket_mode=${DOCKER_SOCKET_MODE:-none}
 container_group_ids=${CONTAINER_GROUP_IDS:-none}
 host_docker_internal_mapped=${HOST_DOCKER_INTERNAL_MAPPED:-false}
 expected_auth_provider=${EXPECTED_AUTH_PROVIDER:-none}
+expected_auth_model=${EXPECTED_AUTH_MODEL:-none}
+auth_provider_model_preference=${AUTH_PROVIDER_MODEL_PREFERENCE:-none}
 auth_status_raw=${AUTH_STATUS_RAW:-none}
 auth_status_post_canary=${AUTH_STATUS_POST_CANARY:-none}
 auth_status_valid=${AUTH_STATUS_VALID:-skipped}

--- a/scripts/prepare-moltis-runtime-config.sh
+++ b/scripts/prepare-moltis-runtime-config.sh
@@ -17,6 +17,32 @@ log() {
     echo "[prepare-moltis-runtime-config] $*"
 }
 
+read_toml_key() {
+    local toml_file="$1"
+    local section="$2"
+    local key="$3"
+
+    [[ -f "$toml_file" ]] || return 1
+
+    awk -v section="$section" -v key="$key" '
+        BEGIN { in_section = 0 }
+        /^[[:space:]]*\[/ {
+            in_section = ($0 == section)
+            next
+        }
+        in_section && $0 ~ ("^[[:space:]]*" key "[[:space:]]*=") {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            sub(/[[:space:]]*#.*$/, "", line)
+            sub("^[^=]+=[[:space:]]*", "", line)
+            gsub(/^"/, "", line)
+            gsub(/"$/, "", line)
+            print line
+            exit
+        }
+    ' "$toml_file"
+}
+
 copy_static_item() {
     local src="$1"
     local dst="$2"
@@ -28,6 +54,45 @@ copy_static_item() {
         mkdir -p "$(dirname "$dst")"
         cp "$src" "$dst"
     fi
+}
+
+normalize_openai_codex_model_preferences() {
+    local tracked_model provider_keys_file tmp_file
+
+    tracked_model="$(read_toml_key "$STATIC_CONFIG_DIR/moltis.toml" "[providers.openai-codex]" "model" || true)"
+    provider_keys_file="$RUNTIME_CONFIG_DIR/provider_keys.json"
+
+    [[ -n "$tracked_model" ]] || return 0
+    [[ -f "$provider_keys_file" ]] || return 0
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log "jq is unavailable, skipping runtime model preference normalization"
+        return 0
+    fi
+
+    if ! jq -e '.["openai-codex"]? | type == "object"' "$provider_keys_file" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    tmp_file="$provider_keys_file.tmp.$$"
+    if ! jq \
+        --arg tracked_model "$tracked_model" \
+        '
+        .["openai-codex"].models = (
+          [$tracked_model] +
+          (
+            (.["openai-codex"].models // [])
+            | if type == "array" then map(select(. != $tracked_model)) else [] end
+          )
+        )
+        ' "$provider_keys_file" >"$tmp_file"; then
+        rm -f "$tmp_file"
+        echo "Failed to normalize OpenAI Codex model preferences in $provider_keys_file" >&2
+        exit 1
+    fi
+
+    mv "$tmp_file" "$provider_keys_file"
+    log "normalized runtime-managed openai-codex preferences to keep $tracked_model primary"
 }
 
 main() {
@@ -65,6 +130,15 @@ main() {
             fi
         fi
     done
+
+    normalize_openai_codex_model_preferences
+
+    if [[ -f "$RUNTIME_CONFIG_DIR/provider_keys.json" ]]; then
+        chmod 600 "$RUNTIME_CONFIG_DIR/provider_keys.json" 2>/dev/null || true
+        if [[ "$(id -u)" -eq 0 ]]; then
+            chown "$SERVICE_UID:$SERVICE_GID" "$RUNTIME_CONFIG_DIR/provider_keys.json"
+        fi
+    fi
 
     log "runtime config prepared at $RUNTIME_CONFIG_DIR"
 }

--- a/tests/component/test_circuit_breaker.sh
+++ b/tests/component/test_circuit_breaker.sh
@@ -12,6 +12,8 @@ export FALLBACK_COUNTER_FILE="$COUNTER_FILE"
 export CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
 export CIRCUIT_BREAKER_RECOVERY_TIMEOUT=2
 export CIRCUIT_BREAKER_SUCCESS_THRESHOLD=2
+export PRIMARY_PROVIDER="openai-codex"
+export FALLBACK_PROVIDER="ollama"
 export GLM_API_KEY="fixture-glm"
 export OLLAMA_HOST="http://127.0.0.1:11434"
 
@@ -19,8 +21,8 @@ export OLLAMA_HOST="http://127.0.0.1:11434"
 source "$PROJECT_ROOT/scripts/health-monitor.sh"
 
 send_alert() { :; }
-check_glm_health() { return 0; }
-check_ollama_health() { return 0; }
+check_primary_provider_health() { return 0; }
+check_fallback_provider_health() { return 0; }
 
 setup_component_circuit_breaker() {
     require_commands_or_skip jq flock || return 2
@@ -70,7 +72,7 @@ run_component_circuit_breaker_tests() {
     reset_state
     init_circuit_breaker
     assert_eq "closed" "$(get_current_state)" "Circuit breaker should initialize in CLOSED state"
-    assert_eq "glm" "$(get_active_provider)" "Active provider should default to glm"
+    assert_eq "openai-codex" "$(get_active_provider)" "Active provider should default to openai-codex"
     test_pass
 
     test_start "component_circuit_breaker_opens_after_threshold"

--- a/tests/component/test_llm_failover_component.sh
+++ b/tests/component/test_llm_failover_component.sh
@@ -12,6 +12,8 @@ export FALLBACK_COUNTER_FILE="$COUNTER_FILE"
 export CIRCUIT_BREAKER_FAILURE_THRESHOLD=2
 export CIRCUIT_BREAKER_RECOVERY_TIMEOUT=2
 export CIRCUIT_BREAKER_SUCCESS_THRESHOLD=1
+export PRIMARY_PROVIDER="openai-codex"
+export FALLBACK_PROVIDER="ollama"
 export GLM_API_KEY="fixture-glm"
 export OLLAMA_HOST="http://127.0.0.1:11434"
 
@@ -20,20 +22,20 @@ source "$PROJECT_ROOT/scripts/health-monitor.sh"
 
 send_alert() { :; }
 
-set_glm_health() {
-    export TEST_GLM_HEALTH="$1"
+set_primary_health() {
+    export TEST_PRIMARY_HEALTH="$1"
 }
 
-set_ollama_health() {
-    export TEST_OLLAMA_HEALTH="$1"
+set_fallback_health() {
+    export TEST_FALLBACK_HEALTH="$1"
 }
 
-check_glm_health() {
-    [[ "${TEST_GLM_HEALTH:-healthy}" == "healthy" ]]
+check_primary_provider_health() {
+    [[ "${TEST_PRIMARY_HEALTH:-healthy}" == "healthy" ]]
 }
 
-check_ollama_health() {
-    [[ "${TEST_OLLAMA_HEALTH:-healthy}" == "healthy" ]]
+check_fallback_provider_health() {
+    [[ "${TEST_FALLBACK_HEALTH:-healthy}" == "healthy" ]]
 }
 
 setup_component_llm_failover() {
@@ -43,7 +45,7 @@ setup_component_llm_failover() {
 
 reset_failover_fixture() {
     rm -f "$STATE_FILE" "$STATE_FILE.lock" "$COUNTER_FILE"
-    unset TEST_GLM_HEALTH TEST_OLLAMA_HEALTH
+    unset TEST_PRIMARY_HEALTH TEST_FALLBACK_HEALTH
     init_circuit_breaker
 }
 
@@ -86,16 +88,16 @@ run_component_llm_failover_tests() {
     reset_failover_fixture
     local status_json
     status_json=$(get_llm_provider_status)
-    if echo "$status_json" | jq -e '.glm and .ollama' >/dev/null 2>&1; then
+    if echo "$status_json" | jq -e '."openai-codex" and .ollama' >/dev/null 2>&1; then
         test_pass
     else
-        test_fail "Provider status should include glm and ollama keys"
+        test_fail "Provider status should include openai-codex and ollama keys"
     fi
 
     test_start "component_llm_evaluate_records_failure"
     reset_failover_fixture
-    set_glm_health unhealthy
-    set_ollama_health healthy
+    set_primary_health unhealthy
+    set_fallback_health healthy
     evaluate_llm_health >/dev/null 2>&1 || true
     assert_eq "1" "$(jq -r '.failure_count' "$STATE_FILE")" "Failure count should increment after unhealthy primary"
     test_pass
@@ -109,8 +111,8 @@ run_component_llm_failover_tests() {
     test_start "component_llm_recovery_path_returns_half_open_then_closed"
     reset_failover_fixture
     write_old_open_state
-    set_glm_health healthy
-    set_ollama_health healthy
+    set_primary_health healthy
+    set_fallback_health healthy
     evaluate_llm_health >/dev/null 2>&1 || true
     assert_eq "closed" "$(jq -r '.state' "$STATE_FILE")" "Healthy primary should close circuit after half-open success"
     test_pass

--- a/tests/component/test_moltis_runtime_attestation.sh
+++ b/tests/component/test_moltis_runtime_attestation.sh
@@ -199,6 +199,10 @@ provider = "ollama"
 base_url = "http://ollama:11434"
 model = "nomic-embed-text"
 
+[providers.openai-codex]
+model = "gpt-5.4"
+models = ["gpt-5.4"]
+
 [tools.browser]
 enabled = true
 sandbox_image = "moltis-browserless-chrome:tracked"
@@ -238,6 +242,13 @@ run_component_moltis_runtime_attestation_tests() {
     live_sha="$(git -C "$workspace_root" rev-parse HEAD)"
     cp "$workspace_root/config/moltis.toml" "$original_tracked_toml"
     cp "$workspace_root/config/moltis.toml" "$runtime_config_dir/moltis.toml"
+    cat >"$runtime_config_dir/provider_keys.json" <<'EOF'
+{
+  "openai-codex": {
+    "models": ["gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark"]
+  }
+}
+EOF
 
     cat >"$workspace_root/.env" <<EOF
 MOLTIS_RUNTIME_CONFIG_DIR=$runtime_config_dir
@@ -313,6 +324,8 @@ EOF
        [[ "$(jq -r '.details.docker_socket_gid' "$output_json")" != "999" ]] || \
        [[ "$(jq -r '.details.host_docker_internal_mapped' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.expected_auth_provider' "$output_json")" != "openai-codex" ]] || \
+       [[ "$(jq -r '.details.expected_auth_model' "$output_json")" != "gpt-5.4" ]] || \
+       [[ "$(jq -r '.details.auth_provider_model_preference' "$output_json")" != "gpt-5.4" ]] || \
        [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.auth_validation_path' "$output_json")" != "status" ]]; then
         test_fail "Runtime attestation success output does not reflect the expected provenance details"
@@ -320,6 +333,51 @@ EOF
         return
     fi
     test_pass
+
+    cat >"$runtime_config_dir/provider_keys.json" <<'EOF'
+{
+  "openai-codex": {
+    "models": ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex-spark"]
+  }
+}
+EOF
+
+    test_start "component_runtime_attestation_fails_when_provider_keys_model_preference_drifted"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" \
+            --expected-auth-provider "openai-codex" >"$output_json" 2>"$fixture_root/stderr-model-preference.log"
+    exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "AUTH_PROVIDER_MODEL_PREFERENCE_MISMATCH")' "$output_json" >/dev/null 2>&1 || \
+       [[ "$(jq -r '.details.expected_auth_model' "$output_json")" != "gpt-5.4" ]] || \
+       [[ "$(jq -r '.details.auth_provider_model_preference' "$output_json")" != "gpt-5.4-mini" ]]; then
+        test_fail "Runtime attestation should fail when runtime provider_keys.json prefers a different OpenAI Codex model than tracked config"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    cat >"$runtime_config_dir/provider_keys.json" <<'EOF'
+{
+  "openai-codex": {
+    "models": ["gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark"]
+  }
+}
+EOF
 
     test_start "component_runtime_attestation_fails_when_browser_sandbox_image_is_missing_on_host"
     set +e

--- a/tests/component/test_prepare_moltis_runtime_config.sh
+++ b/tests/component/test_prepare_moltis_runtime_config.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+PREPARE_SCRIPT="$PROJECT_ROOT/scripts/prepare-moltis-runtime-config.sh"
+
+run_component_prepare_moltis_runtime_config_tests() {
+    start_timer
+
+    test_start "component_prepare_runtime_config_preserves_auth_files_and_normalizes_openai_codex_model_order"
+
+    local fixture_root static_dir runtime_dir
+    fixture_root="$(secure_temp_dir prepare-moltis-runtime-config)"
+    static_dir="$fixture_root/static"
+    runtime_dir="$fixture_root/runtime"
+
+    mkdir -p "$static_dir/subdir" "$runtime_dir"
+    cat >"$static_dir/moltis.toml" <<'EOF'
+[providers.openai-codex]
+enabled = true
+model = "gpt-5.4"
+models = ["gpt-5.4"]
+EOF
+    printf 'tracked\n' >"$static_dir/subdir/marker.txt"
+
+    cat >"$runtime_dir/oauth_tokens.json" <<'EOF'
+{"openai-codex":{"refresh_token":"refresh-token"}}
+EOF
+    cat >"$runtime_dir/provider_keys.json" <<'EOF'
+{
+  "openai-codex": {
+    "models": ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+  },
+  "zai": {
+    "models": ["glm-5"]
+  }
+}
+EOF
+
+    if ! bash "$PREPARE_SCRIPT" "$static_dir" "$runtime_dir" >"$fixture_root/stdout.log" 2>"$fixture_root/stderr.log"; then
+        test_fail "prepare-moltis-runtime-config.sh should succeed for a valid static/runtime fixture"
+        rm -rf "$fixture_root"
+        return
+    fi
+
+    assert_file_exists "$runtime_dir/moltis.toml" "Runtime moltis.toml should be copied from static config"
+    assert_file_exists "$runtime_dir/subdir/marker.txt" "Static directories should be copied into runtime config"
+    assert_contains "$(cat "$runtime_dir/oauth_tokens.json")" '"refresh_token":"refresh-token"' "oauth_tokens.json must stay preserved"
+
+    if [[ "$(jq -r '."openai-codex".models[0]' "$runtime_dir/provider_keys.json")" != "gpt-5.4" ]] || \
+       [[ "$(jq -r '."openai-codex".models[1]' "$runtime_dir/provider_keys.json")" != "gpt-5.4-mini" ]] || \
+       [[ "$(jq -r '.zai.models[0]' "$runtime_dir/provider_keys.json")" != "glm-5" ]]; then
+        test_fail "prepare-moltis-runtime-config.sh must keep tracked gpt-5.4 first while preserving the rest of provider_keys.json"
+        rm -rf "$fixture_root"
+        return
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    run_component_prepare_moltis_runtime_config_tests
+fi

--- a/tests/component/test_prometheus_metrics.sh
+++ b/tests/component/test_prometheus_metrics.sh
@@ -15,6 +15,8 @@ export FALLBACK_COUNTER_FILE="$COUNTER_FILE"
 export PROMETHEUS_TEXTFILE_DIR="$PROM_DIR"
 export PROMETHEUS_METRICS_FILE="$PROM_FILE"
 export CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
+export PRIMARY_PROVIDER="openai-codex"
+export FALLBACK_PROVIDER="ollama"
 export GLM_API_KEY="fixture-glm"
 export OLLAMA_HOST="http://127.0.0.1:11434"
 
@@ -22,8 +24,8 @@ export OLLAMA_HOST="http://127.0.0.1:11434"
 source "$PROJECT_ROOT/scripts/health-monitor.sh"
 
 send_alert() { :; }
-check_glm_health() { return 0; }
-check_ollama_health() { return 0; }
+check_primary_provider_health() { return 0; }
+check_fallback_provider_health() { return 0; }
 
 reset_metrics_fixture() {
     cat > "$STATE_FILE" <<JSON
@@ -33,7 +35,7 @@ reset_metrics_fixture() {
   "success_count": 0,
   "last_failure_time": null,
   "last_state_change": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-  "active_provider": "glm",
+  "active_provider": "openai-codex",
   "fallback_provider": "ollama"
 }
 JSON
@@ -54,11 +56,11 @@ run_component_prometheus_metrics_tests() {
     export_prometheus_metrics
     local metrics
     metrics=$(cat "$PROM_FILE")
-    assert_contains "$metrics" 'llm_provider_available{provider="glm"}' "GLM availability metric should exist"
+    assert_contains "$metrics" 'llm_provider_available{provider="openai-codex"}' "OpenAI Codex availability metric should exist"
     assert_contains "$metrics" 'llm_provider_available{provider="ollama"}' "Ollama availability metric should exist"
     assert_contains "$metrics" 'llm_fallback_triggered_total' "Fallback counter should exist"
     assert_contains "$metrics" 'moltis_circuit_state' "Circuit state metric should exist"
-    assert_contains "$metrics" 'moltis_active_provider{provider="glm"} 1' "Active provider metric should exist"
+    assert_contains "$metrics" 'moltis_active_provider{provider="openai-codex"} 1' "Active provider metric should exist"
     test_pass
 
     test_start "component_metrics_include_help_and_type_annotations"
@@ -86,10 +88,10 @@ run_component_prometheus_metrics_tests() {
     test_pass
 
     test_start "component_metrics_reflect_active_provider_changes"
-    jq '.state = "half_open" | .active_provider = "glm" | .success_count = 1' "$STATE_FILE" > "$STATE_FILE.tmp"
+    jq '.state = "half_open" | .active_provider = "openai-codex" | .success_count = 1' "$STATE_FILE" > "$STATE_FILE.tmp"
     mv "$STATE_FILE.tmp" "$STATE_FILE"
     export_prometheus_metrics
-    assert_contains "$(cat "$PROM_FILE")" 'moltis_active_provider{provider="glm"} 1' "Metric should show glm as active"
+    assert_contains "$(cat "$PROM_FILE")" 'moltis_active_provider{provider="openai-codex"} 1' "Metric should show OpenAI Codex as active"
     test_pass
 
     test_start "component_metrics_output_is_parseable"

--- a/tests/resilience/test_full_failover_chain.sh
+++ b/tests/resilience/test_full_failover_chain.sh
@@ -8,6 +8,7 @@ ALLOW_DESTRUCTIVE_TESTS="${ALLOW_DESTRUCTIVE_TESTS:-0}"
 GLM_API_KEY="${GLM_API_KEY:-}"
 OLLAMA_HOST="${OLLAMA_HOST:-}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-15}"
+MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
 
 run_resilience_failover_chain_tests() {
     start_timer
@@ -19,7 +20,7 @@ run_resilience_failover_chain_tests() {
         return
     fi
 
-    require_commands_or_skip curl jq || {
+    require_commands_or_skip curl jq docker || {
         test_start "resilience_failover_setup"
         test_skip "Dependencies unavailable"
         generate_report
@@ -34,7 +35,16 @@ run_resilience_failover_chain_tests() {
     fi
     test_pass
 
-    test_start "resilience_failover_glm_health"
+    test_start "resilience_failover_openai_codex_auth"
+    local auth_output
+    auth_output="$(docker exec "$MOLTIS_CONTAINER" moltis auth status 2>/dev/null || true)"
+    if printf '%s\n' "$auth_output" | grep -F 'openai-codex [valid' >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "OpenAI Codex auth should be valid before failover drill"
+    fi
+
+    test_start "resilience_failover_zai_health"
     require_secret_or_skip GLM_API_KEY "GLM_API_KEY" || {
         generate_report
         return
@@ -44,7 +54,7 @@ run_resilience_failover_chain_tests() {
     if [[ "$glm_code" =~ ^(200|201)$ ]]; then
         test_pass
     else
-        test_fail "GLM provider should be reachable before failover drill (got $glm_code)"
+        test_fail "Z.ai fallback provider should be reachable before failover drill (got $glm_code)"
     fi
 
     test_start "resilience_failover_ollama_health"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -163,6 +163,7 @@ suite_entries_for_lane() {
             printf '%s\n' \
                 "bash|component_backup_restore_readiness|Backup restore-readiness component|$SCRIPT_DIR/component/test_backup_restore_readiness.sh" \
                 "bash|component_moltis_version_helper|Moltis version helper component|$SCRIPT_DIR/component/test_moltis_version_helper.sh" \
+                "bash|component_prepare_moltis_runtime_config|Prepare Moltis runtime config component|$SCRIPT_DIR/component/test_prepare_moltis_runtime_config.sh" \
                 "bash|component_circuit_breaker|Circuit breaker component|$SCRIPT_DIR/component/test_circuit_breaker.sh" \
                 "bash|component_prometheus_metrics|Prometheus metrics component|$SCRIPT_DIR/component/test_prometheus_metrics.sh" \
                 "bash|component_llm_failover|LLM failover component|$SCRIPT_DIR/component/test_llm_failover_component.sh" \


### PR DESCRIPTION
## Summary
- normalize runtime-managed openai-codex model preferences back to tracked 
- fail attestation when runtime  drifts away from tracked auth model
- align health-monitor, alerts, docs, and component/resilience tests with the OpenAI-first chain

## Validation
- 
- 
▶ Test: component_prepare_runtime_config_preserves_auth_files_and_normalizes_openai_codex_model_order
  ✓ PASS component_prepare_runtime_config_preserves_auth_files_and_normalizes_openai_codex_model_order

=========================================
  Test Results Summary
=========================================

✓ Test suite passed

Total:   1
Passed:  1
Failed:  0
Skipped: 0
Duration: 0s

=========================================
- 
▶ Test: component_runtime_attestation_succeeds_for_live_provenance_contract
  ✓ PASS component_runtime_attestation_succeeds_for_live_provenance_contract

▶ Test: component_runtime_attestation_fails_when_provider_keys_model_preference_drifted
  ✓ PASS component_runtime_attestation_fails_when_provider_keys_model_preference_drifted

▶ Test: component_runtime_attestation_fails_when_browser_sandbox_image_is_missing_on_host
  ✓ PASS component_runtime_attestation_fails_when_browser_sandbox_image_is_missing_on_host

▶ Test: component_runtime_attestation_fails_when_non_persistent_browser_profile_allows_concurrency
  ✓ PASS component_runtime_attestation_fails_when_non_persistent_browser_profile_allows_concurrency

▶ Test: component_runtime_attestation_fails_when_browser_profile_root_is_not_world_writable
  ✓ PASS component_runtime_attestation_fails_when_browser_profile_root_is_not_world_writable

▶ Test: component_runtime_attestation_fails_when_browser_socket_gid_mismatches_live_groups
  ✓ PASS component_runtime_attestation_fails_when_browser_socket_gid_mismatches_live_groups

▶ Test: component_runtime_attestation_fails_when_runtime_config_drifted_from_tracked_contract
  ✓ PASS component_runtime_attestation_fails_when_runtime_config_drifted_from_tracked_contract

▶ Test: component_runtime_attestation_fails_when_workspace_mount_drifts_from_active_root
  ✓ PASS component_runtime_attestation_fails_when_workspace_mount_drifts_from_active_root

▶ Test: component_runtime_attestation_recovers_refreshable_expired_auth_provider_via_canary
  ✓ PASS component_runtime_attestation_recovers_refreshable_expired_auth_provider_via_canary

▶ Test: component_runtime_attestation_fails_when_refreshable_expired_auth_provider_does_not_recover
  ✓ PASS component_runtime_attestation_fails_when_refreshable_expired_auth_provider_does_not_recover

▶ Test: component_runtime_attestation_fails_when_expected_auth_provider_is_invalid
  ✓ PASS component_runtime_attestation_fails_when_expected_auth_provider_is_invalid

=========================================
  Test Results Summary
=========================================

✓ Test suite passed

Total:   11
Passed:  11
Failed:  0
Skipped: 0
Duration: 5s

=========================================
- 
▶ Test: component_metrics_exports_prometheus_file[0m
[2026-04-10 20:24:51] [INFO] [0mPrometheus metrics exported to /var/folders/rr/q13r5zyn38g4jsqrl14kjy6h0000gn/T//prometheus-textfile.W3A4DJ/moltis_llm.prom[0m
[0;32m  ✓ PASS[0m component_metrics_exports_prometheus_file

▶ Test: component_metrics_include_required_series[0m
[2026-04-10 20:24:51] [INFO] [0mPrometheus metrics exported to /var/folders/rr/q13r5zyn38g4jsqrl14kjy6h0000gn/T//prometheus-textfile.W3A4DJ/moltis_llm.prom[0m
[0;32m  ✓ PASS[0m component_metrics_include_required_series

▶ Test: component_metrics_include_help_and_type_annotations[0m
[0;32m  ✓ PASS[0m component_metrics_include_help_and_type_annotations

▶ Test: component_metrics_numeric_mapping_matches_state[0m
[2026-04-10 20:24:51] [INFO] [0mPrometheus metrics exported to /var/folders/rr/q13r5zyn38g4jsqrl14kjy6h0000gn/T//prometheus-textfile.W3A4DJ/moltis_llm.prom[0m
[0;32m  ✓ PASS[0m component_metrics_numeric_mapping_matches_state

▶ Test: component_metrics_fallback_counter_increments_on_open_transition[0m
[2026-04-10 20:24:51] [INFO] [0mPrometheus metrics exported to /var/folders/rr/q13r5zyn38g4jsqrl14kjy6h0000gn/T//prometheus-textfile.W3A4DJ/moltis_llm.prom[0m
[0;32m  ✓ PASS[0m component_metrics_fallback_counter_increments_on_open_transition

▶ Test: component_metrics_reflect_active_provider_changes[0m
[2026-04-10 20:24:51] [INFO] [0mPrometheus metrics exported to /var/folders/rr/q13r5zyn38g4jsqrl14kjy6h0000gn/T//prometheus-textfile.W3A4DJ/moltis_llm.prom[0m
[0;32m  ✓ PASS[0m component_metrics_reflect_active_provider_changes

▶ Test: component_metrics_output_is_parseable[0m
[0;32m  ✓ PASS[0m component_metrics_output_is_parseable

=========================================
  Test Results Summary
=========================================

[0;32m✓ Test suite passed[0m

Total:   7
Passed:  [0;32m7[0m
Failed:  [0;31m0[0m
Skipped: [1;33m0[0m
Duration: 0s

=========================================
- 
▶ Test: component_circuit_breaker_dependencies[0m
[1;33m  ⊘ SKIP[0m component_circuit_breaker_dependencies - Missing jq/flock for portable component state-machine checks

=========================================
  Test Results Summary
=========================================

[1;33m⚠ Test suite skipped[0m

Total:   1
Passed:  [0;32m0[0m
Failed:  [0;31m0[0m
Skipped: [1;33m1[0m
Duration: 0s

[1;33mSkipped tests:[0m
  - component_circuit_breaker_dependencies: Missing jq/flock for portable component state-machine checks

========================================= (skipped locally: missing )
- 
▶ Test: component_llm_failover_dependencies[0m
[1;33m  ⊘ SKIP[0m component_llm_failover_dependencies - Missing jq/flock for portable failover component checks

=========================================
  Test Results Summary
=========================================

[1;33m⚠ Test suite skipped[0m

Total:   1
Passed:  [0;32m0[0m
Failed:  [0;31m0[0m
Skipped: [1;33m1[0m
Duration: 0s

[1;33mSkipped tests:[0m
  - component_llm_failover_dependencies: Missing jq/flock for portable failover component checks

========================================= (skipped locally: missing )
- live runtime repair on , restart, attestation success, and real canary on 

## Production proof
- before repair, live attestation failed with  because runtime  preferred 
- runtime config was backed up to 
- after normalization + restart,  stayed valid and live canary returned , , 