### PR TITLE
docs(topology): publish remote-governance snapshot

### DIFF
--- a/docs/GIT-TOPOLOGY-REGISTRY.md
+++ b/docs/GIT-TOPOLOGY-REGISTRY.md
@@ -12,6 +12,7 @@
 | Remote Branch | Current Intent |
 |---|---|
 | `origin/chore/topology-registry-publish` | Needs decision |
+| `origin/feat/moltinger-jb6-1-gpt54-oauth-persistence-fix` | Needs decision |
 
 ## Reviewed Intent Awaiting Reconciliation
 


### PR DESCRIPTION
## Automated topology registry publish

This PR updates the tracked `docs/GIT-TOPOLOGY-REGISTRY.md` snapshot from the dedicated publish branch.

Contract:
- tracked registry scope: shared remote governance snapshot
- local worktrees and local-only branches remain live-only
- generation performed through `scripts/git-topology-registry.sh refresh --write-doc` on `chore/topology-registry-publish`
