### PR TITLE
fix(deploy): bootstrap cron package in host automation

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-04-10
-**Total Lessons**: 71
+**Generated**: 2026-04-14
+**Total Lessons**: 72
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (31 lessons)
+#### P1 (32 lessons)
+- [Deploy host automation missing cron package bootstrap](../docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md)
 - [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
 - [Runtime-only Beads repair still pointed at raw bootstrap after the CLI contract drifted](../docs/rca/2026-03-29-runtime-only-repair-contract-still-pointed-at-raw-bootstrap.md)
 - [Managed worktree creation mixed up the create executor and hook bootstrap-source contract](../docs/rca/2026-03-28-worktree-create-helper-and-hook-bootstrap-source-drift.md)
@@ -96,7 +97,8 @@
 ### By Category
 
 
-#### cicd (28 lessons)
+#### cicd (29 lessons)
+- [Deploy host automation missing cron package bootstrap](../docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md)
 - [Tracked deploy empty stdout broke GitHub Actions JSON contract](../docs/rca/2026-04-02-tracked-deploy-empty-stdout-broke-json-contract.md)
 - [Tracked Moltis deploy failed because the repo skill sync helper crashed in its EXIT trap under set -u](../docs/rca/2026-03-28-moltis-repo-skill-sync-trap-broke-deploy-verification.md)
 - [Tracked Moltis deploy failed because auto-rollback reused an unsafe recreate path while health-monitor mutated Docker state during the same incident](../docs/rca/2026-03-28-moltis-deploy-auto-rollback-recreate-and-health-monitor-interference.md)
@@ -184,7 +186,7 @@
 
 - `moltis` (26 lessons)
 - `rca` (20 lessons)
-- `deploy` (18 lessons)
+- `deploy` (19 lessons)
 - `github-actions` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
@@ -200,10 +202,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 71 |
-| Critical (P0/P1) | 32 |
+| Total Lessons | 72 |
+| Critical (P0/P1) | 33 |
 | Categories | 6 |
-| Unique Tags | 147 |
+| Unique Tags | 150 |
 
 ---
 

--- a/docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md
+++ b/docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md
@@ -1,0 +1,99 @@
+---
+title: "Deploy host automation missing cron package bootstrap"
+date: 2026-04-14
+severity: P1
+category: cicd
+tags: [deploy, cron, scheduler, host-automation, apt]
+root_cause: "Tracked host automation assumed an existing cron/crond systemd unit and had no package-bootstrap path for fresh Debian/Ubuntu hosts."
+---
+
+# RCA: Deploy host automation missing cron package bootstrap
+
+**Дата:** 2026-04-14  
+**Статус:** Resolved  
+**Влияние:** Production deploy после merge `#173` не смог завершить host automation, поэтому live Moltis не получил исправление Telegram-safe guard и scheduler path остался без прод-роллаута.  
+**Контекст:** beads `moltinger-1inj`, deploy run `24366831337`, шаг `Apply Moltis host automation from active deploy root`.
+
+## Ошибка
+
+Симптомы:
+
+- `Deploy Moltis` run `24366831337` завершился `failure`.
+- Падение произошло на шаге `Apply Moltis host automation from active deploy root`.
+- Лог завершался строкой: `apply-moltis-host-automation.sh: unable to resolve a cron service unit (expected cron or crond)`.
+
+Дополнительные факты:
+
+- На хосте `root@ainetic.tech` присутствовал cron file `/etc/cron.d/moltis-codex-upstream-watcher`, но `systemctl list-unit-files` не показывал ни `cron.service`, ни `crond.service`.
+- На том же хосте был доступен `apt-get`, а `/etc/os-release` подтверждал `Ubuntu 22.04.5 LTS`.
+- Значит, проблема была не в "inactive service", а в полном отсутствии установленного scheduler package.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag deploy`
+- `./scripts/query-lessons.sh --tag cron`
+
+**Релевантные прошлые RCA/уроки:**
+
+1. `docs/rca/2026-03-28-moltis-repo-skill-sync-trap-broke-deploy-verification.md` — deploy helper scripts должны иметь blocking regression coverage на failure-path.
+2. `docs/rca/2026-03-20-deploy-collision-and-active-root-symlink-guard.md` — deploy control plane нужно вытаскивать в versioned script entrypoints, а не держать implicit behavior в workflow.
+
+**Что могло быть упущено без этой сверки:**
+
+- можно было снова ограничиться server-only workaround (`systemctl start cron`) вместо source fix в owning helper;
+- можно было закрыть incident без unit coverage на package-bootstrap path.
+
+**Что в текущем инциденте действительно новое:**
+
+- helper уже управлял cron/systemd convergence, но не умел materialize сам dependency package на чистом Debian/Ubuntu host.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему production deploy упал на host automation? | Скрипт не смог разрешить `cron`/`crond` unit и завершился ошибкой. | `gh run view 24366831337 --log-failed` |
+| 2 | Почему `cron`/`crond` unit не разрешился? | На сервере не было установленного пакета cron, поэтому `systemctl` не видел соответствующий unit. | `systemctl list-unit-files`, `command -v cron`, `command -v crond` на `root@ainetic.tech` |
+| 3 | Почему отсутствие пакета не было обработано автоматически? | `scripts/apply-moltis-host-automation.sh` умел только reload/restart/enable existing service, но не имел bootstrap path для missing package. | Исходный код helper до фикса |
+| 4 | Почему такой сценарий прошёл в `main` без guard? | Unit tests покрывали только "service exists but inactive" и "service remains inactive", но не "service missing because package absent". | `tests/unit/test_deploy_workflow_guards.sh` до фикса |
+| 5 | Почему coverage не поймала реальный production prerequisite? | Мы зафиксировали operational contract на уровне systemd activation, но не сформулировали более базовую инварианту: helper обязан либо materialize scheduler dependency, либо fail с явной diagnostic причиной. | Разрыв между live host facts и проверяемым тестовым контрактом |
+
+## Корневая причина
+
+Tracked deploy helper предполагал, что на целевом Debian/Ubuntu host уже существует systemd unit `cron`/`crond`.  
+Это было неверное инфраструктурное предположение: при свежем или неполном хосте helper не materialize-ил обязательный scheduler dependency package и не имел regression test на этот prerequisite.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Actionable? | yes | Исправляется в owning helper script и test contract |
+| Systemic? | yes | Ошибка в versioned deploy control-plane, а не в единичном ручном действии |
+| Preventable? | yes | Покрывается package-bootstrap path + unit regressions |
+
+## Принятые меры
+
+1. **Немедленное исправление:**  
+   `scripts/apply-moltis-host-automation.sh` теперь при отсутствии `cron`/`crond` unit пытается официально bootstrap-нуть пакет `cron` через `apt-get update -yqq && apt-get install -y -qq cron`, затем повторно разрешает service и продолжает activation contract.
+2. **Предотвращение:**  
+   В `tests/unit/test_deploy_workflow_guards.sh` добавлены блокирующие regression tests на:
+   - успешный package bootstrap при отсутствии cron unit;
+   - явный fail-fast, если `apt-get install cron` не удаётся.
+3. **Документация:**  
+   Создан этот RCA; lessons flow обновлён через пересборку индекса уроков.
+
+## Связанные обновления
+
+- [ ] Новый файл правила создан
+- [ ] Краткая ссылка добавлена в CLAUDE.md
+- [ ] Новые навыки созданы
+- [x] Тесты добавлены
+- [x] Новый RCA создан
+
+## Уроки
+
+1. Для deploy helper-а "service activation" недостаточно, если runtime dependency может отсутствовать на хосте целиком.
+2. Host automation должна либо materialize обязательную системную зависимость официальным путём, либо падать с explicit diagnostic message вместо общего `unable to resolve`.
+3. Production prerequisites нужно закреплять unit-тестами не только на happy path existing-service, но и на fresh-host package-missing path.

--- a/scripts/apply-moltis-host-automation.sh
+++ b/scripts/apply-moltis-host-automation.sh
@@ -106,6 +106,10 @@ systemctl_available() {
     command -v systemctl >/dev/null 2>&1
 }
 
+apt_get_available() {
+    command -v apt-get >/dev/null 2>&1
+}
+
 cron_service_exists() {
     local candidate="${1:-}"
     local load_state=""
@@ -134,11 +138,30 @@ resolve_cron_service_name() {
     return 1
 }
 
+bootstrap_cron_service_package() {
+    if ! apt_get_available; then
+        echo "apply-moltis-host-automation.sh: cron service unit is missing and no supported package bootstrap is available (expected apt-get for Debian/Ubuntu host)" >&2
+        return 1
+    fi
+
+    log "Cron service unit missing; bootstrapping cron package via apt-get"
+    if ! DEBIAN_FRONTEND=noninteractive apt-get update -yqq; then
+        echo "apply-moltis-host-automation.sh: apt-get update failed while bootstrapping cron package" >&2
+        return 1
+    fi
+
+    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq cron; then
+        echo "apply-moltis-host-automation.sh: apt-get install cron failed while bootstrapping cron package" >&2
+        return 1
+    fi
+}
+
 ensure_cron_service_active() {
     local cron_service=""
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "resolve cron service via MOLTIS_CRON_SERVICE_NAME or detected cron/crond unit"
+        log_dry_run "if no cron/crond unit exists and apt-get is available: apt-get update -yqq && apt-get install -y -qq cron"
         log_dry_run "systemctl reload \$CRON_SERVICE || systemctl restart \$CRON_SERVICE || true"
         log_dry_run "if ! systemctl is-active --quiet \$CRON_SERVICE; then systemctl enable --now \$CRON_SERVICE || systemctl start \$CRON_SERVICE; fi"
         log_dry_run "systemctl is-active --quiet \$CRON_SERVICE"
@@ -152,7 +175,12 @@ ensure_cron_service_active() {
 
     cron_service="$(resolve_cron_service_name || true)"
     if [[ -z "$cron_service" ]]; then
-        echo "apply-moltis-host-automation.sh: unable to resolve a cron service unit (expected cron or crond)" >&2
+        bootstrap_cron_service_package || return 1
+        cron_service="$(resolve_cron_service_name || true)"
+    fi
+
+    if [[ -z "$cron_service" ]]; then
+        echo "apply-moltis-host-automation.sh: cron package bootstrap completed but no cron/crond systemd unit was found" >&2
         return 1
     fi
 

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -1230,6 +1230,7 @@ test_host_automation_script_dry_run_keeps_scheduler_disabled_without_mutating_ac
        ! grep -Fq "$host_systemd_dir/moltis-backup.timer" "$output_file" || \
        ! grep -Fq "$host_systemd_dir/moltis-health-monitor.service" "$output_file" || \
        ! grep -Fq "resolve cron service via MOLTIS_CRON_SERVICE_NAME or detected cron/crond unit" "$output_file" || \
+       ! grep -Fq "if no cron/crond unit exists and apt-get is available: apt-get update -yqq && apt-get install -y -qq cron" "$output_file" || \
        ! grep -Fq 'systemctl is-active --quiet $CRON_SERVICE' "$output_file" || \
        ! grep -Fq "systemctl disable --now moltis-telegram-web-user-monitor.timer" "$output_file" || \
        ! grep -Fq "systemctl daemon-reload" "$output_file"; then
@@ -1330,6 +1331,38 @@ EOF
     chmod +x "$destination"
 }
 
+write_fake_apt_get_for_host_automation_tests() {
+    local destination="${1:-}"
+
+    cat >"$destination" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+state_dir="${FAKE_APT_GET_STATE_DIR:?}"
+command="${1:-}"
+shift || true
+
+case "$command" in
+    update)
+        : > "$state_dir/apt-get.update.called"
+        [[ -f "$state_dir/apt-get.update.fail" ]] && exit 1
+        exit 0
+        ;;
+    install)
+        : > "$state_dir/apt-get.install.called"
+        [[ -f "$state_dir/apt-get.install.fail" ]] && exit 1
+        if [[ " $* " == *" cron "* ]]; then
+            : > "$state_dir/cron.service.exists"
+        fi
+        exit 0
+        ;;
+esac
+
+exit 1
+EOF
+    chmod +x "$destination"
+}
+
 write_noop_chown_for_host_automation_tests() {
     local destination="${1:-}"
 
@@ -1389,6 +1422,56 @@ test_host_automation_script_activates_inactive_cron_service() {
     test_pass
 }
 
+test_host_automation_script_bootstraps_missing_cron_package() {
+    test_start "Shared host-automation script should install cron package when no cron unit exists on host"
+
+    if [[ ! -f "$HOST_AUTOMATION_SCRIPT" ]]; then
+        test_skip "Missing script file: $HOST_AUTOMATION_SCRIPT"
+        return
+    fi
+
+    local tmp_dir active_root host_cron_dir host_systemd_dir fakebin state_dir output_file
+    tmp_dir="$(mktemp -d)"
+    active_root="$tmp_dir/active-root"
+    host_cron_dir="$tmp_dir/etc-cron.d"
+    host_systemd_dir="$tmp_dir/etc-systemd"
+    fakebin="$tmp_dir/fakebin"
+    state_dir="$tmp_dir/systemctl-state"
+    output_file="$tmp_dir/output.log"
+
+    mkdir -p "$active_root/scripts/cron.d" "$active_root/systemd" "$host_cron_dir" "$host_systemd_dir" "$fakebin" "$state_dir"
+    printf 'watcher\n' > "$active_root/scripts/cron.d/moltis-codex-upstream-watcher"
+    printf '[Unit]\nDescription=health monitor\n' > "$active_root/systemd/moltis-health-monitor.service"
+    : > "$state_dir/moltis-health-monitor.service.exists"
+
+    write_fake_systemctl_for_host_automation_tests "$fakebin/systemctl"
+    write_fake_apt_get_for_host_automation_tests "$fakebin/apt-get"
+    write_noop_chown_for_host_automation_tests "$fakebin/chown"
+
+    if ! PATH="$fakebin:$PATH" \
+        FAKE_SYSTEMCTL_STATE_DIR="$state_dir" \
+        FAKE_APT_GET_STATE_DIR="$state_dir" \
+        MOLTIS_HOST_CRON_DIR="$host_cron_dir" \
+        MOLTIS_HOST_SYSTEMD_DIR="$host_systemd_dir" \
+        bash "$HOST_AUTOMATION_SCRIPT" --active-root "$active_root" >"$output_file" 2>&1; then
+        test_fail "apply-moltis-host-automation.sh should bootstrap cron package when no cron unit exists"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    if [[ ! -f "$state_dir/apt-get.update.called" ]] || \
+       [[ ! -f "$state_dir/apt-get.install.called" ]] || \
+       [[ ! -f "$state_dir/cron.service.active" ]] || \
+       ! grep -Fq "Cron service unit missing; bootstrapping cron package via apt-get" "$output_file"; then
+        test_fail "Host automation should bootstrap cron via apt-get and activate cron.service"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    rm -rf "$tmp_dir"
+    test_pass
+}
+
 test_host_automation_script_fails_when_cron_service_remains_inactive() {
     test_start "Shared host-automation script should fail fast when cron service stays inactive after automation"
 
@@ -1429,6 +1512,54 @@ test_host_automation_script_fails_when_cron_service_remains_inactive() {
 
     if ! grep -Fq "cron service 'cron.service' is not active after host automation" "$output_file"; then
         test_fail "Failure should explain that cron.service stayed inactive after host automation"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    rm -rf "$tmp_dir"
+    test_pass
+}
+
+test_host_automation_script_fails_when_cron_package_bootstrap_fails() {
+    test_start "Shared host-automation script should fail fast when cron package bootstrap fails"
+
+    if [[ ! -f "$HOST_AUTOMATION_SCRIPT" ]]; then
+        test_skip "Missing script file: $HOST_AUTOMATION_SCRIPT"
+        return
+    fi
+
+    local tmp_dir active_root host_cron_dir host_systemd_dir fakebin state_dir output_file
+    tmp_dir="$(mktemp -d)"
+    active_root="$tmp_dir/active-root"
+    host_cron_dir="$tmp_dir/etc-cron.d"
+    host_systemd_dir="$tmp_dir/etc-systemd"
+    fakebin="$tmp_dir/fakebin"
+    state_dir="$tmp_dir/systemctl-state"
+    output_file="$tmp_dir/output.log"
+
+    mkdir -p "$active_root/scripts/cron.d" "$active_root/systemd" "$host_cron_dir" "$host_systemd_dir" "$fakebin" "$state_dir"
+    printf 'watcher\n' > "$active_root/scripts/cron.d/moltis-codex-upstream-watcher"
+    printf '[Unit]\nDescription=health monitor\n' > "$active_root/systemd/moltis-health-monitor.service"
+    : > "$state_dir/moltis-health-monitor.service.exists"
+    : > "$state_dir/apt-get.install.fail"
+
+    write_fake_systemctl_for_host_automation_tests "$fakebin/systemctl"
+    write_fake_apt_get_for_host_automation_tests "$fakebin/apt-get"
+    write_noop_chown_for_host_automation_tests "$fakebin/chown"
+
+    if PATH="$fakebin:$PATH" \
+        FAKE_SYSTEMCTL_STATE_DIR="$state_dir" \
+        FAKE_APT_GET_STATE_DIR="$state_dir" \
+        MOLTIS_HOST_CRON_DIR="$host_cron_dir" \
+        MOLTIS_HOST_SYSTEMD_DIR="$host_systemd_dir" \
+        bash "$HOST_AUTOMATION_SCRIPT" --active-root "$active_root" >"$output_file" 2>&1; then
+        test_fail "apply-moltis-host-automation.sh must fail when cron package bootstrap fails"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    if ! grep -Fq "apt-get install cron failed while bootstrapping cron package" "$output_file"; then
+        test_fail "Cron bootstrap failure should explain the apt-get install failure"
         rm -rf "$tmp_dir"
         return
     fi
@@ -1678,7 +1809,9 @@ run_all_tests() {
     test_tracked_deploy_script_treats_env_file_as_data
     test_host_automation_script_dry_run_keeps_scheduler_disabled_without_mutating_active_root
     test_host_automation_script_activates_inactive_cron_service
+    test_host_automation_script_bootstraps_missing_cron_package
     test_host_automation_script_fails_when_cron_service_remains_inactive
+    test_host_automation_script_fails_when_cron_package_bootstrap_fails
     test_active_root_script_migrates_legacy_directory
     test_active_root_script_requires_existing_target_directory
     test_prod_mutation_guard_denies_unapproved_production_replay


### PR DESCRIPTION
## Summary\n- bootstrap the cron package via apt-get when host automation finds no cron/crond systemd unit on Debian/Ubuntu hosts\n- fail closed with explicit bootstrap diagnostics when package installation still cannot materialize a cron service\n- add unit regressions for package-missing bootstrap, bootstrap failure, and record the incident in RCA/lessons docs\n\n## Testing\n- bash -n scripts/apply-moltis-host-automation.sh\n- bash -n tests/unit/test_deploy_workflow_guards.sh\n- bash tests/unit/test_deploy_workflow_guards.sh\n\n## RCA\n- docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md