### PR TITLE
fix(telegram): harden codex-update scheduler replies

### DIFF
--- a/scripts/telegram-e2e-on-demand.sh
+++ b/scripts/telegram-e2e-on-demand.sh
@@ -622,6 +622,24 @@ message_is_codex_update_query() {
   return 1
 }
 
+message_is_codex_update_scheduler_query() {
+  local normalized
+  normalized="$(normalize_message_text "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  [[ -n "$normalized" ]] || return 1
+
+  if ! message_is_codex_update_query "$normalized"; then
+    return 1
+  fi
+
+  case "$normalized" in
+    *"крон"*|*"cron"*|*"scheduler"*|*"schedule"*|*"расписан"*|*"расписанию"*|*"регулярн"*|*"автопровер"*|*"автоматич"*|*"watcher"*|*"монитор"*|*"периодич"*|*"daemon"*|*"демон"*|*"каждые"*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
 reply_has_codex_update_false_negative() {
   local normalized
   normalized="$(normalize_message_text "${1:-}" | tr '[:upper:]' '[:lower:]')"
@@ -665,6 +683,20 @@ reply_has_codex_update_state_memory_false_negative() {
 
   case "$normalized" in
     *"в памяти не найдено"*|*"В памяти не найдено"*|*"не найдено в памяти"*|*"Не найдено в памяти"*|*"в памяти записи о последней известной версии не найдено"*|*"В памяти записи о последней известной версии не найдено"*|*"в памяти записи не найдено"*|*"В памяти записи не найдено"*|*"в памяти у меня не зафиксирована"*|*"В памяти у меня не зафиксирована"*|*"в базе у меня не зафиксирована"*|*"В базе у меня не зафиксирована"*|*"в базе не зафиксирована"*|*"В базе не зафиксирована"*|*"не вижу физически доступного содержимого skill"*|*"Не вижу физически доступного содержимого skill"*|*"не вижу физически доступного содержимого скил"*|*"Не вижу физически доступного содержимого скил"*|*"механизм отслеживания обновлений codex cli сейчас не в рабочем состоянии"*|*"Механизм отслеживания обновлений Codex CLI сейчас не в рабочем состоянии"*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+reply_has_codex_update_scheduler_memory_false_negative() {
+  local normalized
+  normalized="$(normalize_message_text "${1:-}")"
+  [[ -n "$normalized" ]] || return 1
+
+  case "$normalized" in
+    *"проверить по памяти/расписанию"*|*"Проверить по памяти/расписанию"*|*"инструмент поиска памяти"*|*"Инструмент поиска памяти"*|*"не вижу подтверждения, что такой крон"*|*"Не вижу подтверждения, что такой крон"*|*"подтвердить наличие такого крона я сейчас не могу"*|*"Подтвердить наличие такого крона я сейчас не могу"*|*"Searching memory"*|*"missing 'query' parameter"*)
       return 0
       ;;
   esac
@@ -1043,6 +1075,19 @@ evaluate_authoritative_semantics() {
       --argjson base "$DIAGNOSTIC_JSON" \
       '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_state_memory_false_negative"}}')"
     RECOMMENDED_ACTION="Reconcile codex-update state queries so they read runtime state helper truth instead of memory-search fallbacks, then rerun authoritative UAT."
+    return 0
+  fi
+
+  if message_is_codex_update_scheduler_query "$normalized_message" && reply_has_codex_update_scheduler_memory_false_negative "$reply_text"; then
+    VERDICT="failed"
+    RUN_STAGE="semantic_review"
+    FAILURE_JSON="$(build_failure_json "semantic_codex_update_scheduler_memory_false_negative" "$RUN_STAGE" "Authoritative Codex update scheduler reply treated chat memory or broken memory-search behavior as evidence about live cron/scheduler state" "operator" true)"
+    DIAGNOSTIC_JSON="$(jq -cn \
+      --arg reply_text "$reply_text" \
+      --arg message "$normalized_message" \
+      --argjson base "$DIAGNOSTIC_JSON" \
+      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_scheduler_memory_false_negative"}}')"
+    RECOMMENDED_ACTION="Reconcile codex-update scheduler questions so Telegram answers from the remote-safe scheduler contract instead of drifting into memory/schedule speculation, then rerun authoritative UAT."
     return 0
   fi
 

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -1618,10 +1618,36 @@ codex_update_result_label_ru() {
     esac
 }
 
+build_codex_update_scheduler_reply_text() {
+    local state_json="" state_run_at="" state_run_date="" reply_text=""
+
+    state_json="$(read_codex_update_state_json || true)"
+    if [[ -n "$state_json" ]]; then
+        state_run_at="$(extract_json_string_field_from_text "$state_json" "last_run_at" || true)"
+        state_run_date="$(format_iso_date_short "$state_run_at" || true)"
+    fi
+
+    reply_text='По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI.'
+    if [[ -n "$state_run_date" ]]; then
+        reply_text="${reply_text} В сохранённом состоянии последняя проверка была ${state_run_date}, но это само по себе не доказывает, что live cron сейчас включён."
+    else
+        reply_text="${reply_text} Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён."
+    fi
+    reply_text="${reply_text} Для точного статуса нужен операторский/runtime check, а не memory search."
+
+    printf '%s' "$reply_text"
+}
+
 build_codex_update_reply_text() {
+    local mode="${1:-release}"
     local release_json="" latest_version="" published_at="" published_date=""
     local state_json="" state_version="" state_run_at="" state_run_date="" state_result="" state_result_ru=""
     local reply_text=""
+
+    if [[ "$mode" == "scheduler" ]]; then
+        build_codex_update_scheduler_reply_text
+        return 0
+    fi
 
     release_json="$(fetch_codex_update_release_json || true)"
     if [[ -n "$release_json" ]]; then
@@ -3081,8 +3107,16 @@ fi
 looks_like_sparse_skill_create_request="$current_turn_sparse_skill_create_request"
 
 current_turn_codex_update_request=false
-if [[ "$looks_like_skill_turn" != true ]] && \
-   printf '%s' "$intent_text_flat" | grep -Eiq '((codex([[:space:]]+cli)?|codex-update).{0,80}(обновлен|update|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового))|(((обновлен|update|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового).{0,80}(codex([[:space:]]+cli)?|codex-update))))'; then
+current_turn_codex_update_scheduler_request=false
+codex_update_subject_request=false
+if [[ "$looks_like_skill_turn" != true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(codex([[:space:]]+cli)?|codex-update)'; then
+    codex_update_subject_request=true
+fi
+if [[ "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(крон(а|у|ом)?|cron|scheduler|schedule|расписан|расписанию|регулярн|автопровер|автоматич|watcher|монитор|периодич|daemon|демон|каждые)'; then
+    current_turn_codex_update_scheduler_request=true
+    current_turn_codex_update_request=true
+fi
+if [[ "$current_turn_codex_update_request" != true && "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(обновлен|обновлени|update|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового|новой|новая|новую)'; then
     current_turn_codex_update_request=true
 fi
 
@@ -3150,6 +3184,17 @@ persisted_skill_detail_name=""
 if [[ "$persisted_turn_intent" =~ ^skill_detail:([A-Za-z0-9._-]+)$ ]]; then
     persisted_skill_detail_name="${BASH_REMATCH[1]}"
 fi
+persisted_codex_update_request=false
+persisted_codex_update_scheduler_request=false
+case "${persisted_turn_intent:-}" in
+    codex_update)
+        persisted_codex_update_request=true
+        ;;
+    codex_update_scheduler)
+        persisted_codex_update_request=true
+        persisted_codex_update_scheduler_request=true
+        ;;
+esac
 if [[ -z "$resolved_skill_name" && -n "$persisted_skill_detail_name" ]]; then
     resolved_skill_name="$persisted_skill_detail_name"
 fi
@@ -3226,6 +3271,12 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         next_turn_intent="skill_visibility"
     elif [[ "$looks_like_skill_template_request" == true ]]; then
         next_turn_intent="skill_template"
+    elif [[ "$current_turn_codex_update_request" == true ]]; then
+        if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
+            next_turn_intent="codex_update_scheduler"
+        else
+            next_turn_intent="codex_update"
+        fi
     elif [[ "$current_turn_skill_detail_request" == true && -n "${resolved_skill_name:-}" ]]; then
         next_turn_intent="skill_detail:${resolved_skill_name}"
     elif [[ "$looks_like_sparse_skill_create_request" == true && -n "${requested_skill_name:-}" ]]; then
@@ -3312,7 +3363,11 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             fi
         fi
         if [[ "$current_turn_codex_update_request" == true ]]; then
-            codex_update_reply_text="$(build_codex_update_reply_text || true)"
+            codex_update_reply_mode="release"
+            if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
+                codex_update_reply_mode="scheduler"
+            fi
+            codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
             if [[ -n "$codex_update_reply_text" ]] && direct_fastpath_send_with_suppression "codex_update" "$telegram_chat_id" "$codex_update_reply_text" "codex_update"; then
                 clear_turn_intent "${turn_session_key:-}"
                 exit 0
@@ -3383,7 +3438,11 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             fi
         fi
         if [[ "$current_turn_codex_update_request" == true ]]; then
-            codex_update_reply_text="$(build_codex_update_reply_text || true)"
+            codex_update_reply_mode="release"
+            if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
+                codex_update_reply_mode="scheduler"
+            fi
+            codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
             if [[ -n "$codex_update_reply_text" ]]; then
                 codex_update_guard="$(build_codex_update_hard_override_message "$codex_update_reply_text")"
                 codex_update_user=$'Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего.'
@@ -3545,6 +3604,23 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
             else
                 clear_turn_intent "${turn_session_key:-}"
                 emit_modified_payload "$skill_detail_reply_text" false
+            fi
+            exit 0
+        fi
+    fi
+    if [[ "$current_turn_codex_update_request" == true || "$persisted_codex_update_request" == true ]]; then
+        codex_update_reply_mode="release"
+        if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
+            codex_update_reply_mode="scheduler"
+        fi
+        codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
+        if [[ -n "$codex_update_reply_text" ]]; then
+            write_audit_line "emit_modify event=$event reason=codex_update_reply_override mode=$codex_update_reply_mode"
+            if [[ "$event" == "AfterLLMCall" ]]; then
+                emit_modified_payload "$codex_update_reply_text" true
+            else
+                clear_turn_intent "${turn_session_key:-}"
+                emit_modified_payload "$codex_update_reply_text" false
             fi
             exit 0
         fi

--- a/tests/component/test_telegram_remote_uat_contract.sh
+++ b/tests/component/test_telegram_remote_uat_contract.sh
@@ -713,6 +713,70 @@ JSON
   exit 0
 fi
 
+if [[ "$mode" == "codex_update_scheduler_memory_false_negative_pass" ]]; then
+  cat <<'JSON'
+{
+  "ok": true,
+  "status": "pass",
+  "stage": "wait_reply",
+  "reply_text": "Не вижу подтверждения, что такой крон у меня есть. Я бы хотел это проверить по памяти/расписанию, но инструмент поиска памяти сейчас тоже отвечает криво, так что честно: подтвердить наличие такого крона я сейчас не могу.",
+  "reply_mid": 42,
+  "sent_mid": 41,
+  "checks": {
+    "non_empty": true,
+    "min_length": true,
+    "reply_settled": true,
+    "error_signature_clean": true,
+    "sensitive_signature_clean": true
+  },
+  "failures": [],
+  "attribution_evidence": {
+    "attribution_confidence": "proven"
+  },
+  "diagnostic_context": {
+    "stats": {
+      "url": "https://web.telegram.org/k/#@moltinger_bot",
+      "hasSearch": true
+    }
+  },
+  "recommended_action": "Authoritative Telegram Web path passed; no secondary diagnostics are needed."
+}
+JSON
+  exit 0
+fi
+
+if [[ "$mode" == "codex_update_scheduler_contract_safe_pass" ]]; then
+  cat <<'JSON'
+{
+  "ok": true,
+  "status": "pass",
+  "stage": "wait_reply",
+  "reply_text": "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search.",
+  "reply_mid": 42,
+  "sent_mid": 41,
+  "checks": {
+    "non_empty": true,
+    "min_length": true,
+    "reply_settled": true,
+    "error_signature_clean": true,
+    "sensitive_signature_clean": true
+  },
+  "failures": [],
+  "attribution_evidence": {
+    "attribution_confidence": "proven"
+  },
+  "diagnostic_context": {
+    "stats": {
+      "url": "https://web.telegram.org/k/#@moltinger_bot",
+      "hasSearch": true
+    }
+  },
+  "recommended_action": "Authoritative Telegram Web path passed; no secondary diagnostics are needed."
+}
+JSON
+  exit 0
+fi
+
 if [[ "$mode" == "skill_visibility_false_negative_pass" ]]; then
   cat <<'JSON'
 {
@@ -1531,6 +1595,37 @@ run_component_telegram_remote_uat_contract_tests() {
         test_pass
     else
         test_fail "Authoritative wrapper must not fail a correct codex-update runtime-state reply only because it contrasts with chat memory"
+    fi
+
+    test_start "component_telegram_remote_uat_fails_codex_update_scheduler_memory_false_negative_even_if_helper_passes"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_memory_false_negative_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-memory.json" \
+        >/dev/null 2>&1
+    then
+        test_fail "Authoritative wrapper must fail when codex-update scheduler questions drift into memory/schedule speculation"
+    else
+        if jq -e '.failure.code == "semantic_codex_update_scheduler_memory_false_negative" and .run.stage == "semantic_review"' "$TEST_TMPDIR/result-codex-update-scheduler-memory.json" >/dev/null 2>&1
+        then
+            test_pass
+        else
+            test_fail "Wrapper must surface codex-update scheduler replies that substitute memory-search speculation for the remote-safe scheduler contract"
+        fi
+    fi
+
+    test_start "component_telegram_remote_uat_allows_codex_update_scheduler_contract_safe_reply"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_contract_safe_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-safe.json" \
+        >/dev/null 2>&1
+    then
+        test_pass
+    else
+        test_fail "Authoritative wrapper must allow the remote-safe codex-update scheduler contract reply"
     fi
 
     test_start "component_telegram_remote_uat_fails_skill_visibility_false_negative_against_live_api_skills"

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -2444,6 +2444,46 @@ EOF
         test_fail "MessageSending guard must rewrite codex-update skill-detail failures into a clean Telegram-safe summary instead of falling back to operator-heavy description text"
     fi
 
+    test_start "component_after_llm_guard_rewrites_codex_update_scheduler_question_into_remote_safe_contract_reply"
+    local codex_update_scheduler_after_output
+    codex_update_scheduler_after_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$(secure_temp_dir telegram-safe-codex-update-scheduler-after)" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","session_key":"session:codex-update-scheduler-after","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872993 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"text":"Не вижу подтверждения, что такой крон у меня есть. Я бы хотел это проверить по памяти/расписанию, но инструмент поиска памяти сейчас тоже отвечает криво.","tool_calls":[{"name":"mcp__mempalace__search","arguments":{"query":"codex cli cron watcher"}}]}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
+       jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
+       jq -e '.data.text | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
+       jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
+       jq -e '.data.text | test("Activity log|Searching memory|missing '\''query'\'' parameter|памяти/расписанию|криво") | not' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall guard must rewrite codex-update scheduler questions into the deterministic remote-safe contract instead of leaving memory/tool reasoning in place"
+    fi
+
+    test_start "component_message_sending_guard_rewrites_codex_update_scheduler_memory_leak_into_remote_safe_contract_reply"
+    local codex_update_scheduler_message_output
+    codex_update_scheduler_message_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$(secure_temp_dir telegram-safe-codex-update-scheduler-message)" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-update-scheduler-message","data":{"account_id":"moltis-bot","to":"262872994","reply_to_message_id":964,"user_message":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?","text":"Не вижу подтверждения, что такой крон у меня есть.\n\nЯ бы хотел это проверить по памяти/расписанию, но инструмент поиска памяти сейчас тоже отвечает криво, так что честно: подтвердить наличие такого крона я сейчас не могу.\n\n📋 Activity log\n• 🧠 Searching memory...\n• ❌ missing 'query' parameter"}} 
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
+       jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
+       jq -e '.data.text | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
+       jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
+       jq -e '.data.reply_to_message_id == 964' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
+       jq -e '.data.text | test("Activity log|Searching memory|missing '\''query'\'' parameter|памяти/расписанию|криво") | not' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output"; then
+        test_pass
+    else
+        test_fail "MessageSending guard must replace codex-update scheduler memory leaks with the deterministic remote-safe contract reply"
+    fi
+
     test_start "component_message_sending_guard_rewrites_post_close_classifier_skill_detail_into_clean_runtime_summary"
     local classifier_skill_dir message_sending_classifier_skill_output classifier_skill_fakebin
     classifier_skill_dir="$(secure_temp_dir telegram-safe-post-close-classifier-detail-runtime)"


### PR DESCRIPTION
## Summary
- classify codex-update scheduler questions separately from generic release questions
- force a deterministic Telegram-safe scheduler reply in BeforeLLMCall and late override stages
- extend authoritative UAT/component coverage for scheduler-specific memory/tool leakage

## RCA
- scheduler-mode support already existed in Moltis, but Telegram-safe routing did not treat scheduler/cron questions as their own contract
- that let the same user intent drift into memory-search fallbacks or raw cron tool leakage such as `missing 'action' parameter`
- the fix makes the scheduler question family terminal and text-only on Telegram-safe surfaces

## Validation
- bash -n scripts/telegram-safe-llm-guard.sh
- bash -n scripts/telegram-e2e-on-demand.sh
- bash -n tests/component/test_telegram_safe_llm_guard.sh
- bash -n tests/component/test_telegram_remote_uat_contract.sh
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_remote_uat_contract.sh

Refs: moltinger-be5h