### PR TITLE
fix(telegram): terminalize codex-update follow-up turns

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-14
-**Total Lessons**: 74
+**Total Lessons**: 75
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (34 lessons)
+#### P1 (35 lessons)
+- [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
 - [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
 - [Telegram chat probe skill pointed to a missing wrapper entrypoint](../docs/rca/2026-04-14-telegram-chat-probe-skill-pointed-to-missing-wrapper-entrypoint.md)
 - [Deploy host automation missing cron package bootstrap](../docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md)
@@ -173,7 +174,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (1 lessons)
+#### product (2 lessons)
+- [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
 - [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
 
 #### security (1 lessons)
@@ -191,9 +193,9 @@
 ### Popular Tags
 
 - `moltis` (26 lessons)
-- `rca` (22 lessons)
+- `rca` (23 lessons)
 - `deploy` (19 lessons)
-- `telegram` (17 lessons)
+- `telegram` (18 lessons)
 - `github-actions` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
@@ -208,10 +210,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 74 |
-| Critical (P0/P1) | 35 |
+| Total Lessons | 75 |
+| Critical (P0/P1) | 36 |
 | Categories | 7 |
-| Unique Tags | 155 |
+| Unique Tags | 156 |
 
 ---
 

--- a/docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md
+++ b/docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md
@@ -1,0 +1,104 @@
+---
+title: "Telegram codex-update hard override did not terminalize blocked tool follow-up"
+date: 2026-04-14
+severity: P1
+category: product
+tags: [telegram, codex-update, hook, terminalization, cron, rca]
+root_cause: "The Telegram-safe codex-update hard override still allowed a blocked cron tool follow-up to create a second internal LLM pass, and the generic MessageSending short-circuit sat ahead of the persisted codex-update rewrite needed to finalize that recovered turn."
+---
+
+# RCA: Telegram codex-update hard override did not terminalize blocked tool follow-up
+
+Date: 2026-04-14  
+Status: Resolved in source, pending landing/deploy/live re-verification  
+Context: follow-up to `2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run`, beads lane `moltinger-mcgq`
+
+## Error
+
+После production fix-а, который убрал ранний `codex-update` direct fastpath, authoritative Telegram Web path уже начал проходить. Но live audit показал, что внутри того же turn проблема ещё жила:
+
+- `BeforeLLMCall` делал `codex_update_hard_override`;
+- затем runtime всё равно входил в `BeforeToolCall` на `cron`;
+- после synthetic tool block происходил ещё один `BeforeLLMCall`/`AfterLLMCall`;
+- поздний internal answer всё ещё формулировался как сломанный `cron`/`missing 'action' parameter`.
+
+То есть пользовательский ответ мог уже не течь наружу, но корень проблемы оставался: turn после deterministic hard override не становился truly terminal.
+
+## Lessons Pre-check
+
+Проверены lessons:
+
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag codex-update`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Релевантные прошлые RCA:
+
+1. `2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md`  
+   Уже покрывал запрет раннего direct fastpath и требование смотреть на live audit, а не только на ранний green smoke.
+2. `2026-04-02-telegram-direct-fastpath-tail-was-not-terminal.md`  
+   Уже фиксировал, что same-turn suppression must stay alive, если runtime продолжает хвост после user-visible ответа.
+
+Что оставалось непокрытым:
+
+- deterministic `hard override` сам по себе не считался “terminal”, если runtime успел войти в blocked tool branch;
+- persisted `codex-update` reply override для recovered empty delivery всё ещё стоял после слишком раннего generic `MessageSending` short-circuit.
+
+## Evidence
+
+Production evidence из `/tmp/moltis-telegram-safe-llm-guard.audit.log` и `docker logs moltis` на `root@ainetic.tech`:
+
+- `2026-04-14T12:16:44Z` `BeforeLLMCall` с intent `codex_update_scheduler`
+- `2026-04-14T12:16:45Z` `before_modify reason=codex_update_hard_override`
+- `2026-04-14T12:16:49Z` `emit_modify event=AfterLLMCall reason=codex_update_reply_override mode=scheduler`
+- `2026-04-14T12:16:50Z` `emit_modify event=BeforeToolCall reason=disallowed_tool_block tool=cron`
+- `2026-04-14T12:16:52Z` повторный `BeforeLLMCall` на тот же turn
+- `2026-04-14T12:16:59Z` поздний `AfterLLMCall` всё ещё содержал bad scheduler false-negative candidate
+- `2026-04-14T12:17:00Z` app log завершал run текстом про сломанный scheduler tool
+
+Локальное воспроизведение на branch подтвердило тот же sequence: без отдельной terminalization blocked tool branch запускал повторный LLM pass.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Почему после `codex_update_hard_override` ещё появлялся второй internal reply? | Потому что runtime всё равно продолжал tool-follow-up branch и создавал второй LLM pass. |
+| 2 | Почему hard override не остановил этот branch? | Потому что hook переписывал prompt/text, но не держал отдельное same-turn terminal state после blocked tool follow-up. |
+| 3 | Почему blocked `cron` follow-up не считался терминальным событием? | Потому что логика guard различала direct-fastpath suppression, но не имела отдельного состояния для deterministic hard-override turn, который уже “решён”, но ещё не доставлен. |
+| 4 | Почему recovered empty final delivery не превращался гарантированно в канонический `codex-update` reply? | Потому что persisted `codex-update` rewrite стоял после generic `MessageSending` short-circuit, который мог просто пропустить пустой safe-looking payload. |
+| 5 | Почему это стало системной проблемой? | Потому что инварианта была неполной: мы зафиксировали “не использовать ранний direct fastpath”, но не оформили вторую половину контракта — blocked tool follow-up после hard override тоже должен переводить turn в terminal recovery path. |
+
+## Root Cause
+
+Telegram-safe `codex-update` path после удаления раннего direct fastpath всё ещё не имел специальной terminalization-фазы для same-turn blocked tool follow-up.
+
+В результате:
+
+1. `BeforeToolCall` на `cron` блокировался, но turn не помечался как terminal recovery turn;
+2. runtime входил во второй `BeforeLLMCall`/`AfterLLMCall`;
+3. поздний internal bad reply снова формировался;
+4. при попытке чинить это empty final delivery generic `MessageSending` short-circuit ещё и мог обойти persisted `codex-update` rewrite.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - добавлен session-scoped `.terminal` marker для `codex-update` blocked tool follow-up;
+   - `BeforeToolCall` на `codex-update` теперь переводит turn в terminal recovery mode;
+   - повторный `BeforeLLMCall` при активном terminal marker возвращает empty text-only override;
+   - повторный `AfterLLMCall` при активном terminal marker принудительно обнуляет text/tool calls;
+   - persisted `codex-update` MessageSending rewrite поднят перед generic short-circuit и по финальной доставке переводит turn в normal same-turn suppression (`.suppress`), чтобы хвосты падали в `NO_REPLY`.
+2. `tests/component/test_telegram_safe_llm_guard.sh`
+   - добавлен regression на полный live-like sequence:
+     `BeforeLLM hard override -> BeforeToolCall cron -> repeated BeforeLLM -> repeated AfterLLM -> final MessageSending -> repeated dirty tail`.
+
+## Prevention
+
+1. Для Telegram-safe deterministic routes нужен не только prompt override, но и явный terminal recovery state на blocked tool follow-up.
+2. Generic `MessageSending` early-exit нельзя ставить раньше persisted reply rewrites для recovery turns.
+3. Если live audit показывает второй internal pass, bug не считается закрытым даже при внешне корректном пользовательском reply.
+
+## Уроки
+
+1. `hard override` и `terminal turn` — не синонимы; blocked tool branch после hard override требует отдельного state machine шага.
+2. Recovery reply для empty final payload должен быть расположен раньше generic short-circuit, иначе fix останется полу-рабочим.
+3. После любого Telegram-safe live fix нужно проверять не только user-visible verdict, но и audit sequence внутри turn.

--- a/docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md
+++ b/docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md
@@ -4,7 +4,7 @@ date: 2026-04-14
 severity: P1
 category: product
 tags: [telegram, codex-update, hook, terminalization, cron, rca]
-root_cause: "The Telegram-safe codex-update hard override still allowed a blocked cron tool follow-up to create a second internal LLM pass, and the generic MessageSending short-circuit sat ahead of the persisted codex-update rewrite needed to finalize that recovered turn."
+root_cause: "The Telegram-safe codex-update hard override still allowed a blocked cron tool follow-up to create a second internal LLM pass; terminal recovery depended on brittle iteration/order assumptions, and the final MessageSending recovery path could fail open if suppression state was not armed successfully."
 ---
 
 # RCA: Telegram codex-update hard override did not terminalize blocked tool follow-up
@@ -42,7 +42,9 @@ Context: follow-up to `2026-04-14-telegram-codex-update-direct-fastpath-raced-un
 Что оставалось непокрытым:
 
 - deterministic `hard override` сам по себе не считался “terminal”, если runtime успел войти в blocked tool branch;
-- persisted `codex-update` reply override для recovered empty delivery всё ещё стоял после слишком раннего generic `MessageSending` short-circuit.
+- persisted `codex-update` reply override для recovered empty delivery всё ещё стоял после слишком раннего generic `MessageSending` short-circuit;
+- repeat-guard зависел от `iteration > 1`, хотя повторный same-turn hook мог прийти без `iteration`;
+- terminal marker жил на коротком suppression TTL и не был fail-closed, если финальная arm-фаза suppression state ломалась.
 
 ## Evidence
 
@@ -65,37 +67,45 @@ Production evidence из `/tmp/moltis-telegram-safe-llm-guard.audit.log` и `doc
 | 1 | Почему после `codex_update_hard_override` ещё появлялся второй internal reply? | Потому что runtime всё равно продолжал tool-follow-up branch и создавал второй LLM pass. |
 | 2 | Почему hard override не остановил этот branch? | Потому что hook переписывал prompt/text, но не держал отдельное same-turn terminal state после blocked tool follow-up. |
 | 3 | Почему blocked `cron` follow-up не считался терминальным событием? | Потому что логика guard различала direct-fastpath suppression, но не имела отдельного состояния для deterministic hard-override turn, который уже “решён”, но ещё не доставлен. |
-| 4 | Почему recovered empty final delivery не превращался гарантированно в канонический `codex-update` reply? | Потому что persisted `codex-update` rewrite стоял после generic `MessageSending` short-circuit, который мог просто пропустить пустой safe-looking payload. |
-| 5 | Почему это стало системной проблемой? | Потому что инварианта была неполной: мы зафиксировали “не использовать ранний direct fastpath”, но не оформили вторую половину контракта — blocked tool follow-up после hard override тоже должен переводить turn в terminal recovery path. |
+| 4 | Почему recovered empty final delivery не превращался гарантированно в канонический `codex-update` reply? | Потому что persisted `codex-update` rewrite стоял после generic `MessageSending` short-circuit, а arm suppression state в финальной доставке не проверялся fail-closed. |
+| 5 | Почему это стало системной проблемой? | Потому что инварианта была неполной: мы зафиксировали “не использовать ранний direct fastpath”, но не оформили вторую половину контракта — blocked tool follow-up после hard override должен переводить turn в terminal recovery path без зависимости от `iteration`, порядка хуков и удачного best-effort write suppression-файлов. |
 
 ## Root Cause
 
-Telegram-safe `codex-update` path после удаления раннего direct fastpath всё ещё не имел специальной terminalization-фазы для same-turn blocked tool follow-up.
+Telegram-safe `codex-update` path после удаления раннего direct fastpath всё ещё не имел достаточно жёсткой terminalization-фазы для same-turn blocked tool follow-up.
 
 В результате:
 
 1. `BeforeToolCall` на `cron` блокировался, но turn не помечался как terminal recovery turn;
-2. runtime входил во второй `BeforeLLMCall`/`AfterLLMCall`;
+2. runtime входил во второй `BeforeLLMCall`/`AfterLLMCall`, а repeat recovery зависел от наличия `iteration > 1`;
 3. поздний internal bad reply снова формировался;
-4. при попытке чинить это empty final delivery generic `MessageSending` short-circuit ещё и мог обойти persisted `codex-update` rewrite.
+4. terminal marker мог утечь через turn boundary или истечь слишком рано, потому что жил на suppression TTL и не был жёстко ограждён codex-update intent;
+5. при попытке чинить это empty final delivery generic `MessageSending` short-circuit ещё и мог обойти persisted `codex-update` rewrite, а сама arm-фаза suppression state была fail-open.
 
 ## Fixes Applied
 
 1. `scripts/telegram-safe-llm-guard.sh`
    - добавлен session-scoped `.terminal` marker для `codex-update` blocked tool follow-up;
    - `BeforeToolCall` на `codex-update` теперь переводит turn в terminal recovery mode;
-   - повторный `BeforeLLMCall` при активном terminal marker возвращает empty text-only override;
+   - terminal marker больше не зависит от `iteration > 1`: repeated `BeforeLLMCall` теперь может быть terminal-marker-driven даже без `iteration` и без reclassification из user text;
+   - terminal marker очищается на non-`codex-update` user turn, чтобы не течь в чужой следующий turn;
+   - terminal marker живёт на отдельном `TERMINAL_TTL_SEC`, а не на коротком suppression TTL;
    - повторный `AfterLLMCall` при активном terminal marker принудительно обнуляет text/tool calls;
-   - persisted `codex-update` MessageSending rewrite поднят перед generic short-circuit и по финальной доставке переводит turn в normal same-turn suppression (`.suppress`), чтобы хвосты падали в `NO_REPLY`.
+   - arm suppression state для финальной codex-update доставки переведён в fail-closed helper: если suppression не arm'ится, guard сохраняет terminal marker и intent, а поздние dirty tails продолжают переписываться в детерминированный safe reply вместо выхода в fail-open.
 2. `tests/component/test_telegram_safe_llm_guard.sh`
    - добавлен regression на полный live-like sequence:
-     `BeforeLLM hard override -> BeforeToolCall cron -> repeated BeforeLLM -> repeated AfterLLM -> final MessageSending -> repeated dirty tail`.
+     `BeforeLLM hard override -> BeforeToolCall cron -> repeated BeforeLLM -> repeated AfterLLM -> final MessageSending -> repeated dirty tail`;
+   - добавлен regression на marker-driven repeat без `iteration` и без user-text reclassification;
+   - добавлен regression на cleanup safety следующего user turn в том же chat;
+   - добавлен regression на fail-closed поведение, когда suppression arm ломается.
 
 ## Prevention
 
 1. Для Telegram-safe deterministic routes нужен не только prompt override, но и явный terminal recovery state на blocked tool follow-up.
-2. Generic `MessageSending` early-exit нельзя ставить раньше persisted reply rewrites для recovery turns.
-3. Если live audit показывает второй internal pass, bug не считается закрытым даже при внешне корректном пользовательском reply.
+2. Recovery path не должен зависеть от наличия `iteration`, если persisted turn state уже доказывает same-turn continuation.
+3. Любая финальная arm-фаза suppression state на границе user-visible delivery должна быть fail-closed, а не `|| true`.
+4. Generic `MessageSending` early-exit нельзя ставить раньше persisted reply rewrites для recovery turns.
+5. Если live audit показывает второй internal pass, bug не считается закрытым даже при внешне корректном пользовательском reply.
 
 ## Уроки
 

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -10,6 +10,8 @@ AUDIT_FILE="${MOLTIS_TELEGRAM_SAFE_LLM_GUARD_AUDIT_FILE:-}"
 INTENT_DIR="${MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR:-/tmp/moltis-telegram-safe-llm-guard-intent}"
 INTENT_TTL_SEC="${MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_TTL_SEC:-900}"
 SUPPRESS_TTL_SEC="${MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SUPPRESS_TTL_SEC:-300}"
+TERMINAL_TTL_SEC="${MOLTIS_TELEGRAM_SAFE_LLM_GUARD_TERMINAL_TTL_SEC:-3600}"
+TERMINAL_REPEAT_WINDOW_SEC="${MOLTIS_TELEGRAM_SAFE_LLM_GUARD_TERMINAL_REPEAT_WINDOW_SEC:-30}"
 DIRECT_FASTPATH_ENABLED="${MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH:-true}"
 DIRECT_SEND_SCRIPT="${MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT:-/server/scripts/telegram-bot-send.sh}"
 CODEX_UPDATE_STATE_SCRIPT="${MOLTIS_CODEX_UPDATE_STATE_SCRIPT:-/server/scripts/moltis-codex-update-state.sh}"
@@ -32,6 +34,13 @@ payload_flat="$(
         | tr '\r\n' '  ' \
         | sed 's/[[:space:]][[:space:]]*/ /g'
 )"
+
+compute_turn_fingerprint() {
+    local source_text="${1:-}"
+
+    [[ -n "$source_text" ]] || return 1
+    printf '%s' "$source_text" | cksum | awk '{print $1 "-" $2}'
+}
 
 extract_first_string() {
     local key="$1"
@@ -1129,12 +1138,39 @@ load_terminal_marker() {
 
     now_epoch="$(date +%s)"
     age_sec=$((now_epoch - stored_epoch))
-    if (( age_sec < 0 || age_sec > SUPPRESS_TTL_SEC )); then
+    if (( age_sec < 0 || age_sec > TERMINAL_TTL_SEC )); then
         rm -f "$terminal_file" 2>/dev/null || true
         return 1
     fi
 
     printf '%s' "$stored_token"
+}
+
+turn_intent_is_recent_for_repeat() {
+    local raw_key="${1:-}"
+    local max_age_sec="${2:-}"
+    local intent_file=""
+    local stored_epoch=""
+    local stored_intent=""
+    local stored_fingerprint=""
+    local now_epoch=0
+    local age_sec=0
+
+    [[ -n "$raw_key" && "$max_age_sec" =~ ^[0-9]+$ ]] || return 1
+
+    intent_file="$(intent_file_path "$raw_key" || true)"
+    [[ -n "$intent_file" && -f "$intent_file" ]] || return 1
+
+    IFS=$'\t' read -r stored_epoch stored_intent stored_fingerprint <"$intent_file" || return 1
+    [[ "$stored_epoch" =~ ^[0-9]+$ && -n "$stored_intent" ]] || return 1
+
+    now_epoch="$(date +%s)"
+    age_sec=$((now_epoch - stored_epoch))
+    if (( age_sec < 0 || age_sec > max_age_sec )); then
+        return 1
+    fi
+
+    return 0
 }
 
 clear_terminal_marker() {
@@ -1233,6 +1269,40 @@ rollback_direct_fastpath_delivery_suppression() {
     clear_delivery_suppression_for_chat "$chat_id"
 }
 
+arm_codex_update_terminal_delivery_suppression() {
+    local raw_key="${1:-}"
+    local chat_id="${2:-}"
+    local token="${3:-}"
+    local session_armed=false
+
+    [[ -n "$token" ]] || return 1
+    if [[ -z "$raw_key" && -z "$chat_id" ]]; then
+        return 1
+    fi
+
+    if [[ -n "$raw_key" ]]; then
+        if ! persist_delivery_suppression "$raw_key" "$token"; then
+            write_audit_line "codex_update_terminal_suppress_arm_failed scope=session token=$token key=${raw_key:-missing}"
+            return 1
+        fi
+        session_armed=true
+    fi
+
+    if [[ -z "$chat_id" ]]; then
+        return 0
+    fi
+
+    if persist_delivery_suppression_for_chat "$chat_id" "$token"; then
+        return 0
+    fi
+
+    if [[ "$session_armed" == true ]]; then
+        clear_delivery_suppression "$raw_key"
+    fi
+    write_audit_line "codex_update_terminal_suppress_arm_failed scope=chat token=$token chat_id=${chat_id:-missing}"
+    return 1
+}
+
 direct_fastpath_send_with_suppression() {
     local kind="${1:-}"
     local chat_id="${2:-}"
@@ -1261,6 +1331,7 @@ direct_fastpath_send_with_suppression() {
 persist_turn_intent() {
     local raw_key="${1:-}"
     local intent_name="${2:-}"
+    local turn_fingerprint="${3:-}"
     local intent_file=""
 
     [[ -n "$raw_key" && -n "$intent_name" ]] || return 0
@@ -1272,7 +1343,7 @@ persist_turn_intent() {
         write_audit_line "intent_set_failed key=$(basename "$intent_file") intent=$intent_name reason=mkdir"
         return 0
     fi
-    if ! printf '%s\t%s\n' "$(date +%s)" "$intent_name" >"$intent_file" 2>/dev/null; then
+    if ! printf '%s\t%s\t%s\n' "$(date +%s)" "$intent_name" "$turn_fingerprint" >"$intent_file" 2>/dev/null; then
         rm -f "$intent_file" 2>/dev/null || true
         write_audit_line "intent_set_failed key=$(basename "$intent_file") intent=$intent_name reason=write"
         return 0
@@ -1294,7 +1365,7 @@ load_turn_intent() {
     intent_file="$(intent_file_path "$raw_key" || true)"
     [[ -n "$intent_file" && -f "$intent_file" ]] || return 1
 
-    IFS=$'\t' read -r stored_epoch stored_intent <"$intent_file" || return 1
+    IFS=$'\t' read -r stored_epoch stored_intent _stored_fingerprint <"$intent_file" || return 1
     [[ "$stored_epoch" =~ ^[0-9]+$ && -n "$stored_intent" ]] || return 1
 
     now_epoch="$(date +%s)"
@@ -1305,6 +1376,34 @@ load_turn_intent() {
     fi
 
     printf '%s' "$stored_intent"
+}
+
+load_turn_intent_fingerprint() {
+    local raw_key="${1:-}"
+    local intent_file=""
+    local stored_epoch=""
+    local stored_intent=""
+    local stored_fingerprint=""
+    local now_epoch=0
+    local age_sec=0
+
+    [[ -n "$raw_key" ]] || return 1
+
+    intent_file="$(intent_file_path "$raw_key" || true)"
+    [[ -n "$intent_file" && -f "$intent_file" ]] || return 1
+
+    IFS=$'\t' read -r stored_epoch stored_intent stored_fingerprint <"$intent_file" || return 1
+    [[ "$stored_epoch" =~ ^[0-9]+$ && -n "$stored_intent" ]] || return 1
+
+    now_epoch="$(date +%s)"
+    age_sec=$((now_epoch - stored_epoch))
+    if (( age_sec < 0 || age_sec > INTENT_TTL_SEC )); then
+        rm -f "$intent_file" 2>/dev/null || true
+        return 1
+    fi
+
+    [[ -n "$stored_fingerprint" ]] || return 1
+    printf '%s' "$stored_fingerprint"
 }
 
 clear_turn_intent() {
@@ -3017,8 +3116,20 @@ intent_text_flat="${latest_user_message_flat:-$user_message_flat}"
 status_query_text_flat="${intent_text_flat:-$user_message_flat}"
 current_iteration="$(extract_first_number iteration || true)"
 persisted_turn_intent="$(load_turn_intent "${turn_session_key:-}" || true)"
+persisted_turn_fingerprint="$(load_turn_intent_fingerprint "${turn_session_key:-}" || true)"
 persisted_delivery_suppression="$(load_delivery_suppression "${turn_session_key:-}" || true)"
 persisted_terminal_marker="$(load_terminal_marker "${turn_session_key:-}" || true)"
+loaded_persisted_codex_update_request=false
+loaded_persisted_codex_update_scheduler_request=false
+case "${persisted_turn_intent:-}" in
+    codex_update)
+        loaded_persisted_codex_update_request=true
+        ;;
+    codex_update_scheduler)
+        loaded_persisted_codex_update_request=true
+        loaded_persisted_codex_update_scheduler_request=true
+        ;;
+esac
 channel_account="$(extract_runtime_field_from_text "${latest_system_message:-}" "channel_account" || true)"
 system_chat_id="$(extract_runtime_field_from_text "${latest_system_message:-}" "channel_chat_id" || true)"
 delivery_chat_id="$(extract_first_string to || true)"
@@ -3032,6 +3143,7 @@ has_current_user_turn=false
 if [[ -n "$intent_text_flat" ]]; then
     has_current_user_turn=true
 fi
+current_turn_fingerprint="$(compute_turn_fingerprint "$intent_text_flat" || true)"
 
 before_llm_starts_new_user_turn=false
 if [[ "$event" == "BeforeLLMCall" && "$has_current_user_turn" == true ]]; then
@@ -3247,14 +3359,36 @@ fi
 
 effective_delivery_suppression="${persisted_delivery_suppression:-$persisted_chat_delivery_suppression}"
 
-if [[ "$event" == "BeforeLLMCall" && "$has_current_user_turn" == true && -n "$persisted_terminal_marker" ]]; then
-    if [[ "$before_llm_starts_new_user_turn" == true ]]; then
-        write_audit_line "terminal_clear reason=new_user_turn token=$persisted_terminal_marker iteration=${current_iteration:-missing}"
-        clear_terminal_marker "${turn_session_key:-}"
-        persisted_terminal_marker=""
+if [[ "$event" == "BeforeLLMCall" && -n "$persisted_terminal_marker" ]]; then
+    if [[ "$has_current_user_turn" == true ]]; then
+        if [[ "$current_turn_codex_update_request" == true && -n "$current_turn_fingerprint" && -n "$persisted_turn_fingerprint" && "$current_turn_fingerprint" == "$persisted_turn_fingerprint" ]] && turn_intent_is_recent_for_repeat "${turn_session_key:-}" "$TERMINAL_REPEAT_WINDOW_SEC"; then
+            write_audit_line "terminal_keep reason=matching_codex_repeat token=$persisted_terminal_marker iteration=${current_iteration:-missing}"
+        else
+            write_audit_line "terminal_clear reason=new_user_turn token=$persisted_terminal_marker iteration=${current_iteration:-missing}"
+            clear_terminal_marker "${turn_session_key:-}"
+            persisted_terminal_marker=""
+        fi
     else
         write_audit_line "terminal_keep reason=same_turn_before_llm token=$persisted_terminal_marker iteration=${current_iteration:-missing}"
     fi
+fi
+
+codex_update_terminal_repeat_guard=false
+if [[ "$loaded_persisted_codex_update_request" == true ]]; then
+    if [[ -n "$persisted_terminal_marker" ]]; then
+        codex_update_terminal_repeat_guard=true
+    elif [[ "$has_current_user_turn" != true ]]; then
+        codex_update_terminal_repeat_guard=true
+    elif [[ -n "$current_turn_fingerprint" && -n "$persisted_turn_fingerprint" && "$current_turn_fingerprint" == "$persisted_turn_fingerprint" ]] && turn_intent_is_recent_for_repeat "${turn_session_key:-}" "$TERMINAL_REPEAT_WINDOW_SEC"; then
+        codex_update_terminal_repeat_guard=true
+    fi
+fi
+
+if [[ "$event" == "BeforeLLMCall" && "$has_current_user_turn" == true && "$current_turn_codex_update_request" != true && "$loaded_persisted_codex_update_request" == true ]]; then
+    if [[ -n "$persisted_terminal_marker" ]]; then
+        clear_terminal_marker "${turn_session_key:-}"
+    fi
+    persisted_terminal_marker=""
 fi
 
 resolved_skill_name=""
@@ -3405,10 +3539,33 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     fi
 
     if [[ -n "$next_turn_intent" ]]; then
-        persist_turn_intent "${turn_session_key:-}" "$next_turn_intent"
+        persist_turn_intent "${turn_session_key:-}" "$next_turn_intent" "$current_turn_fingerprint"
+    elif [[ "$has_current_user_turn" != true && "$loaded_persisted_codex_update_request" == true && -n "${persisted_turn_intent:-}" ]]; then
+        next_turn_intent="$persisted_turn_intent"
+        persist_turn_intent "${turn_session_key:-}" "$next_turn_intent" "$persisted_turn_fingerprint"
     else
         clear_turn_intent "${turn_session_key:-}"
     fi
+
+    persisted_turn_intent="${next_turn_intent:-}"
+    if [[ -n "$next_turn_intent" ]]; then
+        if [[ "$has_current_user_turn" == true ]]; then
+            persisted_turn_fingerprint="$current_turn_fingerprint"
+        fi
+    else
+        persisted_turn_fingerprint=""
+    fi
+    persisted_codex_update_request=false
+    persisted_codex_update_scheduler_request=false
+    case "${persisted_turn_intent:-}" in
+        codex_update)
+            persisted_codex_update_request=true
+            ;;
+        codex_update_scheduler)
+            persisted_codex_update_request=true
+            persisted_codex_update_scheduler_request=true
+            ;;
+    esac
 
     if [[ -n "$effective_delivery_suppression" && "$has_current_user_turn" == true && "$current_iteration" =~ ^[0-9]+$ ]] && (( current_iteration > 1 )); then
         same_turn_guard="$(build_same_turn_fastpath_guard_message)"
@@ -3419,7 +3576,7 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         exit 0
     fi
 
-    if [[ -n "$persisted_terminal_marker" && "$current_iteration" =~ ^[0-9]+$ ]] && (( current_iteration > 1 )); then
+    if [[ "$codex_update_terminal_repeat_guard" == true || ( -n "$persisted_terminal_marker" && ( "$persisted_codex_update_request" == true || "$current_turn_codex_update_request" == true || "$loaded_persisted_codex_update_request" == true ) ) ]]; then
         same_turn_guard="$(build_codex_update_terminal_guard_message)"
         same_turn_user=$'Верни пустую строку. Не вызывай инструменты.'
         messages_json="[$(build_message_json system "$same_turn_guard"),$(build_message_json user "$same_turn_user")]"
@@ -3586,7 +3743,9 @@ if [[ "$event" == "BeforeToolCall" && "$is_telegram_safe_lane" == true ]]; then
         if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
             codex_update_terminal_token="scheduler"
         fi
-        persist_terminal_marker "${turn_session_key:-}" "$codex_update_terminal_token" || true
+        if ! persist_terminal_marker "${turn_session_key:-}" "$codex_update_terminal_token"; then
+            write_audit_line "codex_update_terminal_marker_fallback token=$codex_update_terminal_token"
+        fi
         synthetic_command="$(build_exec_heredoc_command "Telegram-safe codex-update turn already resolved by the hard override. Skip this tool follow-up and continue to final text-only delivery.")"
         write_audit_line "emit_modify event=$event reason=codex_update_terminal_tool_suppress token=$codex_update_terminal_token tool=${tool_name:-missing}"
         emit_before_tool_modified_payload "exec" "{\"command\":\"$(json_escape "$synthetic_command")\"}"
@@ -3639,7 +3798,7 @@ if [[ "$event" == "AfterLLMCall" && -n "$effective_delivery_suppression" && "$is
     exit 0
 fi
 
-if [[ "$event" == "AfterLLMCall" && -n "$persisted_terminal_marker" && "$is_telegram_safe_lane" == true ]]; then
+if [[ "$event" == "AfterLLMCall" && -n "$persisted_terminal_marker" && "$is_telegram_safe_lane" == true && ( "$persisted_codex_update_request" == true || "$loaded_persisted_codex_update_request" == true ) ]]; then
     write_audit_line "emit_modify event=$event reason=codex_update_terminal_after_llm_suppress token=$persisted_terminal_marker"
     emit_modified_payload "" true
     exit 0
@@ -3663,14 +3822,19 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
             if [[ "$event" == "AfterLLMCall" ]]; then
                 emit_modified_payload "$codex_update_reply_text" true
             else
+                codex_update_terminal_suppression_armed=true
                 if [[ -n "$persisted_terminal_marker" ]]; then
-                    persist_delivery_suppression "${turn_session_key:-}" "codex_update_terminal:${persisted_terminal_marker}" || true
-                    if [[ -n "${current_chat_id:-}" ]]; then
-                        persist_delivery_suppression_for_chat "${current_chat_id:-}" "codex_update_terminal:${persisted_terminal_marker}" || true
+                    if arm_codex_update_terminal_delivery_suppression "${turn_session_key:-}" "${current_chat_id:-}" "codex_update_terminal:${persisted_terminal_marker}"; then
+                        clear_terminal_marker "${turn_session_key:-}"
+                    else
+                        codex_update_terminal_suppression_armed=false
                     fi
-                    clear_terminal_marker "${turn_session_key:-}"
                 fi
-                clear_turn_intent "${turn_session_key:-}"
+                if [[ "$codex_update_terminal_suppression_armed" == true ]]; then
+                    clear_turn_intent "${turn_session_key:-}"
+                else
+                    write_audit_line "codex_update_terminal_intent_preserved reason=suppress_arm_failed token=${persisted_terminal_marker:-none}"
+                fi
                 emit_modified_payload "$codex_update_reply_text" false
             fi
             exit 0

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -959,6 +959,16 @@ suppress_file_path() {
 
     printf '%s/%s.suppress' "$INTENT_DIR" "$safe_key"
 }
+
+terminal_file_path() {
+    local raw_key="${1:-}"
+    local safe_key=""
+
+    safe_key="$(sanitize_intent_key "$raw_key" || true)"
+    [[ -n "$safe_key" ]] || return 1
+
+    printf '%s/%s.terminal' "$INTENT_DIR" "$safe_key"
+}
 persist_safe_lane_marker() {
     local raw_key="${1:-}"
     local lane_file=""
@@ -1076,6 +1086,67 @@ clear_delivery_suppression() {
     [[ -n "$suppress_file" ]] || return 0
 
     rm -f "$suppress_file" 2>/dev/null || true
+}
+
+persist_terminal_marker() {
+    local raw_key="${1:-}"
+    local token="${2:-}"
+    local terminal_file=""
+
+    [[ -n "$raw_key" && -n "$token" ]] || return 0
+
+    terminal_file="$(terminal_file_path "$raw_key" || true)"
+    [[ -n "$terminal_file" ]] || return 1
+
+    if ! mkdir -p "$INTENT_DIR" 2>/dev/null; then
+        write_audit_line "terminal_set_failed key=$(basename "$terminal_file") token=$token reason=mkdir"
+        return 1
+    fi
+    if ! printf '%s\t%s\n' "$(date +%s)" "$token" >"$terminal_file" 2>/dev/null; then
+        rm -f "$terminal_file" 2>/dev/null || true
+        write_audit_line "terminal_set_failed key=$(basename "$terminal_file") token=$token reason=write"
+        return 1
+    fi
+    write_audit_line "terminal_set key=$(basename "$terminal_file") token=$token"
+    return 0
+}
+
+load_terminal_marker() {
+    local raw_key="${1:-}"
+    local terminal_file=""
+    local stored_epoch=""
+    local stored_token=""
+    local now_epoch=0
+    local age_sec=0
+
+    [[ -n "$raw_key" ]] || return 1
+
+    terminal_file="$(terminal_file_path "$raw_key" || true)"
+    [[ -n "$terminal_file" && -f "$terminal_file" ]] || return 1
+
+    IFS=$'\t' read -r stored_epoch stored_token <"$terminal_file" || return 1
+    [[ "$stored_epoch" =~ ^[0-9]+$ && -n "$stored_token" ]] || return 1
+
+    now_epoch="$(date +%s)"
+    age_sec=$((now_epoch - stored_epoch))
+    if (( age_sec < 0 || age_sec > SUPPRESS_TTL_SEC )); then
+        rm -f "$terminal_file" 2>/dev/null || true
+        return 1
+    fi
+
+    printf '%s' "$stored_token"
+}
+
+clear_terminal_marker() {
+    local raw_key="${1:-}"
+    local terminal_file=""
+
+    [[ -n "$raw_key" ]] || return 0
+
+    terminal_file="$(terminal_file_path "$raw_key" || true)"
+    [[ -n "$terminal_file" ]] || return 0
+
+    rm -f "$terminal_file" 2>/dev/null || true
 }
 
 chat_delivery_suppression_key() {
@@ -1541,6 +1612,16 @@ build_same_turn_fastpath_guard_message() {
 Telegram-safe same-turn fastpath guard:
 - A Telegram-safe direct fastpath already delivered the user-visible reply for this turn.
 - This repeated BeforeLLMCall entry is internal runtime churn, not a new user turn.
+- Do not call tools.
+- Return exactly an empty string and nothing else.
+EOF
+}
+
+build_codex_update_terminal_guard_message() {
+    cat <<'EOF'
+Telegram-safe codex-update terminal guard:
+- A deterministic codex-update reply has already been selected for this turn.
+- The runtime entered another internal pass only because a blocked tool follow-up was attempted after the hard override.
 - Do not call tools.
 - Return exactly an empty string and nothing else.
 EOF
@@ -2937,6 +3018,7 @@ status_query_text_flat="${intent_text_flat:-$user_message_flat}"
 current_iteration="$(extract_first_number iteration || true)"
 persisted_turn_intent="$(load_turn_intent "${turn_session_key:-}" || true)"
 persisted_delivery_suppression="$(load_delivery_suppression "${turn_session_key:-}" || true)"
+persisted_terminal_marker="$(load_terminal_marker "${turn_session_key:-}" || true)"
 channel_account="$(extract_runtime_field_from_text "${latest_system_message:-}" "channel_account" || true)"
 system_chat_id="$(extract_runtime_field_from_text "${latest_system_message:-}" "channel_chat_id" || true)"
 delivery_chat_id="$(extract_first_string to || true)"
@@ -3165,6 +3247,16 @@ fi
 
 effective_delivery_suppression="${persisted_delivery_suppression:-$persisted_chat_delivery_suppression}"
 
+if [[ "$event" == "BeforeLLMCall" && "$has_current_user_turn" == true && -n "$persisted_terminal_marker" ]]; then
+    if [[ "$before_llm_starts_new_user_turn" == true ]]; then
+        write_audit_line "terminal_clear reason=new_user_turn token=$persisted_terminal_marker iteration=${current_iteration:-missing}"
+        clear_terminal_marker "${turn_session_key:-}"
+        persisted_terminal_marker=""
+    else
+        write_audit_line "terminal_keep reason=same_turn_before_llm token=$persisted_terminal_marker iteration=${current_iteration:-missing}"
+    fi
+fi
+
 resolved_skill_name=""
 requested_skill_reference_name="$(extract_referenced_skill_candidate "${latest_user_message:-${user_message:-}}" || true)"
 skill_runtime_snapshot_csv="$(discover_runtime_skill_names_csv || true)"
@@ -3327,6 +3419,15 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         exit 0
     fi
 
+    if [[ -n "$persisted_terminal_marker" && "$current_iteration" =~ ^[0-9]+$ ]] && (( current_iteration > 1 )); then
+        same_turn_guard="$(build_codex_update_terminal_guard_message)"
+        same_turn_user=$'Верни пустую строку. Не вызывай инструменты.'
+        messages_json="[$(build_message_json system "$same_turn_guard"),$(build_message_json user "$same_turn_user")]"
+        write_audit_line "before_modify reason=codex_update_terminal_repeat_guard token=$persisted_terminal_marker iteration=$current_iteration"
+        emit_before_llm_modified_payload "$messages_json" 0
+        exit 0
+    fi
+
     if [[ "$is_telegram_safe_lane" == true ]] && flag_enabled "$DIRECT_FASTPATH_ENABLED" && [[ -n "${telegram_chat_id:-}" ]]; then
         # codex-update turns stay on the deterministic hard-override path below.
         # A direct send here does not actually terminate the underlying run and
@@ -3480,6 +3581,18 @@ if [[ "$event" == "BeforeToolCall" && "$is_telegram_safe_lane" == true ]]; then
         exit 0
     fi
 
+    if [[ "$current_turn_codex_update_request" == true || "$persisted_codex_update_request" == true ]]; then
+        codex_update_terminal_token="release"
+        if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
+            codex_update_terminal_token="scheduler"
+        fi
+        persist_terminal_marker "${turn_session_key:-}" "$codex_update_terminal_token" || true
+        synthetic_command="$(build_exec_heredoc_command "Telegram-safe codex-update turn already resolved by the hard override. Skip this tool follow-up and continue to final text-only delivery.")"
+        write_audit_line "emit_modify event=$event reason=codex_update_terminal_tool_suppress token=$codex_update_terminal_token tool=${tool_name:-missing}"
+        emit_before_tool_modified_payload "exec" "{\"command\":\"$(json_escape "$synthetic_command")\"}"
+        exit 0
+    fi
+
     if [[ "$current_turn_skill_detail_request" == true || -n "$persisted_skill_detail_name" ]]; then
         skill_detail_reply_text="$(build_skill_detail_reply_text "${requested_skill_reference_name:-}" "${resolved_skill_name:-}" "$skill_runtime_snapshot_csv" || true)"
         if [[ -z "$skill_detail_reply_text" ]]; then
@@ -3526,6 +3639,12 @@ if [[ "$event" == "AfterLLMCall" && -n "$effective_delivery_suppression" && "$is
     exit 0
 fi
 
+if [[ "$event" == "AfterLLMCall" && -n "$persisted_terminal_marker" && "$is_telegram_safe_lane" == true ]]; then
+    write_audit_line "emit_modify event=$event reason=codex_update_terminal_after_llm_suppress token=$persisted_terminal_marker"
+    emit_modified_payload "" true
+    exit 0
+fi
+
 if [[ "$event" == "MessageSending" && -n "$effective_delivery_suppression" && "$is_telegram_safe_lane" == true ]]; then
     write_audit_line "emit_modify event=$event reason=direct_fastpath_delivery_suppress token=$effective_delivery_suppression"
     emit_modified_payload "NO_REPLY" false
@@ -3533,9 +3652,9 @@ if [[ "$event" == "MessageSending" && -n "$effective_delivery_suppression" && "$
 fi
 
 if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
-    if [[ "$current_turn_codex_update_request" == true ]]; then
+    if [[ "$current_turn_codex_update_request" == true || "$persisted_codex_update_request" == true ]]; then
         codex_update_reply_mode="release"
-        if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
+        if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
             codex_update_reply_mode="scheduler"
         fi
         codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
@@ -3544,6 +3663,13 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
             if [[ "$event" == "AfterLLMCall" ]]; then
                 emit_modified_payload "$codex_update_reply_text" true
             else
+                if [[ -n "$persisted_terminal_marker" ]]; then
+                    persist_delivery_suppression "${turn_session_key:-}" "codex_update_terminal:${persisted_terminal_marker}" || true
+                    if [[ -n "${current_chat_id:-}" ]]; then
+                        persist_delivery_suppression_for_chat "${current_chat_id:-}" "codex_update_terminal:${persisted_terminal_marker}" || true
+                    fi
+                    clear_terminal_marker "${turn_session_key:-}"
+                fi
                 clear_turn_intent "${turn_session_key:-}"
                 emit_modified_payload "$codex_update_reply_text" false
             fi
@@ -3625,23 +3751,6 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
             else
                 clear_turn_intent "${turn_session_key:-}"
                 emit_modified_payload "$skill_detail_reply_text" false
-            fi
-            exit 0
-        fi
-    fi
-    if [[ "$current_turn_codex_update_request" == true || "$persisted_codex_update_request" == true ]]; then
-        codex_update_reply_mode="release"
-        if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
-            codex_update_reply_mode="scheduler"
-        fi
-        codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
-        if [[ -n "$codex_update_reply_text" ]]; then
-            write_audit_line "emit_modify event=$event reason=codex_update_reply_override mode=$codex_update_reply_mode"
-            if [[ "$event" == "AfterLLMCall" ]]; then
-                emit_modified_payload "$codex_update_reply_text" true
-            else
-                clear_turn_intent "${turn_session_key:-}"
-                emit_modified_payload "$codex_update_reply_text" false
             fi
             exit 0
         fi

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -346,6 +346,119 @@ EOF
         test_fail "Codex-update turns must stay on the deterministic hard-override path even when direct fastpath is enabled, because out-of-band send races with later bad replies on live Telegram"
     fi
 
+    test_start "component_codex_update_terminalizes_blocked_followup_tool_turn_after_hard_override"
+    local codex_terminal_tmp codex_terminal_intent_dir codex_terminal_marker codex_terminal_session_suppress codex_terminal_chat_suppress
+    local codex_terminal_before_output codex_terminal_tool_output codex_terminal_repeat_before_output codex_terminal_after_output
+    local codex_terminal_send_output codex_terminal_repeat_send_output codex_terminal_reply_text
+    local codex_terminal_marker_present_after_tool codex_terminal_suppress_absent_after_tool
+    local codex_terminal_marker_cleared_after_send codex_terminal_session_suppress_present_after_send codex_terminal_chat_suppress_present_after_send
+    codex_terminal_tmp="$(secure_temp_dir telegram-safe-codex-update-terminal)"
+    codex_terminal_intent_dir="$codex_terminal_tmp/intent"
+    codex_terminal_marker="$codex_terminal_intent_dir/session_codex-terminal.terminal"
+    codex_terminal_session_suppress="$codex_terminal_intent_dir/session_codex-terminal.suppress"
+    codex_terminal_chat_suppress="$codex_terminal_intent_dir/chat-262872984.suppress"
+    codex_terminal_reply_text='По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search.'
+    codex_terminal_before_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    codex_terminal_tool_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeToolCall","session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"cron","arguments":{"action":"list"}}
+EOF
+    )"
+    if [[ -f "$codex_terminal_marker" ]]; then
+        codex_terminal_marker_present_after_tool=true
+    else
+        codex_terminal_marker_present_after_tool=false
+    fi
+    if [[ ! -e "$codex_terminal_session_suppress" ]]; then
+        codex_terminal_suppress_absent_after_tool=true
+    else
+        codex_terminal_suppress_absent_after_tool=false
+    fi
+    codex_terminal_repeat_before_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":2}}
+EOF
+    )"
+    codex_terminal_after_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Проверил — и да, тут инструмент расписания реально сломан: на list он снова ответил missing action parameter.","tool_calls":[{"name":"cron","arguments":{"action":"list"}}]}
+EOF
+    )"
+    codex_terminal_send_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-terminal","data":{"account_id":"moltis-bot","to":"262872984","reply_to_message_id":1401,"text":""}}
+EOF
+    )"
+    if [[ ! -e "$codex_terminal_marker" ]]; then
+        codex_terminal_marker_cleared_after_send=true
+    else
+        codex_terminal_marker_cleared_after_send=false
+    fi
+    if [[ -f "$codex_terminal_session_suppress" ]]; then
+        codex_terminal_session_suppress_present_after_send=true
+    else
+        codex_terminal_session_suppress_present_after_send=false
+    fi
+    if [[ -f "$codex_terminal_chat_suppress" ]]; then
+        codex_terminal_chat_suppress_present_after_send=true
+    else
+        codex_terminal_chat_suppress_present_after_send=false
+    fi
+    codex_terminal_repeat_send_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-terminal","data":{"account_id":"moltis-bot","to":"262872984","reply_to_message_id":1402,"text":"Проверил — и да, тут инструмент расписания реально сломан: на list он снова ответил missing action parameter."}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_before_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update hard override")' >/dev/null 2>&1 <<<"$codex_terminal_before_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_tool_output" && \
+       jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$codex_terminal_tool_output" && \
+       jq -e '.data.arguments.command | contains("codex-update turn already resolved by the hard override")' >/dev/null 2>&1 <<<"$codex_terminal_tool_output" && \
+       [[ "$codex_terminal_marker_present_after_tool" == true ]] && \
+       [[ "$codex_terminal_suppress_absent_after_tool" == true ]] && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_after_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$codex_terminal_after_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$codex_terminal_after_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_send_output" && \
+       jq -e --arg reply "$codex_terminal_reply_text" '.data.text == $reply' >/dev/null 2>&1 <<<"$codex_terminal_send_output" && \
+       jq -e '.data.account_id == "moltis-bot"' >/dev/null 2>&1 <<<"$codex_terminal_send_output" && \
+       jq -e '.data.to == "262872984"' >/dev/null 2>&1 <<<"$codex_terminal_send_output" && \
+       jq -e '.data.reply_to_message_id == 1401' >/dev/null 2>&1 <<<"$codex_terminal_send_output" && \
+       [[ "$codex_terminal_marker_cleared_after_send" == true ]] && \
+       [[ "$codex_terminal_session_suppress_present_after_send" == true ]] && \
+       [[ "$codex_terminal_chat_suppress_present_after_send" == true ]] && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_send_output" && \
+       jq -e '.data.text == "NO_REPLY"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_send_output"; then
+        test_pass
+    else
+        test_fail "Codex-update hard override must terminalize a blocked same-turn tool follow-up: suppress the repeated LLM/tool churn, deliver the deterministic scheduler reply once, and drop any later dirty tail"
+    fi
+
     test_start "component_before_llm_guard_direct_fastpaths_skill_visibility_via_bot_send_when_enabled"
     local fastpath_visibility_tmp fastpath_visibility_send_script fastpath_visibility_log fastpath_visibility_stdout fastpath_visibility_stderr fastpath_visibility_status fastpath_visibility_intent_dir fastpath_visibility_suppress_file
     fastpath_visibility_tmp="$(secure_temp_dir telegram-safe-fastpath-visibility)"

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -349,9 +349,10 @@ EOF
     test_start "component_codex_update_terminalizes_blocked_followup_tool_turn_after_hard_override"
     local codex_terminal_tmp codex_terminal_intent_dir codex_terminal_marker codex_terminal_session_suppress codex_terminal_chat_suppress
     local codex_terminal_before_output codex_terminal_tool_output codex_terminal_repeat_before_output codex_terminal_after_output
-    local codex_terminal_send_output codex_terminal_repeat_send_output codex_terminal_reply_text
+    local codex_terminal_send_output codex_terminal_repeat_send_output codex_terminal_next_turn_output codex_terminal_reply_text
     local codex_terminal_marker_present_after_tool codex_terminal_suppress_absent_after_tool
     local codex_terminal_marker_cleared_after_send codex_terminal_session_suppress_present_after_send codex_terminal_chat_suppress_present_after_send
+    local codex_terminal_session_suppress_cleared_on_next_turn codex_terminal_chat_suppress_cleared_on_next_turn codex_terminal_marker_absent_on_next_turn
     codex_terminal_tmp="$(secure_temp_dir telegram-safe-codex-update-terminal)"
     codex_terminal_intent_dir="$codex_terminal_tmp/intent"
     codex_terminal_marker="$codex_terminal_intent_dir/session_codex-terminal.terminal"
@@ -389,7 +390,7 @@ EOF
             MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":2}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"}],"tool_count":37}}
 EOF
     )"
     codex_terminal_after_output="$(
@@ -431,6 +432,29 @@ EOF
 {"event":"MessageSending","session_id":"session:codex-terminal","data":{"account_id":"moltis-bot","to":"262872984","reply_to_message_id":1402,"text":"Проверил — и да, тут инструмент расписания реально сломан: на list он снова ответил missing action parameter."}}
 EOF
     )"
+    codex_terminal_next_turn_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Привет"}],"tool_count":37}}
+EOF
+    )"
+    if [[ ! -e "$codex_terminal_session_suppress" ]]; then
+        codex_terminal_session_suppress_cleared_on_next_turn=true
+    else
+        codex_terminal_session_suppress_cleared_on_next_turn=false
+    fi
+    if [[ ! -e "$codex_terminal_chat_suppress" ]]; then
+        codex_terminal_chat_suppress_cleared_on_next_turn=true
+    else
+        codex_terminal_chat_suppress_cleared_on_next_turn=false
+    fi
+    if [[ ! -e "$codex_terminal_marker" ]]; then
+        codex_terminal_marker_absent_on_next_turn=true
+    else
+        codex_terminal_marker_absent_on_next_turn=false
+    fi
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_before_output" && \
        jq -e '.data.messages[0].content | contains("Telegram-safe codex-update hard override")' >/dev/null 2>&1 <<<"$codex_terminal_before_output" && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_tool_output" && \
@@ -453,10 +477,134 @@ EOF
        [[ "$codex_terminal_session_suppress_present_after_send" == true ]] && \
        [[ "$codex_terminal_chat_suppress_present_after_send" == true ]] && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_send_output" && \
-       jq -e '.data.text == "NO_REPLY"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_send_output"; then
+       jq -e '.data.text == "NO_REPLY"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_send_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_next_turn_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard") | not' >/dev/null 2>&1 <<<"$codex_terminal_next_turn_output" && \
+       [[ "$codex_terminal_session_suppress_cleared_on_next_turn" == true ]] && \
+       [[ "$codex_terminal_chat_suppress_cleared_on_next_turn" == true ]] && \
+       [[ "$codex_terminal_marker_absent_on_next_turn" == true ]]; then
         test_pass
     else
         test_fail "Codex-update hard override must terminalize a blocked same-turn tool follow-up: suppress the repeated LLM/tool churn, deliver the deterministic scheduler reply once, and drop any later dirty tail"
+    fi
+
+    test_start "component_codex_update_keeps_terminal_state_when_suppression_arm_fails"
+    local codex_terminal_fail_tmp codex_terminal_fail_intent_dir codex_terminal_fail_marker codex_terminal_fail_intent_file
+    local codex_terminal_fail_session_suppress codex_terminal_fail_chat_suppress codex_terminal_fail_before_output codex_terminal_fail_tool_output
+    local codex_terminal_fail_send_output codex_terminal_fail_repeat_send_output
+    codex_terminal_fail_tmp="$(secure_temp_dir telegram-safe-codex-update-terminal-fail)"
+    codex_terminal_fail_intent_dir="$codex_terminal_fail_tmp/intent"
+    codex_terminal_fail_marker="$codex_terminal_fail_intent_dir/session_codex-terminal-fail.terminal"
+    codex_terminal_fail_intent_file="$codex_terminal_fail_intent_dir/session_codex-terminal-fail.intent"
+    codex_terminal_fail_session_suppress="$codex_terminal_fail_intent_dir/session_codex-terminal-fail.suppress"
+    codex_terminal_fail_chat_suppress="$codex_terminal_fail_intent_dir/chat-262872985.suppress"
+    codex_terminal_fail_before_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal-fail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872985 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    codex_terminal_fail_tool_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeToolCall","session_key":"session:codex-terminal-fail","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"cron","arguments":{"action":"list"}}
+EOF
+    )"
+    mkdir -p "$codex_terminal_fail_session_suppress" "$codex_terminal_fail_chat_suppress"
+    codex_terminal_fail_send_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-terminal-fail","data":{"account_id":"moltis-bot","to":"262872985","reply_to_message_id":1501,"text":""}}
+EOF
+    )"
+    codex_terminal_fail_repeat_send_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-terminal-fail","data":{"account_id":"moltis-bot","to":"262872985","reply_to_message_id":1502,"text":"Проверил — и да, тут инструмент расписания реально сломан: на list он снова ответил missing action parameter."}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_fail_before_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_fail_tool_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_fail_send_output" && \
+       jq -e --arg reply "$codex_terminal_reply_text" '.data.text == $reply' >/dev/null 2>&1 <<<"$codex_terminal_fail_send_output" && \
+       [[ -f "$codex_terminal_fail_marker" ]] && \
+       [[ -f "$codex_terminal_fail_intent_file" ]] && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_fail_repeat_send_output" && \
+       jq -e --arg reply "$codex_terminal_reply_text" '.data.text == $reply' >/dev/null 2>&1 <<<"$codex_terminal_fail_repeat_send_output"; then
+        test_pass
+    else
+        test_fail "Codex-update terminalization must fail closed when suppression cannot be armed: keep the terminal marker and intent, then continue rewriting later dirty tails to the deterministic scheduler reply"
+    fi
+
+    test_start "component_codex_update_repeat_guard_survives_terminal_marker_write_failure"
+    local codex_terminal_marker_fail_tmp codex_terminal_marker_fail_intent_dir codex_terminal_marker_fail_marker
+    local codex_terminal_marker_fail_before_output codex_terminal_marker_fail_tool_output codex_terminal_marker_fail_repeat_before_output
+    codex_terminal_marker_fail_tmp="$(secure_temp_dir telegram-safe-codex-update-marker-fail)"
+    codex_terminal_marker_fail_intent_dir="$codex_terminal_marker_fail_tmp/intent"
+    codex_terminal_marker_fail_marker="$codex_terminal_marker_fail_intent_dir/session_codex-terminal-marker-fail.terminal"
+    codex_terminal_marker_fail_before_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_marker_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal-marker-fail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872986 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    mkdir -p "$codex_terminal_marker_fail_marker"
+    codex_terminal_marker_fail_tool_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_marker_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeToolCall","session_key":"session:codex-terminal-marker-fail","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"cron","arguments":{"action":"list"}}
+EOF
+    )"
+    codex_terminal_marker_fail_repeat_before_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_marker_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal-marker-fail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872986 | data_dir=/home/moltis/.moltis"}],"tool_count":37}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_before_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_tool_output" && \
+       jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_tool_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_repeat_before_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_repeat_before_output"; then
+        test_pass
+    else
+        test_fail "Codex-update repeat guard must still terminalize the blocked follow-up even when the .terminal marker itself cannot be written"
+    fi
+
+    test_start "component_codex_update_terminal_state_does_not_leak_into_fresh_same_subject_turn"
+    local codex_terminal_fail_stored_epoch codex_terminal_fail_stored_intent codex_terminal_fail_stored_fingerprint codex_terminal_fresh_turn_output
+    IFS=$'\t' read -r codex_terminal_fail_stored_epoch codex_terminal_fail_stored_intent codex_terminal_fail_stored_fingerprint <"$codex_terminal_fail_intent_file"
+    printf '%s\t%s\t%s\n' "$(( $(date +%s) - 120 ))" "$codex_terminal_fail_stored_intent" "$codex_terminal_fail_stored_fingerprint" >"$codex_terminal_fail_intent_file"
+    codex_terminal_fresh_turn_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_TERMINAL_REPEAT_WINDOW_SEC=30 \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_terminal_fail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-terminal-fail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872985 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_fresh_turn_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update hard override")' >/dev/null 2>&1 <<<"$codex_terminal_fresh_turn_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard") | not' >/dev/null 2>&1 <<<"$codex_terminal_fresh_turn_output" && \
+       [[ ! -e "$codex_terminal_fail_marker" ]]; then
+        test_pass
+    else
+        test_fail "Codex-update terminal state must not bleed into a fresh later codex-update user turn after fail-closed recovery preserved marker+intent"
     fi
 
     test_start "component_before_llm_guard_direct_fastpaths_skill_visibility_via_bot_send_when_enabled"
@@ -1484,7 +1632,7 @@ EOF
     stale_status_template_intent="$(cat "$stale_status_template_dir/session_template-followup.intent" 2>/dev/null || true)"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$stale_status_template_output" && \
        jq -e '.data.messages[0].content | contains("Telegram-safe skill-template hard override")' >/dev/null 2>&1 <<<"$stale_status_template_output" && \
-       [[ "$stale_status_template_intent" == *$'\tskill_template' ]]; then
+       [[ "$stale_status_template_intent" == *$'\tskill_template\t'* ]]; then
         test_pass
     else
         test_fail "BeforeLLMCall guard must not persist a stale /status intent when the latest user turn is a template follow-up"
@@ -1504,7 +1652,7 @@ EOF
     stale_visibility_template_intent="$(cat "$stale_visibility_template_dir/session_template-after-visibility.intent" 2>/dev/null || true)"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$stale_visibility_template_output" && \
        jq -e '.data.messages[0].content | contains("Telegram-safe skill-template hard override")' >/dev/null 2>&1 <<<"$stale_visibility_template_output" && \
-       [[ "$stale_visibility_template_intent" == *$'\tskill_template' ]]; then
+       [[ "$stale_visibility_template_intent" == *$'\tskill_template\t'* ]]; then
         test_pass
     else
         test_fail "BeforeLLMCall guard must let a template follow-up replace stale persisted skill-visibility intent instead of reusing the previous skills turn"
@@ -1528,7 +1676,7 @@ EOF
        jq -e '.data.messages[0].content | contains("Telegram-safe skill-create hard override")' >/dev/null 2>&1 <<<"$stale_visibility_create_output" && \
        [[ -f "$stale_visibility_create_file" ]] && \
        grep -Fq 'name: codex-update-new-from-stale' "$stale_visibility_create_file" && \
-       [[ "$stale_visibility_create_intent" == *$'\tskill_create_created:codex-update-new-from-stale' ]]; then
+       [[ "$stale_visibility_create_intent" == *$'\tskill_create_created:codex-update-new-from-stale\t'* ]]; then
         test_pass
     else
         test_fail "BeforeLLMCall guard must let a sparse create follow-up replace stale persisted skill-visibility intent instead of reusing the previous skills turn"


### PR DESCRIPTION
## Summary
- add a codex-update terminal recovery path for blocked same-turn tool follow-ups in `telegram-safe-llm-guard`
- suppress repeated BeforeLLM/AfterLLM churn and finalize the recovered turn through the persisted codex-update MessageSending rewrite before the generic short-circuit
- add a component regression for the full live-like sequence and record the RCA/lessons follow-up

## Testing
- `bash tests/component/test_telegram_safe_llm_guard.sh`
- `bash tests/component/test_telegram_remote_uat_contract.sh`
- `git diff --check`