### PR TITLE
fix(telegram): restore codex-update live direct fastpath

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-14
-**Total Lessons**: 75
+**Total Lessons**: 76
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (35 lessons)
+#### P1 (36 lessons)
+- [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
 - [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
 - [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
 - [Telegram chat probe skill pointed to a missing wrapper entrypoint](../docs/rca/2026-04-14-telegram-chat-probe-skill-pointed-to-missing-wrapper-entrypoint.md)
@@ -174,7 +175,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (2 lessons)
+#### product (3 lessons)
+- [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
 - [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
 - [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
 
@@ -193,9 +195,9 @@
 ### Popular Tags
 
 - `moltis` (26 lessons)
-- `rca` (23 lessons)
+- `rca` (24 lessons)
+- `telegram` (19 lessons)
 - `deploy` (19 lessons)
-- `telegram` (18 lessons)
 - `github-actions` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
@@ -210,8 +212,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 75 |
-| Critical (P0/P1) | 36 |
+| Total Lessons | 76 |
+| Critical (P0/P1) | 37 |
 | Categories | 7 |
 | Unique Tags | 156 |
 

--- a/docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md
+++ b/docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md
@@ -1,0 +1,128 @@
+---
+title: "Telegram codex-update live runtime ignored in-band hook modify despite correct guard output"
+date: 2026-04-14
+severity: P1
+category: product
+tags: [telegram, codex-update, fastpath, hook, runtime, cron, rca]
+root_cause: "Production Moltis Telegram runtime still ignored correct in-band hook `modify` outputs for the `codex-update` scheduler turn, so relying on hard-override/terminalization alone could not deliver the deterministic user-facing reply; the reliable contract remained the direct Bot API fastpath with same-turn suppression."
+---
+
+# RCA: Telegram codex-update live runtime ignored in-band hook modify despite correct guard output
+
+Date: 2026-04-14  
+Status: Resolved in source, pending merge/deploy/live re-verification  
+Context: beads `moltinger-mvy8`, production regression after merge/deploy of `#177`
+
+## Ошибка
+
+После production deploy пользователь по-прежнему получал ложный ответ вида:
+
+```text
+Проверил — и да, тут инструмент расписания реально сломан...
+...
+📋 Activity log
+• 🔧 cron
+•   ❌ missing 'action' parameter
+```
+
+То есть Telegram-safe `codex-update` scheduler turn снова уходил в broken tool/memory path вместо канонического remote-safe contract reply.
+
+## Проверка прошлых уроков
+
+Проверены:
+
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag codex-update`
+- `./scripts/query-lessons.sh --tag hooks`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Релевантные прошлые RCA:
+
+1. `docs/rca/2026-04-02-telegram-skill-detail-single-inband-path-regressed-live-runtime.md`  
+   уже фиксировал, что live Telegram runtime может игнорировать корректный in-band hook path и что для некоторых user-facing turns надёжным контрактом остаётся direct Bot API fastpath.
+2. `docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md`  
+   уже показывал, что одного hard override недостаточно без terminal/suppression state machine.
+3. `docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md`  
+   содержал гипотезу, что direct fastpath сам по себе является корнем проблемы для `codex-update`.
+
+Что оказалось новым:
+
+- production evidence после `#177` показал, что guard script уже выдавал правильные `modify` payloads, а ломался именно live runtime layer, который их не применял;
+- значит, предыдущее решение “убрать direct fastpath и оставить чистый in-band hard override” было неправильным для этого конкретного live Telegram path;
+- для `codex-update` надо вернуть direct fastpath, но сохранить same-turn suppression contract, чтобы underlying run не мог дописать второй хвост.
+
+## Evidence
+
+Собранная production evidence:
+
+1. серверный script checksum совпал локально и на live host:
+   - local `scripts/telegram-safe-llm-guard.sh` SHA256
+   - live `/opt/moltinger/scripts/telegram-safe-llm-guard.sh` SHA256
+   - значения совпали, то есть deploy drift guard script не было
+2. hook был реально зарегистрирован в runtime:
+   - `[[hooks.hooks]] name = "telegram-safe-llm-guard"` в `/opt/moltinger/config/moltis.toml`
+   - `docker logs moltis` содержал `hook handler registered handler="telegram-safe-llm-guard"`
+3. audit log внутри контейнера `/tmp/moltis-telegram-safe-llm-guard.audit.log` для проблемного nonce-turn показал:
+   - `intent_set ... intent=codex_update_scheduler`
+   - `before_modify reason=codex_update_hard_override`
+   - `emit_modify event=AfterLLMCall reason=codex_update_reply_override`
+   - `emit_modify event=BeforeToolCall reason=codex_update_terminal_tool_suppress tool=memory_search`
+   - `emit_modify event=AfterLLMCall reason=codex_update_terminal_after_llm_suppress`
+4. captured hook artefacts внутри контейнера показали корректные JSON outputs:
+   - repeated `BeforeLLMCall` возвращал `action=modify` с terminal guard и `tool_count=0`
+   - late `AfterLLMCall` возвращал `action=modify`, `text=""`, `tool_calls=[]`
+5. при этом `docker logs moltis` для того же run показал фактическое поведение runtime:
+   - tool `memory_search` всё равно был реально вызван
+   - tool упал с `missing 'query' parameter`
+   - late final bad reply всё равно был возвращён в `moltis_chat`
+   - outbound Telegram send ушёл как `sent`
+
+Это доказало, что сам guard уже работал корректно, но live runtime не уважал его in-band `modify` outputs для этого класса turns.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---|---|---|---|
+| 1 | Почему пользователь снова увидел broken scheduler reply? | Потому что production turn снова дошёл до real `memory_search`/late bad text path. | `docker logs moltis`, nonce turn `run_id=889189a3-3d1d-487b-a683-8ff04e316b89` |
+| 2 | Почему late bad path вообще исполнился после `#177`? | Потому что live runtime не применил корректные hook `modify` outputs, хотя guard их сгенерировал. | audit log + captured `*.output.json` inside container |
+| 3 | Почему это не было просто deploy drift старого guard script? | Потому что live script и локальный script совпали по SHA256, а hook registration остался активным. | local/live SHA256 compare, `moltis.toml`, `docker logs moltis` |
+| 4 | Почему hard override + terminalization не спасли пользовательский ответ? | Потому что этот механизм опирался на in-band hook application, а именно этот слой и оказался ненадёжным в live Telegram runtime. | audit says `modify`; runtime still executed tool and returned text |
+| 5 | Почему прошлое решение оказалось неверным? | Потому что оно трактовало проблему как “direct fastpath race”, хотя новые production evidence показали другой корень: runtime игнорирует корректный in-band modify и поэтому direct fastpath остаётся live-proven delivery contract. | contradicted by post-deploy live audit and container captures |
+
+## Root Cause
+
+Корневая причина была не в текущем `telegram-safe-llm-guard.sh` script и не в его классификации prompt family.  
+Корневая причина была в architectural mismatch между repo-owned guard contract и live Moltis Telegram runtime:
+
+- guard возвращал правильные deterministic `modify` payloads;
+- но production runtime для `codex-update` scheduler turn всё равно продолжал underlying LLM/tool loop и отправлял user-visible bad tail.
+
+Следовательно, для этого user-facing Telegram scenario in-band hard override/terminalization path сам по себе не может считаться надёжным delivery contract. Надёжным contract остаётся direct Bot API fastpath с same-turn suppression, как и у ранее доказанных live scenarios.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - restored controlled direct fastpath for `codex-update` release/scheduler turns when `MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true`
+   - left hard-override path below as fallback when direct send is disabled or unavailable
+2. `tests/component/test_telegram_safe_llm_guard.sh`
+   - replaced regression that forbade direct fastpath for `codex-update`
+   - added codex-update direct-fastpath regression that proves:
+     - direct send is used
+     - session/chat suppression markers are armed
+     - repeated same-turn `BeforeLLMCall` is suppressed
+     - follow-up tool, late `AfterLLMCall`, and `MessageSending` tail are suppressed
+3. lessons flow
+   - new RCA recorded
+   - lessons index rebuilt
+
+## Prevention
+
+1. Не считать “чистый in-band hook path” улучшением сам по себе, если именно этот delivery path не подтверждён live Telegram evidence.
+2. Для user-facing Telegram routes differentiator должен быть не “красивее архитектурно”, а “какой contract реально доходит до пользователя в production”.
+3. Если audit log и captured hook outputs уже правильные, а live reply неправильный, следующий fix должен идти в delivery architecture, а не в очередной classifier tweak.
+
+## Уроки
+
+1. Для Telegram-safe routes “hook правильно сгенерировал modify” и “пользователь реально увидел modify-результат” — это разные утверждения.
+2. Если production evidence опровергает предыдущий RCA, нужно не защищать старую гипотезу, а переписать source contract под новый факт.
+3. `codex-update` и `skill_detail` теперь подтверждают один и тот же урок: для части live Telegram scenarios direct Bot API fastpath остаётся reliability contract, а не просто оптимизацией.

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -3590,6 +3590,12 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         # reliable through the direct Bot API fastpath than through pure
         # in-band hook modify delivery. Keep the hard-override path below as
         # the fallback when direct send is disabled or unavailable.
+        if [[ "$current_turn_status_request" == true ]]; then
+            if direct_fastpath_send_with_suppression "status" "$telegram_chat_id" "$canonical_status" "status"; then
+                clear_turn_intent "${turn_session_key:-}"
+                exit 0
+            fi
+        fi
         if [[ "$current_turn_codex_update_request" == true ]]; then
             codex_update_reply_mode="release"
             if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
@@ -3597,12 +3603,6 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             fi
             codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
             if [[ -n "$codex_update_reply_text" ]] && direct_fastpath_send_with_suppression "codex_update" "$telegram_chat_id" "$codex_update_reply_text" "codex_update:${codex_update_reply_mode}" "mode=$codex_update_reply_mode"; then
-                clear_turn_intent "${turn_session_key:-}"
-                exit 0
-            fi
-        fi
-        if [[ "$current_turn_status_request" == true ]]; then
-            if direct_fastpath_send_with_suppression "status" "$telegram_chat_id" "$canonical_status" "status"; then
                 clear_turn_intent "${turn_session_key:-}"
                 exit 0
             fi

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -3586,9 +3586,21 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     fi
 
     if [[ "$is_telegram_safe_lane" == true ]] && flag_enabled "$DIRECT_FASTPATH_ENABLED" && [[ -n "${telegram_chat_id:-}" ]]; then
-        # codex-update turns stay on the deterministic hard-override path below.
-        # A direct send here does not actually terminate the underlying run and
-        # can race with a later bad LLM/tool reply on live Telegram.
+        # Live Telegram runtime still treats some user-facing turns as more
+        # reliable through the direct Bot API fastpath than through pure
+        # in-band hook modify delivery. Keep the hard-override path below as
+        # the fallback when direct send is disabled or unavailable.
+        if [[ "$current_turn_codex_update_request" == true ]]; then
+            codex_update_reply_mode="release"
+            if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
+                codex_update_reply_mode="scheduler"
+            fi
+            codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
+            if [[ -n "$codex_update_reply_text" ]] && direct_fastpath_send_with_suppression "codex_update" "$telegram_chat_id" "$codex_update_reply_text" "codex_update:${codex_update_reply_mode}" "mode=$codex_update_reply_mode"; then
+                clear_turn_intent "${turn_session_key:-}"
+                exit 0
+            fi
+        fi
         if [[ "$current_turn_status_request" == true ]]; then
             if direct_fastpath_send_with_suppression "status" "$telegram_chat_id" "$canonical_status" "status"; then
                 clear_turn_intent "${turn_session_key:-}"

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -347,6 +347,67 @@ EOF
         test_fail "When direct fastpath is enabled, codex-update scheduler turns must use the same Bot API delivery contract as the other live-proven Telegram-safe routes and arm same-turn suppression markers"
     fi
 
+    test_start "component_before_llm_guard_keeps_status_precedence_over_codex_update_direct_fastpath_on_mixed_turn"
+    local mixed_status_codex_tmp mixed_status_codex_send_script mixed_status_codex_log mixed_status_codex_stdout mixed_status_codex_stderr mixed_status_codex_status mixed_status_codex_intent_dir mixed_status_codex_session_suppress mixed_status_codex_chat_suppress
+    mixed_status_codex_tmp="$(secure_temp_dir telegram-safe-mixed-status-codex)"
+    mixed_status_codex_send_script="$mixed_status_codex_tmp/send.sh"
+    mixed_status_codex_log="$mixed_status_codex_tmp/send.log"
+    mixed_status_codex_intent_dir="$mixed_status_codex_tmp/intent"
+    mixed_status_codex_session_suppress="$mixed_status_codex_intent_dir/session_mixedstatus.suppress"
+    mixed_status_codex_chat_suppress="$mixed_status_codex_intent_dir/chat-262872984.suppress"
+    cat >"$mixed_status_codex_send_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+chat_id=""
+text=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chat-id)
+            chat_id="${2:-}"
+            shift 2
+            ;;
+        --text)
+            text="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf 'chat_id=%s\ntext=%s\n' "$chat_id" "$text" >"$FASTPATH_LOG"
+printf '{"ok":true}\n'
+EOF
+    chmod +x "$mixed_status_codex_send_script"
+    mixed_status_codex_stdout="$mixed_status_codex_tmp/stdout.log"
+    mixed_status_codex_stderr="$mixed_status_codex_tmp/stderr.log"
+    set +e
+    env PATH="$MINIMAL_PATH" \
+        FASTPATH_LOG="$mixed_status_codex_log" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$mixed_status_codex_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$mixed_status_codex_send_script" \
+        MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
+        bash "$HOOK_HANDLER" >"$mixed_status_codex_stdout" 2>"$mixed_status_codex_stderr" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:mixedstatus","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"/status и заодно какая latest версия Codex CLI?"}],"tool_count":37,"iteration":1}}
+EOF
+    mixed_status_codex_status=$?
+    set -e
+    if [[ "$mixed_status_codex_status" -eq 0 ]] && \
+       [[ ! -s "$mixed_status_codex_stdout" ]] && \
+       [[ ! -s "$mixed_status_codex_stderr" ]] && \
+       [[ -f "$mixed_status_codex_session_suppress" ]] && \
+       [[ -f "$mixed_status_codex_chat_suppress" ]] && \
+       grep -Fq $'\tstatus' "$mixed_status_codex_session_suppress" && \
+       grep -Fq $'\tstatus' "$mixed_status_codex_chat_suppress" && \
+       grep -Fq 'text=Статус: Online' "$mixed_status_codex_log" && \
+       ! grep -Fq 'scheduler path для регулярной проверки обновлений Codex CLI' "$mixed_status_codex_log"; then
+        test_pass
+    else
+        test_fail "Explicit /status must keep precedence over codex-update direct fastpath on mixed turns so the canonical status contract does not drift"
+    fi
+
     test_start "component_codex_update_direct_fastpath_keeps_same_turn_runtime_tail_suppressed"
     local codex_direct_tail_tmp codex_direct_tail_send_script codex_direct_tail_log codex_direct_tail_stdout codex_direct_tail_stderr codex_direct_tail_status codex_direct_tail_intent_dir
     local codex_direct_tail_session_suppress codex_direct_tail_chat_suppress codex_direct_tail_repeat_before_output codex_direct_tail_tool_output codex_direct_tail_after_output codex_direct_tail_send_output

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -284,13 +284,14 @@ EOF
         test_fail "Direct /status fastpath must stay handler-safe: send canonical text, return rc=0, and leave only a delivery-suppression marker instead of triggering hook-block"
     fi
 
