### PR TITLE
fix: prove deploy smoke with real openai canary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1327,6 +1327,17 @@ jobs:
               echo "::warning::No authenticated providers are currently loaded in live Moltis"
             fi
 
+            # Test 8: Real OpenAI Codex chat canary
+            echo "Test 8: Real OpenAI Codex chat canary..."
+            MOLTIS_ACTIVE_ROOT="${{ env.DEPLOY_ACTIVE_PATH }}" \
+            MOLTIS_URL="http://localhost:13131" \
+            TEST_TIMEOUT="25" \
+            EXPECTED_PROVIDER="openai-codex" \
+            EXPECTED_MODEL="openai-codex::gpt-5.4" \
+            EXPECTED_REPLY_TEXT="OK" \
+            bash "${{ env.DEPLOY_ACTIVE_PATH }}/scripts/test-moltis-api.sh" \
+              "Reply with exactly OK and nothing else."
+
             echo "All smoke tests passed!"
           EOF
           echo "::endgroup::"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -261,6 +261,26 @@ test_deploy_script_verifies_live_moltis_runtime_contract() {
     test_pass
 }
 
+test_deploy_workflow_runs_real_openai_codex_chat_canary() {
+    test_start "Deploy workflow should run a real OpenAI Codex chat canary after rollout"
+
+    if [[ ! -f "$DEPLOY_WORKFLOW" ]]; then
+        test_skip "Missing workflow file: $DEPLOY_WORKFLOW"
+        return
+    fi
+
+    if ! grep -Fq 'Test 8: Real OpenAI Codex chat canary' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'scripts/test-moltis-api.sh' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'EXPECTED_PROVIDER="openai-codex"' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'EXPECTED_MODEL="openai-codex::gpt-5.4"' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'EXPECTED_REPLY_TEXT="OK"' "$DEPLOY_WORKFLOW"; then
+        test_fail "deploy.yml must prove the live OpenAI Codex chat path with scripts/test-moltis-api.sh against openai-codex::gpt-5.4"
+        return
+    fi
+
+    test_pass
+}
+
 test_deploy_script_exports_live_docker_socket_gid_for_browser_sandbox() {
     test_start "Deploy should export the live Docker socket GID for browser sandbox access"
 
@@ -1448,6 +1468,7 @@ run_all_tests() {
     test_moltis_env_workflows_use_shared_render_script
     test_tracked_deploy_workflows_use_shared_script_entrypoint
     test_deploy_script_verifies_live_moltis_runtime_contract
+    test_deploy_workflow_runs_real_openai_codex_chat_canary
     test_deploy_script_exports_live_docker_socket_gid_for_browser_sandbox
     test_deploy_script_prepares_tracked_browser_sandbox_image
     test_deploy_script_force_recreates_moltis_runtime_on_rollout


### PR DESCRIPTION
## Summary
- add a fail-closed post-deploy real chat canary to `.github/workflows/deploy.yml`
- prove `openai-codex::gpt-5.4` with `scripts/test-moltis-api.sh` instead of relying on `moltis auth status` alone
- add a deploy workflow guard test to keep the real canary contract from regressing

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "YAML_OK"'`
- `bash -n scripts/test-moltis-api.sh`
- `bash tests/unit/test_deploy_workflow_guards.sh`