### PR TITLE
docs: align OpenAI-first recovery wording

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -123,7 +123,7 @@ route:
           receiver: 'llm-failover-alerts'
           group_wait: 30s
           repeat_interval: 1h
-        # GLM down - warning level
+        # Primary LLM down - warning level
         - matchers:
             - alertname="PrimaryLLMProviderDown"
           receiver: 'llm-failover-alerts'

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -111,7 +111,7 @@ An incident is not closed until all of the following are true:
 ### Failover Chain
 
 ```text
-GLM-5 (Z.ai) -> Ollama Gemini -> Google Gemini
+OpenAI Codex (`gpt-5.4`) -> Ollama Gemini -> GLM-5 (Z.ai)
 ```
 
 ### Circuit States


### PR DESCRIPTION
## Summary
- align the Moltis disaster-recovery failover chain with the current OpenAI-first primary path
- rename the stale Alertmanager comment from GLM-specific wording to primary-LLM wording
- carry only the leftover docs/config wording from the old gpt54 oauth lane

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("config/alertmanager/alertmanager.yml"); puts "YAML_OK"'`
- `git diff -- docs/disaster-recovery.md config/alertmanager/alertmanager.yml`