### PR TITLE
fix(telegram): hard-stop codex-update fastpath race

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-14
-**Total Lessons**: 73
+**Total Lessons**: 74
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (33 lessons)
+#### P1 (34 lessons)
+- [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
 - [Telegram chat probe skill pointed to a missing wrapper entrypoint](../docs/rca/2026-04-14-telegram-chat-probe-skill-pointed-to-missing-wrapper-entrypoint.md)
 - [Deploy host automation missing cron package bootstrap](../docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md)
 - [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
@@ -172,6 +173,9 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
+#### product (1 lessons)
+- [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
+
 #### security (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
@@ -187,10 +191,10 @@
 ### Popular Tags
 
 - `moltis` (26 lessons)
-- `rca` (21 lessons)
+- `rca` (22 lessons)
 - `deploy` (19 lessons)
+- `telegram` (17 lessons)
 - `github-actions` (17 lessons)
-- `telegram` (16 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `skills` (11 lessons)
@@ -204,10 +208,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 73 |
-| Critical (P0/P1) | 34 |
-| Categories | 6 |
-| Unique Tags | 153 |
+| Total Lessons | 74 |
+| Critical (P0/P1) | 35 |
+| Categories | 7 |
+| Unique Tags | 155 |
 
 ---
 

--- a/docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md
+++ b/docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md
@@ -1,0 +1,114 @@
+---
+title: "Telegram codex-update direct fastpath raced underlying run"
+date: 2026-04-14
+severity: P1
+category: product
+tags: [telegram, codex-update, fastpath, hook, cron, uat, rca]
+root_cause: "The Telegram-safe `codex-update` path used an out-of-band direct-send fastpath that did not actually terminate the underlying LLM run, so a later `cron` tool failure produced a second bad reply; the authoritative Telegram Web probe also allowed an early clean reply to settle before observing that delayed second reply."
+---
+
+# RCA: Telegram codex-update direct fastpath raced underlying run
+
+Date: 2026-04-14  
+Status: Resolved in source, pending deploy/live re-verification  
+Context: beads `moltinger-15te`, live Moltis Telegram regression on `@moltinger_bot`
+
+## Error
+
+Пользователь получил в live Telegram такой ответ вместо канонического scheduler-safe контракта:
+
+```text
+Проверил — и да, тут инструмент расписания реально сломан: на list он снова ответил missing 'action' parameter.
+...
+📋 Activity log
+• 🔧 cron
+•   ❌ missing 'action' parameter
+```
+
+При этом ранний post-deploy smoke уже был ошибочно интерпретирован как `passed`, хотя bad reply реально существовал в том же production chat.
+
+## Lessons Pre-check
+
+Перед фиксом были проверены lessons и связанные правила:
+
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag cron`
+- `./scripts/query-lessons.sh --tag codex-update`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Релевантные прошлые уроки:
+
+1. `2026-03-20-telegram-uat-false-pass-on-model-not-found.md`  
+   transport/ранний зелёный helper verdict не доказывает корректный пользовательский ответ.
+2. `2026-03-28-telegram-codex-update-sandbox-skill-path-mismatch-and-activity-log-transport-leak.md`  
+   `codex-update` на Telegram-safe surface должен отвечать deterministic contract-ом, а не уходить в tool/memory speculation.
+3. `2026-04-05-telegram-skill-detail-general-hardening.md`  
+   prompt family drift и stale chat contamination нужно ловить по authoritative evidence, а не по “похожему” старому прогону.
+
+Что эти уроки уже покрывали:
+
+- Telegram-safe ответы нельзя считать зелёными только по раннему helper success.
+- `codex-update` routes требуют deterministic rewrite, а не best-effort tool behavior.
+
+Что оставалось непокрытым:
+
+- out-of-band direct fastpath для `codex-update` не считался dangerous, хотя он не останавливал underlying run;
+- authoritative Telegram Web probe не держал дополнительное окно наблюдения после раннего clean reply.
+
+## Evidence
+
+Production evidence с `root@ainetic.tech`:
+
+- `scripts/telegram-e2e-on-demand.sh --mode authoritative` вернул `pre_send_invalid_activity` и показал уже существующий bad incoming reply в чате.
+- `docker logs moltis` зафиксировал живой run:
+  - `2026-04-14T11:39:07Z` tool call `cron` с `{"action":"list",...}`
+  - затем `tool execution failed ... missing 'action' parameter`
+  - затем финальный user-facing bad reply.
+- `/tmp/moltis-telegram-safe-llm-guard.audit.log` зафиксировал, что hook раньше в том же run уже сделал:
+  - `direct_fastpath kind=codex_update`
+  - затем `direct_fastpath_after_llm_suppress`
+  - затем `direct_fastpath_tool_suppress`
+
+Это доказало, что ранний direct send произошёл, но сам run не остановился и позже сгенерировал второй плохой ответ.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Почему пользователь увидел bad reply с `cron`/`missing 'action' parameter`? | Потому что underlying LLM run всё же вызвал `cron` tool и поздно вернул ошибочный текст в чат. |
+| 2 | Почему underlying run вообще продолжил жить после Telegram-safe ответа? | Потому что `codex-update` использовал `BeforeLLMCall` direct fastpath, который делал `sendMessage`, но не заменял prompt на hard override и не завершал сам run. |
+| 3 | Почему это не было остановлено последующими suppress hooks? | Потому что suppression оказался best-effort post-factum механизмом; live runtime всё равно довёл run до позднего финального ответа. |
+| 4 | Почему post-deploy smoke был интерпретирован как зелёный? | Потому что authoritative Telegram Web probe успел стабилизировать ранний clean reply до прихода позднего bad second reply. |
+| 5 | Почему такая гонка вообще была возможна как системный контракт? | Потому что мы считали out-of-band fastpath “эквивалентом short-circuit”, не зафиксировав инварианту: user-facing deterministic reply допустим только если он останавливает модель до tool execution, а не параллельно ей. |
+
+## Root Cause
+
+`codex-update` в Telegram-safe lane использовал out-of-band `direct_fastpath_send_with_suppression()` на `BeforeLLMCall`.  
+Этот path отправлял ранний канонический ответ, но не превращал ход в настоящий hard override до модели. В результате реальный LLM run продолжал выполняться, вызывал `cron` tool, получал ошибку `missing 'action' parameter` и позже отправлял второй bad reply.
+
+Параллельно authoritative Telegram Web probe возвращал verdict слишком рано после первого clean reply и не держал дополнительное observation window, достаточное чтобы заметить поздний второй ответ.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - `codex-update` исключён из `BeforeLLMCall` direct fastpath.
+   - Теперь этот route всегда идёт через deterministic hard override до модели.
+2. `tests/component/test_telegram_safe_llm_guard.sh`
+   - regression теперь требует, чтобы даже при `MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true` `codex-update` шёл через `modify`, а не через direct send.
+3. `scripts/telegram-web-user-probe.mjs`
+   - добавлено `minReplyObservationMs` окно наблюдения после первого reply;
+   - authoritative probe теперь не считается settled только из-за раннего clean-looking ответа.
+4. `tests/component/test_telegram_web_probe_correlation.sh`
+   - добавлена regression на delayed second reply, который должен победить ранний clean reply.
+
+## Prevention
+
+1. Out-of-band direct send нельзя считать safe short-circuit для высокорисковых user-facing маршрутов, если underlying run продолжает жить.
+2. Для deterministic Telegram-safe routes canonical path должен быть `BeforeLLMCall hard override`, а не “отправили напрямую и надеемся, что suppression всё дочистит”.
+3. Authoritative Telegram UAT должен держать observation window после первого reply, если продукт допускает delayed second replies.
+
+## Уроки
+
+1. Ранний “хороший” reply не доказывает успех, если у runtime ещё есть шанс прислать второй ответ в том же turn.
+2. `direct fastpath` и `true short-circuit` — это разные вещи; для Telegram-safe маршрутов их нельзя смешивать.
+3. Если production evidence противоречит старому smoke, источником истины становится live audit/correlation evidence, а не прежний зелёный verdict.

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -3328,6 +3328,9 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     fi
 
     if [[ "$is_telegram_safe_lane" == true ]] && flag_enabled "$DIRECT_FASTPATH_ENABLED" && [[ -n "${telegram_chat_id:-}" ]]; then
+        # codex-update turns stay on the deterministic hard-override path below.
+        # A direct send here does not actually terminate the underlying run and
+        # can race with a later bad LLM/tool reply on live Telegram.
         if [[ "$current_turn_status_request" == true ]]; then
             if direct_fastpath_send_with_suppression "status" "$telegram_chat_id" "$canonical_status" "status"; then
                 clear_turn_intent "${turn_session_key:-}"
@@ -3367,17 +3370,6 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         if [[ "$current_turn_skill_apply_request" == true ]]; then
             apply_reply_text="$(build_skill_apply_reply_text "${requested_skill_name:-}" || true)"
             if [[ -n "$apply_reply_text" ]] && direct_fastpath_send_with_suppression "skill_apply" "$telegram_chat_id" "$apply_reply_text" "skill_apply:${requested_skill_name:-generic}" "skill=${requested_skill_name:-missing}"; then
-                clear_turn_intent "${turn_session_key:-}"
-                exit 0
-            fi
-        fi
-        if [[ "$current_turn_codex_update_request" == true ]]; then
-            codex_update_reply_mode="release"
-            if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
-                codex_update_reply_mode="scheduler"
-            fi
-            codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
-            if [[ -n "$codex_update_reply_text" ]] && direct_fastpath_send_with_suppression "codex_update" "$telegram_chat_id" "$codex_update_reply_text" "codex_update"; then
                 clear_turn_intent "${turn_session_key:-}"
                 exit 0
             fi

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -19,6 +19,7 @@ const DEFAULT_MIN_REPLY_LEN = Number(process.env.TELEGRAM_WEB_MIN_REPLY_LEN || 2
 const DEFAULT_COMPOSER_RETRIES = Number(process.env.TELEGRAM_WEB_COMPOSER_RETRIES || 2);
 const DEFAULT_QUIET_WINDOW_MS = Number(process.env.TELEGRAM_WEB_QUIET_WINDOW_MS || 3000);
 const DEFAULT_REPLY_SETTLE_MS = Number(process.env.TELEGRAM_WEB_REPLY_SETTLE_MS || 5000);
+const DEFAULT_MIN_REPLY_OBSERVATION_MS = Number(process.env.TELEGRAM_WEB_MIN_REPLY_OBSERVATION_MS || 15000);
 const INTERNAL_TELEMETRY_RE =
   /(?:^|[•\n])\s*(?:[\p{Extended_Pictographic}\uFE0F]+\s*)?(?:activity log(?:\s*[•:-]|\b)|running:\s*`?|searching memory(?:\.\.\.)?|memory[_ ]search(?:[_ ]started)?\b|thinking(?:\.\.\.)?|tool(?:[_ ]call)?(?:[_ ](?:started|progress))?\b|mcp__[\p{L}\p{N}_:.-]+|mcp tool error\b|validation errors for call\[|missing required argument\b|unexpected keyword argument\b|fetching (?:github\.com|https?:\/\/)|create_skill\b|update_skill\b|delete_skill\b|session_state\b|send_message\b|send_image\b)/iu;
 const INTERNAL_PLANNING_RE =
@@ -48,6 +49,7 @@ const minReplyLen = Number(getArg("--min-reply-len", String(DEFAULT_MIN_REPLY_LE
 const composerRetries = Math.max(0, Number(getArg("--composer-retries", String(DEFAULT_COMPOSER_RETRIES))) || 0);
 const quietWindowMs = Math.max(500, Number(getArg("--quiet-window-ms", String(DEFAULT_QUIET_WINDOW_MS))) || 0);
 const replySettleMs = Math.max(1000, Number(getArg("--reply-settle-ms", String(DEFAULT_REPLY_SETTLE_MS))) || 0);
+const minReplyObservationMs = Math.max(0, Number(getArg("--min-reply-observation-ms", String(DEFAULT_MIN_REPLY_OBSERVATION_MS))) || 0);
 const headed = hasFlag("--headed");
 const debug = hasFlag("--debug");
 
@@ -236,6 +238,7 @@ function buildCorrelationWindow(details) {
     quiet_window_wait_ms: details.quietWindowWaitMs,
     reply_settle_ms: details.replySettleMs || null,
     reply_settle_wait_ms: details.replySettleWaitMs || null,
+    min_reply_observation_ms: details.minReplyObservationMs || null,
     baseline_max_message_id: details.baselineMaxMid,
     sent_observed_at_ms: details.sentObservedAtMs || null,
     reply_observed_at_ms: details.replyObservedAtMs || null,
@@ -676,6 +679,7 @@ export async function waitForReplySettleWithCollector({
   settleMs,
   maxWaitMs,
   sentMid,
+  minObservationMs = 0,
 }) {
   const startedAt = Date.now();
   let firstReplyObservedAtMs = null;
@@ -701,7 +705,9 @@ export async function waitForReplySettleWithCollector({
         stableReply = latestIncoming;
         stableReplyIsInterim = isLikelyInterimReplyText(latestIncoming.text);
       }
-      if (!stableReplyIsInterim && lastChangeAt !== null && Date.now() - lastChangeAt >= settleMs) {
+      const observationSatisfied =
+        firstReplyObservedAtMs !== null && Date.now() - firstReplyObservedAtMs >= minObservationMs;
+      if (!stableReplyIsInterim && lastChangeAt !== null && Date.now() - lastChangeAt >= settleMs && observationSatisfied) {
         return {
           ok: true,
           settled: true,
@@ -733,6 +739,7 @@ async function waitForReplySettle(page, settleMs, maxWaitMs, sentMid) {
     settleMs,
     maxWaitMs,
     sentMid,
+    minObservationMs: minReplyObservationMs,
   });
 }
 
@@ -1227,6 +1234,7 @@ async function main() {
         quietWindowMs,
         quietWindowWaitMs,
         replySettleMs,
+        minReplyObservationMs,
         replySettleWaitMs: settledReply.settleWaitMs,
         baselineMaxMid: beforeMaxMid,
         sentObservedAtMs,
@@ -1273,6 +1281,7 @@ async function main() {
       quietWindowMs,
       quietWindowWaitMs,
       replySettleMs,
+      minReplyObservationMs,
       replySettleWaitMs: settledReply.settleWaitMs,
       baselineMaxMid: beforeMaxMid,
       sentObservedAtMs,

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -284,7 +284,7 @@ EOF
         test_fail "Direct /status fastpath must stay handler-safe: send canonical text, return rc=0, and leave only a delivery-suppression marker instead of triggering hook-block"
     fi
 
-    test_start "component_before_llm_guard_direct_fastpaths_codex_update_via_bot_send_when_enabled"
+    test_start "component_before_llm_guard_keeps_codex_update_on_hard_override_even_when_direct_fastpath_is_enabled"
     local fastpath_codex_tmp fastpath_codex_send_script fastpath_codex_log fastpath_codex_stdout fastpath_codex_stderr fastpath_codex_status fastpath_codex_intent_dir fastpath_codex_suppress_file
     fastpath_codex_tmp="$(secure_temp_dir telegram-safe-fastpath-codex-update)"
     fastpath_codex_send_script="$fastpath_codex_tmp/send.sh"
@@ -326,21 +326,24 @@ EOF
         MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_codex_stdout" 2>"$fastpath_codex_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:fastcodex","provider":"openai-codex","model":"gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Проверь последние релизы Codex и кратко скажи, есть ли новая стабильная версия"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastcodex","provider":"openai-codex","model":"gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_codex_status=$?
     set -e
     if [[ "$fastpath_codex_status" -eq 0 ]] && \
-       [[ ! -s "$fastpath_codex_stdout" ]] && \
        [[ ! -s "$fastpath_codex_stderr" ]] && \
-       [[ -f "$fastpath_codex_suppress_file" ]] && \
-       grep -Fq $'\tcodex_update' "$fastpath_codex_suppress_file" && \
-       grep -Fq 'chat_id=262872984' "$fastpath_codex_log" && \
-       grep -Fq 'версия 0.118.0' "$fastpath_codex_log" && \
-       grep -Fq 'Дата публикации: 2026-04-01.' "$fastpath_codex_log"; then
+       jq -e '.action == "modify"' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       jq -e '.data.messages | length == 2' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update hard override")' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       jq -e '.data.messages[0].content | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       jq -e '.data.messages[0].content | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       jq -e '.data.messages[1].content == "Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего."' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
+       [[ ! -e "$fastpath_codex_suppress_file" ]] && \
+       [[ ! -s "$fastpath_codex_log" ]]; then
         test_pass
     else
-        test_fail "Direct Codex update fastpath must stay handler-safe: send the canonical release reply, return rc=0, and leave only a delivery-suppression marker"
+        test_fail "Codex-update turns must stay on the deterministic hard-override path even when direct fastpath is enabled, because out-of-band send races with later bad replies on live Telegram"
     fi
 
     test_start "component_before_llm_guard_direct_fastpaths_skill_visibility_via_bot_send_when_enabled"

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -200,6 +200,45 @@ NODE
         test_fail "Probe must keep waiting after a short interim preface and settle on the later attributable final/error reply"
     fi
 
+    test_start "component_telegram_web_probe_keeps_observing_past_early_clean_reply_when_min_observation_is_set"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { waitForReplySettleWithCollector } = await import(process.env.NODE_SCRIPT);
+const snapshots = [
+  [{ mid: 81, direction: "out", text: "cron?" }],
+  [
+    { mid: 81, direction: "out", text: "cron?" },
+    { mid: 82, direction: "in", text: "По проектному контракту у codex-update есть отдельный scheduler path." }
+  ],
+  [
+    { mid: 81, direction: "out", text: "cron?" },
+    { mid: 82, direction: "in", text: "По проектному контракту у codex-update есть отдельный scheduler path." }
+  ],
+  [
+    { mid: 81, direction: "out", text: "cron?" },
+    { mid: 82, direction: "in", text: "По проектному контракту у codex-update есть отдельный scheduler path." },
+    { mid: 83, direction: "in", text: "Проверил — и да, тут инструмент расписания реально сломан: на `list` он снова ответил `missing 'action' parameter`." }
+  ]
+];
+let index = 0;
+const result = await waitForReplySettleWithCollector({
+  collectMessagesFn: async () => snapshots[Math.min(index++, snapshots.length - 1)],
+  sleepFn: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  settleMs: 100,
+  maxWaitMs: 1000,
+  sentMid: 81,
+  minObservationMs: 400,
+});
+if (!result.ok || !result.replyMessage || result.replyMessage.mid !== 83) {
+  throw new Error(`expected late second reply to win after observation window, got ${JSON.stringify(result)}`);
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Probe must keep observing for delayed second replies instead of passing on the first clean-looking answer immediately"
+    fi
+
     test_start "component_telegram_web_probe_waits_for_quiet_window_before_send"
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";


### PR DESCRIPTION
## Summary
- keep codex-update turns on BeforeLLMCall hard override instead of direct fastpath send
- add reply observation window to authoritative Telegram Web probe so delayed second replies do not false-pass
- record RCA and refresh lessons

## Validation
- bash -n scripts/telegram-safe-llm-guard.sh
- node --check scripts/telegram-web-user-probe.mjs
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_web_probe_correlation.sh
- bash tests/component/test_telegram_remote_uat_contract.sh

## RCA
- user-facing bad reply was reproduced from production evidence
- direct fastpath sent an early safe reply but did not terminate the underlying run
- the run later called cron and emitted a second bad reply with missing 'action' parameter
- authoritative probe also needed a longer observation window to catch delayed second replies