-    test_start "component_before_llm_guard_keeps_codex_update_on_hard_override_even_when_direct_fastpath_is_enabled"
-    local fastpath_codex_tmp fastpath_codex_send_script fastpath_codex_log fastpath_codex_stdout fastpath_codex_stderr fastpath_codex_status fastpath_codex_intent_dir fastpath_codex_suppress_file
+    test_start "component_before_llm_guard_direct_fastpaths_codex_update_when_enabled"
+    local fastpath_codex_tmp fastpath_codex_send_script fastpath_codex_log fastpath_codex_stdout fastpath_codex_stderr fastpath_codex_status fastpath_codex_intent_dir fastpath_codex_session_suppress_file fastpath_codex_chat_suppress_file
     fastpath_codex_tmp="$(secure_temp_dir telegram-safe-fastpath-codex-update)"
     fastpath_codex_send_script="$fastpath_codex_tmp/send.sh"
     fastpath_codex_log="$fastpath_codex_tmp/send.log"
     fastpath_codex_intent_dir="$fastpath_codex_tmp/intent"
-    fastpath_codex_suppress_file="$fastpath_codex_intent_dir/session_fastcodex.suppress"
+    fastpath_codex_session_suppress_file="$fastpath_codex_intent_dir/session_fastcodex.suppress"
+    fastpath_codex_chat_suppress_file="$fastpath_codex_intent_dir/chat-262872984.suppress"
     cat >"$fastpath_codex_send_script" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -332,18 +333,115 @@ EOF
     set -e
     if [[ "$fastpath_codex_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_codex_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       jq -e '.data.messages | length == 2' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update hard override")' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       jq -e '.data.messages[0].content | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       jq -e '.data.messages[0].content | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       jq -e '.data.messages[1].content == "Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего."' >/dev/null 2>&1 <"$fastpath_codex_stdout" && \
-       [[ ! -e "$fastpath_codex_suppress_file" ]] && \
-       [[ ! -s "$fastpath_codex_log" ]]; then
+       [[ ! -s "$fastpath_codex_stdout" ]] && \
+       [[ -f "$fastpath_codex_session_suppress_file" ]] && \
+       [[ -f "$fastpath_codex_chat_suppress_file" ]] && \
+       grep -Fq $'\tcodex_update:scheduler' "$fastpath_codex_session_suppress_file" && \
+       grep -Fq $'\tcodex_update:scheduler' "$fastpath_codex_chat_suppress_file" && \
+       grep -Fq 'chat_id=262872984' "$fastpath_codex_log" && \
+       grep -Fq 'scheduler path для регулярной проверки обновлений Codex CLI' "$fastpath_codex_log" && \
+       grep -Fq 'не подтверждаю по памяти' "$fastpath_codex_log" && \
+       grep -Fq 'операторский/runtime check' "$fastpath_codex_log"; then
         test_pass
     else
-        test_fail "Codex-update turns must stay on the deterministic hard-override path even when direct fastpath is enabled, because out-of-band send races with later bad replies on live Telegram"
+        test_fail "When direct fastpath is enabled, codex-update scheduler turns must use the same Bot API delivery contract as the other live-proven Telegram-safe routes and arm same-turn suppression markers"
+    fi
+
+    test_start "component_codex_update_direct_fastpath_keeps_same_turn_runtime_tail_suppressed"
+    local codex_direct_tail_tmp codex_direct_tail_send_script codex_direct_tail_log codex_direct_tail_stdout codex_direct_tail_stderr codex_direct_tail_status codex_direct_tail_intent_dir
+    local codex_direct_tail_session_suppress codex_direct_tail_chat_suppress codex_direct_tail_repeat_before_output codex_direct_tail_tool_output codex_direct_tail_after_output codex_direct_tail_send_output
+    codex_direct_tail_tmp="$(secure_temp_dir telegram-safe-codex-update-direct-tail)"
+    codex_direct_tail_send_script="$codex_direct_tail_tmp/send.sh"
+    codex_direct_tail_log="$codex_direct_tail_tmp/send.log"
+    codex_direct_tail_intent_dir="$codex_direct_tail_tmp/intent"
+    codex_direct_tail_session_suppress="$codex_direct_tail_intent_dir/session_codex-direct.suppress"
+    codex_direct_tail_chat_suppress="$codex_direct_tail_intent_dir/chat-262872984.suppress"
+    cat >"$codex_direct_tail_send_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+chat_id=""
+text=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chat-id)
+            chat_id="${2:-}"
+            shift 2
+            ;;
+        --text)
+            text="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf 'chat_id=%s\ntext=%s\n' "$chat_id" "$text" >"$FASTPATH_LOG"
+printf '{"ok":true}\n'
+EOF
+    chmod +x "$codex_direct_tail_send_script"
+    codex_direct_tail_stdout="$codex_direct_tail_tmp/stdout.log"
+    codex_direct_tail_stderr="$codex_direct_tail_tmp/stderr.log"
+    set +e
+    env PATH="$MINIMAL_PATH" \
+        FASTPATH_LOG="$codex_direct_tail_log" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_direct_tail_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$codex_direct_tail_send_script" \
+        MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
+        bash "$HOOK_HANDLER" >"$codex_direct_tail_stdout" 2>"$codex_direct_tail_stderr" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-direct","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
+EOF
+    codex_direct_tail_status=$?
+    set -e
+    codex_direct_tail_repeat_before_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_direct_tail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-direct","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":2}}
+EOF
+    )"
+    codex_direct_tail_tool_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_direct_tail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeToolCall","session_key":"session:codex-direct","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"memory_search","arguments":{"query":"cron status"}}
+EOF
+    )"
+    codex_direct_tail_after_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_direct_tail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","session_key":"session:codex-direct","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Проверил — и да, тут инструмент расписания реально сломан: missing 'query' parameter.","tool_calls":[{"name":"memory_search","arguments":{"query":"cron status"}}]}
+EOF
+    )"
+    codex_direct_tail_send_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_direct_tail_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-direct","data":{"account_id":"moltis-bot","to":"262872984","reply_to_message_id":1450,"text":"Проверил — и да, тут инструмент расписания реально сломан: missing 'query' parameter."}}
+EOF
+    )"
+    if [[ "$codex_direct_tail_status" -eq 0 ]] && \
+       [[ ! -s "$codex_direct_tail_stdout" ]] && \
+       [[ ! -s "$codex_direct_tail_stderr" ]] && \
+       [[ -f "$codex_direct_tail_session_suppress" ]] && \
+       [[ -f "$codex_direct_tail_chat_suppress" ]] && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_direct_tail_tool_output" && \
+       jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$codex_direct_tail_tool_output" && \
+       jq -e '.data.arguments.command | contains("direct fastpath already handled this reply")' >/dev/null 2>&1 <<<"$codex_direct_tail_tool_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_direct_tail_after_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$codex_direct_tail_after_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$codex_direct_tail_after_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_direct_tail_send_output" && \
+       jq -e '.data.text == "NO_REPLY"' >/dev/null 2>&1 <<<"$codex_direct_tail_send_output"; then
+        test_pass
+    else
+        test_fail "Codex-update direct fastpath must keep the same turn terminal: repeat BeforeLLMCall, follow-up tools, late AfterLLMCall text, and final runtime delivery all stay suppressed"
     fi
 
     test_start "component_codex_update_terminalizes_blocked_followup_tool_turn_after_hard_override"


### PR DESCRIPTION
## Summary
- restore the live-proven direct fastpath for Telegram-safe codex-update scheduler/release turns
- keep same-turn suppression so repeated BeforeLLMCall, tool churn, AfterLLMCall tails, and MessageSending tails stay suppressed
- add RCA and regression coverage for the live runtime gap where in-band hook modify was correct but ignored

## Testing
- bash -n scripts/telegram-safe-llm-guard.sh
- bash -n tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_remote_uat_contract.sh
- bash scripts/build-lessons-index.sh

Refs: moltinger-mvy8