### PR TITLE
fix(telegram): stop codex-update memory-proof reply leakage

### DIFF
--- a/docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-cleared-fallback-state-too-early.md
+++ b/docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-cleared-fallback-state-too-early.md
@@ -1,0 +1,130 @@
+---
+title: "Telegram codex-update direct fastpath cleared fallback state too early"
+date: 2026-04-14
+severity: P1
+category: product
+tags: [telegram, codex-update, direct-fastpath, suppression, semantic-review, rca]
+root_cause: "After a successful codex-update direct fastpath send, the guard immediately cleared persisted turn intent and relied only on suppression markers. If same-turn suppression lookup was later unavailable, late tool calls and final MessageSending tails no longer had codex-update fallback context, so memory-based false positives could escape. The authoritative UAT semantic layer also prioritized generic activity-leak classification ahead of codex-update scheduler semantics and underfit replies that claimed cron existence from chat memory."
+---
+
+# RCA: Telegram codex-update direct fastpath cleared fallback state too early
+
+Date: 2026-04-14  
+Status: Fixed in source, pending PR review / merge / live verification  
+Context: beads `moltinger-ch8h`
+
+## Error
+
+Пользователь снова получил live Telegram ответ, который нельзя считать корректным user-facing contract:
+
+```text
+Да — есть.
+
+В памяти у меня явно записано:
+«Ежедневно проверяю стабильные обновления Codex CLI и присылаю краткое уведомление только если вышла новая стабильная версия.»
+
+...
+📋 Activity log
+• 🔧 cron
+• 🧠 Searching memory...
+• ❌ missing 'action' parameter
+• ❌ missing 'query' parameter
+• ❌ missing 'command' parameter
+```
+
+Это уже не старый false-negative вида «не подтверждено», а новый false-positive: бот утверждает наличие cron по памяти чата и одновременно протекает внутренними tool errors.
+
+## Lessons Pre-check
+
+Перед фиксом были проверены lessons и связанные правила:
+
+- `docs/LESSONS-LEARNED.md`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+- `docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md`
+- `docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md`
+- `docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md`
+
+Что уже было известно:
+
+1. `codex-update` на Telegram-safe surface должен отвечать deterministic scheduler contract-ом, а не уходить в memory/tool speculation.
+2. Ранний direct fastpath не является эквивалентом true short-circuit, если underlying run ещё может прислать поздний хвост.
+3. Для same-turn follow-up нужны terminal markers и fail-closed suppression semantics.
+
+Что оставалось непокрытым:
+
+1. direct fastpath всё ещё считал suppression markers единственным источником истины и очищал `turn_intent` слишком рано;
+2. semantic review в authoritative UAT первым срабатывал на generic `semantic_activity_leak`, а не на codex-update scheduler contract violation;
+3. reply taxonomy в web probe была узкой и выделяла только `missing 'action' parameter`, но не `query/command`.
+
+## Evidence
+
+1. Пользовательский live reply содержал сразу три симптома:
+   - memory-based proof: `В памяти у меня явно записано`
+   - scheduler claim: `Да — есть`
+   - leaked tool errors: `missing 'action'/'query'/'command' parameter`
+2. В локальном component-repro текущий guard после успешного direct fastpath действительно:
+   - ставил `.suppress`
+   - но очищал `turn_intent`
+   - и не оставлял отдельный fallback path, если suppression files потом исчезали.
+3. После точечного source fix локальный repro с искусственно потерянными `.suppress` файлами показал:
+   - `BeforeToolCall` всё ещё terminalizes same-turn follow-up через preserved codex-update context
+   - `MessageSending` переписывается обратно в deterministic scheduler reply вместо memory-based false positive.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Почему пользователю снова пришёл плохой ответ про cron/Codex CLI? | Потому что поздний same-turn tail дошёл до user-facing delivery и ответил от лица “памяти”, а не от deterministic codex-update contract. |
+| 2 | Почему late tail вообще смог пройти после успешного direct fastpath? | Потому что direct fastpath оставлял только suppression markers и сразу очищал persisted `turn_intent`. |
+| 3 | Почему этого оказалось недостаточно? | Потому что при потере или недоступности suppression lookup у поздних `BeforeToolCall`/`MessageSending` событий больше не оставалось codex-update fallback context. |
+| 4 | Почему authoritative UAT не формулировал это как codex-update scheduler contract breach? | Потому что semantic review сначала видел generic activity leak и только потом codex-update-specific semantics; positive memory-proof reply попадал под более грубую классификацию. |
+| 5 | Почему reply taxonomy дополнительно недооценивала такой ответ? | Потому что error signature and scheduler-memory heuristics были заточены под старый negative false-negative и не покрывали positive memory assertion плюс `missing 'query'/'command' parameter`. |
+
+## Root Cause
+
+Корневой дефект состоял из двух связанных частей:
+
+1. `scripts/telegram-safe-llm-guard.sh` после успешного `codex-update` direct fastpath очищал persisted `turn_intent` слишком рано и полагался только на `.suppress` markers. При потере suppression-state поздний same-turn tail больше не знал, что это `codex-update` turn, и мог уйти в memory/tool leakage.
+2. `scripts/telegram-e2e-on-demand.sh` и `scripts/telegram-web-user-probe.mjs` были недоделаны для этой новой формы дефекта: semantic/UAT слой видел generic activity leak раньше domain-specific scheduler breach, а probe taxonomy недооценивала `missing 'query'/'command' parameter`.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - после успешного `codex-update` direct fastpath больше не очищает fallback state сразу;
+   - сохраняет terminal marker для same-turn recovery;
+   - оставляет persisted codex-update intent до тех пор, пока terminal delivery действительно не завершит turn.
+2. `tests/component/test_telegram_safe_llm_guard.sh`
+   - добавлен regression на искусственную потерю suppression-state после successful direct fastpath;
+   - проверяется, что поздний `BeforeToolCall` и `MessageSending` всё равно terminalize/rewrite dirty tail.
+3. `scripts/telegram-e2e-on-demand.sh`
+   - расширен matcher `reply_has_codex_update_scheduler_memory_false_negative()` под positive memory assertions и leaked `action/query/command` parameter variants;
+   - codex-update semantic checks подняты выше generic activity leak classification.
+4. `tests/component/test_telegram_remote_uat_contract.sh`
+   - добавлен authoritative semantic regression на positive memory-based false positive reply.
+5. `scripts/telegram-web-user-probe.mjs`
+   - расширен error-signature regex для `missing 'query' parameter` и `missing 'command' parameter`.
+6. `tests/component/test_telegram_web_probe_correlation.sh`
+   - добавлен regression на mixed `action/query/command` parameter error signature.
+
+## Verification
+
+Локально подтверждено:
+
+- `bash -n scripts/telegram-safe-llm-guard.sh`
+- `bash -n scripts/telegram-e2e-on-demand.sh`
+- `bash tests/component/test_telegram_safe_llm_guard.sh`
+- `bash tests/component/test_telegram_remote_uat_contract.sh`
+- `bash tests/component/test_telegram_web_probe_correlation.sh`
+- `git diff --check`
+
+## Prevention
+
+1. Для high-risk Telegram-safe routes нельзя очищать domain-specific fallback state сразу после direct fastpath send; suppression markers сами по себе недостаточны.
+2. Если defect имеет явную domain семантику (`codex-update scheduler contract breach`), authoritative UAT должен классифицировать её раньше generic leak buckets.
+3. Reply taxonomy для Telegram UAT должна покрывать не только один observed error string, а всё семейство близких tool-parameter leaks.
+
+## Lessons
+
+1. `direct fastpath delivered` не означает `fallback state больше не нужен`; same-turn recovery нужно держать до фактического terminal completion.
+2. Generic leak detector не должен затмевать более полезную domain-specific классификацию, если prompt family уже распознан.
+3. Один новый production reply variant обычно означает не только runtime defect, но и пробел в semantic/UAT taxonomy; чинить надо оба слоя сразу.

--- a/docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-cleared-fallback-state-too-early.md
+++ b/docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-cleared-fallback-state-too-early.md
@@ -4,7 +4,7 @@ date: 2026-04-14
 severity: P1
 category: product
 tags: [telegram, codex-update, direct-fastpath, suppression, semantic-review, rca]
-root_cause: "After a successful codex-update direct fastpath send, the guard immediately cleared persisted turn intent and relied only on suppression markers. If same-turn suppression lookup was later unavailable, late tool calls and final MessageSending tails no longer had codex-update fallback context, so memory-based false positives could escape. The authoritative UAT semantic layer also prioritized generic activity-leak classification ahead of codex-update scheduler semantics and underfit replies that claimed cron existence from chat memory."
+root_cause: "After a successful codex-update direct fastpath send, the guard immediately cleared persisted turn intent and relied only on suppression markers. If same-turn suppression lookup was later unavailable, late tool calls and final MessageSending tails no longer had codex-update fallback context, so memory-based false positives could escape. The authoritative UAT semantic layer also prioritized generic activity-leak classification ahead of codex-update scheduler semantics, and the leak taxonomy underfit both unquoted missing action/query/command parameter variants and the highest-risk late AfterLLMCall recovery path."
 ---
 
 # RCA: Telegram codex-update direct fastpath cleared fallback state too early
@@ -54,7 +54,8 @@ Context: beads `moltinger-ch8h`
 
 1. direct fastpath всё ещё считал suppression markers единственным источником истины и очищал `turn_intent` слишком рано;
 2. semantic review в authoritative UAT первым срабатывал на generic `semantic_activity_leak`, а не на codex-update scheduler contract violation;
-3. reply taxonomy в web probe была узкой и выделяла только `missing 'action' parameter`, но не `query/command`.
+3. reply taxonomy в web probe была узкой и выделяла только quoted `missing 'action' parameter`, но не unquoted `action/query/command` variants.
+4. regression coverage не доказывал самый рискованный late `AfterLLMCall` path после потери suppression-state.
 
 ## Evidence
 
@@ -67,6 +68,7 @@ Context: beads `moltinger-ch8h`
    - но очищал `turn_intent`
    - и не оставлял отдельный fallback path, если suppression files потом исчезали.
 3. После точечного source fix локальный repro с искусственно потерянными `.suppress` файлами показал:
+   - первый late `AfterLLMCall` обнуляет dirty text/tool_calls и сохраняет terminal marker до final delivery;
    - `BeforeToolCall` всё ещё terminalizes same-turn follow-up через preserved codex-update context
    - `MessageSending` переписывается обратно в deterministic scheduler reply вместо memory-based false positive.
 
@@ -78,14 +80,14 @@ Context: beads `moltinger-ch8h`
 | 2 | Почему late tail вообще смог пройти после успешного direct fastpath? | Потому что direct fastpath оставлял только suppression markers и сразу очищал persisted `turn_intent`. |
 | 3 | Почему этого оказалось недостаточно? | Потому что при потере или недоступности suppression lookup у поздних `BeforeToolCall`/`MessageSending` событий больше не оставалось codex-update fallback context. |
 | 4 | Почему authoritative UAT не формулировал это как codex-update scheduler contract breach? | Потому что semantic review сначала видел generic activity leak и только потом codex-update-specific semantics; positive memory-proof reply попадал под более грубую классификацию. |
-| 5 | Почему reply taxonomy дополнительно недооценивала такой ответ? | Потому что error signature and scheduler-memory heuristics были заточены под старый negative false-negative и не покрывали positive memory assertion плюс `missing 'query'/'command' parameter`. |
+| 5 | Почему reply taxonomy дополнительно недооценивала такой ответ? | Потому что error signature and scheduler-memory heuristics были заточены под старый negative false-negative и quoted leaks, не покрывали positive memory assertion плюс unquoted `missing action/query/command parameter`, а regression suite не доказывал первый late `AfterLLMCall` suppression-loss path. |
 
 ## Root Cause
 
 Корневой дефект состоял из двух связанных частей:
 
 1. `scripts/telegram-safe-llm-guard.sh` после успешного `codex-update` direct fastpath очищал persisted `turn_intent` слишком рано и полагался только на `.suppress` markers. При потере suppression-state поздний same-turn tail больше не знал, что это `codex-update` turn, и мог уйти в memory/tool leakage.
-2. `scripts/telegram-e2e-on-demand.sh` и `scripts/telegram-web-user-probe.mjs` были недоделаны для этой новой формы дефекта: semantic/UAT слой видел generic activity leak раньше domain-specific scheduler breach, а probe taxonomy недооценивала `missing 'query'/'command' parameter`.
+2. `scripts/telegram-e2e-on-demand.sh` и `scripts/telegram-web-user-probe.mjs` были недоделаны для этой новой формы дефекта: semantic/UAT слой видел generic activity leak раньше domain-specific scheduler breach, а probe taxonomy недооценивала quoted/unquoted `missing action/query/command parameter` leaks.
 
 ## Fixes Applied
 
@@ -95,16 +97,19 @@ Context: beads `moltinger-ch8h`
    - оставляет persisted codex-update intent до тех пор, пока terminal delivery действительно не завершит turn.
 2. `tests/component/test_telegram_safe_llm_guard.sh`
    - добавлен regression на искусственную потерю suppression-state после successful direct fastpath;
+   - отдельно проверяется, что первый late `AfterLLMCall` гасит dirty text/tool_calls, но сохраняет terminal marker;
    - проверяется, что поздний `BeforeToolCall` и `MessageSending` всё равно terminalize/rewrite dirty tail.
 3. `scripts/telegram-e2e-on-demand.sh`
-   - расширен matcher `reply_has_codex_update_scheduler_memory_false_negative()` под positive memory assertions и leaked `action/query/command` parameter variants;
+   - расширен matcher `reply_has_codex_update_scheduler_memory_false_negative()` под positive memory assertions и leaked quoted/unquoted `action/query/command` parameter variants;
    - codex-update semantic checks подняты выше generic activity leak classification.
 4. `tests/component/test_telegram_remote_uat_contract.sh`
-   - добавлен authoritative semantic regression на positive memory-based false positive reply.
+   - добавлены authoritative semantic regressions на positive memory-based false positive reply;
+   - отдельно покрыты unquoted `missing action/query/command parameter` variants.
 5. `scripts/telegram-web-user-probe.mjs`
-   - расширен error-signature regex для `missing 'query' parameter` и `missing 'command' parameter`.
+   - расширен error-signature regex для quoted/unquoted `missing 'action'/'query'/'command' parameter`.
 6. `tests/component/test_telegram_web_probe_correlation.sh`
-   - добавлен regression на mixed `action/query/command` parameter error signature.
+   - добавлен regression на mixed `action/query/command` parameter error signature;
+   - отдельно покрыты isolated unquoted `action/query/command` variants.
 
 ## Verification
 
@@ -121,10 +126,12 @@ Context: beads `moltinger-ch8h`
 
 1. Для high-risk Telegram-safe routes нельзя очищать domain-specific fallback state сразу после direct fastpath send; suppression markers сами по себе недостаточны.
 2. Если defect имеет явную domain семантику (`codex-update scheduler contract breach`), authoritative UAT должен классифицировать её раньше generic leak buckets.
-3. Reply taxonomy для Telegram UAT должна покрывать не только один observed error string, а всё семейство близких tool-parameter leaks.
+3. Reply taxonomy для Telegram UAT должна покрывать не только один observed error string, а всё семейство близких quoted/unquoted tool-parameter leaks.
+4. Для same-turn recovery нужны тесты не только на final delivery, но и на первый late `AfterLLMCall`, иначе suppression-loss regressions останутся невидимыми.
 
 ## Lessons
 
 1. `direct fastpath delivered` не означает `fallback state больше не нужен`; same-turn recovery нужно держать до фактического terminal completion.
 2. Generic leak detector не должен затмевать более полезную domain-specific классификацию, если prompt family уже распознан.
 3. Один новый production reply variant обычно означает не только runtime defect, но и пробел в semantic/UAT taxonomy; чинить надо оба слоя сразу.
+4. Изолированные quoted и unquoted leak-формы нужно тестировать отдельно, иначе смешанный пример создаёт ложную уверенность в покрытии.

--- a/scripts/telegram-e2e-on-demand.sh
+++ b/scripts/telegram-e2e-on-demand.sh
@@ -690,16 +690,32 @@ reply_has_codex_update_state_memory_false_negative() {
   return 1
 }
 
+reply_has_missing_parameter_family_leak() {
+  local normalized
+  normalized="$(normalize_message_text "${1:-}")"
+  [[ -n "$normalized" ]] || return 1
+
+  if [[ "$normalized" =~ [Mm]issing[[:space:]]+\'?(action|query|command)\'?[[:space:]]+parameter ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 reply_has_codex_update_scheduler_memory_false_negative() {
   local normalized
   normalized="$(normalize_message_text "${1:-}")"
   [[ -n "$normalized" ]] || return 1
 
   case "$normalized" in
-    *"проверить по памяти/расписанию"*|*"Проверить по памяти/расписанию"*|*"инструмент поиска памяти"*|*"Инструмент поиска памяти"*|*"не вижу подтверждения, что такой крон"*|*"Не вижу подтверждения, что такой крон"*|*"подтвердить наличие такого крона я сейчас не могу"*|*"Подтвердить наличие такого крона я сейчас не могу"*|*"в памяти у меня явно записано"*|*"В памяти у меня явно записано"*|*"по сохранённой памяти ответ однозначный"*|*"По сохранённой памяти ответ однозначный"*|*"ежедневно проверяю стабильные обновления Codex CLI"*|*"Ежедневно проверяю стабильные обновления Codex CLI"*|*"Searching memory"*|*"missing 'query' parameter"*|*"missing 'action' parameter"*|*"missing 'command' parameter"*)
+    *"проверить по памяти/расписанию"*|*"Проверить по памяти/расписанию"*|*"инструмент поиска памяти"*|*"Инструмент поиска памяти"*|*"не вижу подтверждения, что такой крон"*|*"Не вижу подтверждения, что такой крон"*|*"подтвердить наличие такого крона я сейчас не могу"*|*"Подтвердить наличие такого крона я сейчас не могу"*|*"в памяти у меня явно записано"*|*"В памяти у меня явно записано"*|*"по сохранённой памяти ответ однозначный"*|*"По сохранённой памяти ответ однозначный"*|*"ежедневно проверяю стабильные обновления Codex CLI"*|*"Ежедневно проверяю стабильные обновления Codex CLI"*|*"Searching memory"*)
       return 0
       ;;
   esac
+
+  if reply_has_missing_parameter_family_leak "$normalized"; then
+    return 0
+  fi
 
   return 1
 }

--- a/scripts/telegram-e2e-on-demand.sh
+++ b/scripts/telegram-e2e-on-demand.sh
@@ -696,7 +696,7 @@ reply_has_codex_update_scheduler_memory_false_negative() {
   [[ -n "$normalized" ]] || return 1
 
   case "$normalized" in
-    *"проверить по памяти/расписанию"*|*"Проверить по памяти/расписанию"*|*"инструмент поиска памяти"*|*"Инструмент поиска памяти"*|*"не вижу подтверждения, что такой крон"*|*"Не вижу подтверждения, что такой крон"*|*"подтвердить наличие такого крона я сейчас не могу"*|*"Подтвердить наличие такого крона я сейчас не могу"*|*"Searching memory"*|*"missing 'query' parameter"*)
+    *"проверить по памяти/расписанию"*|*"Проверить по памяти/расписанию"*|*"инструмент поиска памяти"*|*"Инструмент поиска памяти"*|*"не вижу подтверждения, что такой крон"*|*"Не вижу подтверждения, что такой крон"*|*"подтвердить наличие такого крона я сейчас не могу"*|*"Подтвердить наличие такого крона я сейчас не могу"*|*"в памяти у меня явно записано"*|*"В памяти у меня явно записано"*|*"по сохранённой памяти ответ однозначный"*|*"По сохранённой памяти ответ однозначный"*|*"ежедневно проверяю стабильные обновления Codex CLI"*|*"Ежедневно проверяю стабильные обновления Codex CLI"*|*"Searching memory"*|*"missing 'query' parameter"*|*"missing 'action' parameter"*|*"missing 'command' parameter"*)
       return 0
       ;;
   esac
@@ -778,6 +778,58 @@ evaluate_authoritative_semantics() {
   skill_query_skills_json=""
   requested_skill_name=""
   runtime_skill_names='[]'
+
+  if message_is_codex_update_query "$normalized_message" && reply_has_codex_update_false_negative "$reply_text"; then
+    VERDICT="failed"
+    RUN_STAGE="semantic_review"
+    FAILURE_JSON="$(build_failure_json "semantic_codex_update_false_negative" "$RUN_STAGE" "Authoritative Codex update reply treated sandbox-invisible host paths as proof that the live skill was missing" "operator" true)"
+    DIAGNOSTIC_JSON="$(jq -cn \
+      --arg reply_text "$reply_text" \
+      --arg message "$normalized_message" \
+      --argjson base "$DIAGNOSTIC_JSON" \
+      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_false_negative"}}')"
+    RECOMMENDED_ACTION="Reconcile the Telegram prompt/skill contract so codex-update availability is not disproven via sandbox-invisible host paths, then rerun authoritative UAT."
+    return 0
+  fi
+
+  if message_is_codex_update_query "$normalized_message" && reply_has_codex_update_remote_contract_violation "$reply_text"; then
+    VERDICT="failed"
+    RUN_STAGE="semantic_review"
+    FAILURE_JSON="$(build_failure_json "semantic_codex_update_remote_contract_violation" "$RUN_STAGE" "Authoritative Codex update reply promised operator-only runtime execution or local-machine update behavior on a remote user-facing surface" "operator" true)"
+    DIAGNOSTIC_JSON="$(jq -cn \
+      --arg reply_text "$reply_text" \
+      --arg message "$normalized_message" \
+      --argjson base "$DIAGNOSTIC_JSON" \
+      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_remote_contract_violation"}}')"
+    RECOMMENDED_ACTION="Reconcile the remote codex-update contract so Telegram stays advisory-only and does not promise operator-only runtime execution, then rerun authoritative UAT."
+    return 0
+  fi
+
+  if message_is_codex_update_query "$normalized_message" && reply_has_codex_update_state_memory_false_negative "$reply_text"; then
+    VERDICT="failed"
+    RUN_STAGE="semantic_review"
+    FAILURE_JSON="$(build_failure_json "semantic_codex_update_state_memory_false_negative" "$RUN_STAGE" "Authoritative Codex update reply treated chat memory or generic unavailable text as proof that codex-update runtime state was absent" "operator" true)"
+    DIAGNOSTIC_JSON="$(jq -cn \
+      --arg reply_text "$reply_text" \
+      --arg message "$normalized_message" \
+      --argjson base "$DIAGNOSTIC_JSON" \
+      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_state_memory_false_negative"}}')"
+    RECOMMENDED_ACTION="Reconcile codex-update state queries so they read runtime state helper truth instead of memory-search fallbacks, then rerun authoritative UAT."
+    return 0
+  fi
+
+  if message_is_codex_update_scheduler_query "$normalized_message" && reply_has_codex_update_scheduler_memory_false_negative "$reply_text"; then
+    VERDICT="failed"
+    RUN_STAGE="semantic_review"
+    FAILURE_JSON="$(build_failure_json "semantic_codex_update_scheduler_memory_false_negative" "$RUN_STAGE" "Authoritative Codex update scheduler reply treated chat memory or broken memory-search behavior as evidence about live cron/scheduler state" "operator" true)"
+    DIAGNOSTIC_JSON="$(jq -cn \
+      --arg reply_text "$reply_text" \
+      --arg message "$normalized_message" \
+      --argjson base "$DIAGNOSTIC_JSON" \
+      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_scheduler_memory_false_negative"}}')"
+    RECOMMENDED_ACTION="Reconcile codex-update scheduler questions so Telegram answers from the remote-safe scheduler contract instead of drifting into memory/schedule speculation, then rerun authoritative UAT."
+    return 0
+  fi
 
   if reply_has_internal_activity "$reply_text"; then
     VERDICT="failed"
@@ -1037,58 +1089,6 @@ evaluate_authoritative_semantics() {
       RECOMMENDED_ACTION="Require the next Telegram visibility turn after create to mention the newly created live skill before treating the flow as green."
       return 0
     fi
-  fi
-
-  if message_is_codex_update_query "$normalized_message" && reply_has_codex_update_false_negative "$reply_text"; then
-    VERDICT="failed"
-    RUN_STAGE="semantic_review"
-    FAILURE_JSON="$(build_failure_json "semantic_codex_update_false_negative" "$RUN_STAGE" "Authoritative Codex update reply treated sandbox-invisible host paths as proof that the live skill was missing" "operator" true)"
-    DIAGNOSTIC_JSON="$(jq -cn \
-      --arg reply_text "$reply_text" \
-      --arg message "$normalized_message" \
-      --argjson base "$DIAGNOSTIC_JSON" \
-      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_false_negative"}}')"
-    RECOMMENDED_ACTION="Reconcile the Telegram prompt/skill contract so codex-update availability is not disproven via sandbox-invisible host paths, then rerun authoritative UAT."
-    return 0
-  fi
-
-  if message_is_codex_update_query "$normalized_message" && reply_has_codex_update_remote_contract_violation "$reply_text"; then
-    VERDICT="failed"
-    RUN_STAGE="semantic_review"
-    FAILURE_JSON="$(build_failure_json "semantic_codex_update_remote_contract_violation" "$RUN_STAGE" "Authoritative Codex update reply promised operator-only runtime execution or local-machine update behavior on a remote user-facing surface" "operator" true)"
-    DIAGNOSTIC_JSON="$(jq -cn \
-      --arg reply_text "$reply_text" \
-      --arg message "$normalized_message" \
-      --argjson base "$DIAGNOSTIC_JSON" \
-      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_remote_contract_violation"}}')"
-    RECOMMENDED_ACTION="Reconcile the remote codex-update contract so Telegram stays advisory-only and does not promise operator-only runtime execution, then rerun authoritative UAT."
-    return 0
-  fi
-
-  if message_is_codex_update_query "$normalized_message" && reply_has_codex_update_state_memory_false_negative "$reply_text"; then
-    VERDICT="failed"
-    RUN_STAGE="semantic_review"
-    FAILURE_JSON="$(build_failure_json "semantic_codex_update_state_memory_false_negative" "$RUN_STAGE" "Authoritative Codex update reply treated chat memory or generic unavailable text as proof that codex-update runtime state was absent" "operator" true)"
-    DIAGNOSTIC_JSON="$(jq -cn \
-      --arg reply_text "$reply_text" \
-      --arg message "$normalized_message" \
-      --argjson base "$DIAGNOSTIC_JSON" \
-      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_state_memory_false_negative"}}')"
-    RECOMMENDED_ACTION="Reconcile codex-update state queries so they read runtime state helper truth instead of memory-search fallbacks, then rerun authoritative UAT."
-    return 0
-  fi
-
-  if message_is_codex_update_scheduler_query "$normalized_message" && reply_has_codex_update_scheduler_memory_false_negative "$reply_text"; then
-    VERDICT="failed"
-    RUN_STAGE="semantic_review"
-    FAILURE_JSON="$(build_failure_json "semantic_codex_update_scheduler_memory_false_negative" "$RUN_STAGE" "Authoritative Codex update scheduler reply treated chat memory or broken memory-search behavior as evidence about live cron/scheduler state" "operator" true)"
-    DIAGNOSTIC_JSON="$(jq -cn \
-      --arg reply_text "$reply_text" \
-      --arg message "$normalized_message" \
-      --argjson base "$DIAGNOSTIC_JSON" \
-      '$base + {semantic_review:{message:$message, observed_reply:$reply_text, failure:"semantic_codex_update_scheduler_memory_false_negative"}}')"
-    RECOMMENDED_ACTION="Reconcile codex-update scheduler questions so Telegram answers from the remote-safe scheduler contract instead of drifting into memory/schedule speculation, then rerun authoritative UAT."
-    return 0
   fi
 
   if reply_has_host_path_leak "$reply_text"; then

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -3603,7 +3603,10 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             fi
             codex_update_reply_text="$(build_codex_update_reply_text "$codex_update_reply_mode" || true)"
             if [[ -n "$codex_update_reply_text" ]] && direct_fastpath_send_with_suppression "codex_update" "$telegram_chat_id" "$codex_update_reply_text" "codex_update:${codex_update_reply_mode}" "mode=$codex_update_reply_mode"; then
-                clear_turn_intent "${turn_session_key:-}"
+                if ! persist_terminal_marker "${turn_session_key:-}" "$codex_update_reply_mode"; then
+                    write_audit_line "codex_update_direct_fastpath_terminal_marker_fallback token=$codex_update_reply_mode"
+                fi
+                write_audit_line "codex_update_direct_fastpath_fallback_state_preserved mode=$codex_update_reply_mode"
                 exit 0
             fi
         fi

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -54,7 +54,7 @@ const headed = hasFlag("--headed");
 const debug = hasFlag("--debug");
 
 const ERROR_RE =
-  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'action'\s+parameter)/i;
+  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'(?:action|query|command)'\s+parameter)/i;
 const SENSITIVE_RE = /\b(api[_ -]?key|token|password|secret)\b/i;
 
 let stage = "login";

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -54,7 +54,7 @@ const headed = hasFlag("--headed");
 const debug = hasFlag("--debug");
 
 const ERROR_RE =
-  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'(?:action|query|command)'\s+parameter)/i;
+  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'?(?:action|query|command)'?\s+parameter)/i;
 const SENSITIVE_RE = /\b(api[_ -]?key|token|password|secret)\b/i;
 
 let stage = "login";

--- a/tests/component/test_telegram_remote_uat_contract.sh
+++ b/tests/component/test_telegram_remote_uat_contract.sh
@@ -745,6 +745,38 @@ JSON
   exit 0
 fi
 
+if [[ "$mode" == "codex_update_scheduler_memory_positive_false_positive_pass" ]]; then
+  cat <<'JSON'
+{
+  "ok": true,
+  "status": "pass",
+  "stage": "wait_reply",
+  "reply_text": "Да — есть. В памяти у меня явно записано: «Ежедневно проверяю стабильные обновления Codex CLI и присылаю краткое уведомление только если вышла новая стабильная версия.» cron list снова вернул missing 'action' parameter, memory_search — missing 'query' parameter, exec — missing 'command' parameter.",
+  "reply_mid": 42,
+  "sent_mid": 41,
+  "checks": {
+    "non_empty": true,
+    "min_length": true,
+    "reply_settled": true,
+    "error_signature_clean": true,
+    "sensitive_signature_clean": true
+  },
+  "failures": [],
+  "attribution_evidence": {
+    "attribution_confidence": "proven"
+  },
+  "diagnostic_context": {
+    "stats": {
+      "url": "https://web.telegram.org/k/#@moltinger_bot",
+      "hasSearch": true
+    }
+  },
+  "recommended_action": "Authoritative Telegram Web path passed; no secondary diagnostics are needed."
+}
+JSON
+  exit 0
+fi
+
 if [[ "$mode" == "codex_update_scheduler_contract_safe_pass" ]]; then
   cat <<'JSON'
 {
@@ -1612,6 +1644,24 @@ run_component_telegram_remote_uat_contract_tests() {
             test_pass
         else
             test_fail "Wrapper must surface codex-update scheduler replies that substitute memory-search speculation for the remote-safe scheduler contract"
+        fi
+    fi
+
+    test_start "component_telegram_remote_uat_fails_codex_update_scheduler_memory_positive_false_positive_even_if_helper_passes"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_memory_positive_false_positive_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-memory-positive.json" \
+        >/dev/null 2>&1
+    then
+        test_fail "Authoritative wrapper must fail when codex-update scheduler questions are answered from chat-memory assertions or leaked tool errors even if the helper claims success"
+    else
+        if jq -e '.failure.code == "semantic_codex_update_scheduler_memory_false_negative" and .run.stage == "semantic_review"' "$TEST_TMPDIR/result-codex-update-scheduler-memory-positive.json" >/dev/null 2>&1
+        then
+            test_pass
+        else
+            test_fail "Wrapper must classify memory-asserted codex-update scheduler claims as the same semantic scheduler-contract failure"
         fi
     fi
 

--- a/tests/component/test_telegram_remote_uat_contract.sh
+++ b/tests/component/test_telegram_remote_uat_contract.sh
@@ -777,6 +777,102 @@ JSON
   exit 0
 fi
 
+if [[ "$mode" == "codex_update_scheduler_memory_action_unquoted_false_positive_pass" ]]; then
+  cat <<'JSON'
+{
+  "ok": true,
+  "status": "pass",
+  "stage": "wait_reply",
+  "reply_text": "Да — есть. В памяти у меня явно записано: «Ежедневно проверяю стабильные обновления Codex CLI и присылаю краткое уведомление только если вышла новая стабильная версия.» cron list снова вернул missing action parameter.",
+  "reply_mid": 42,
+  "sent_mid": 41,
+  "checks": {
+    "non_empty": true,
+    "min_length": true,
+    "reply_settled": true,
+    "error_signature_clean": true,
+    "sensitive_signature_clean": true
+  },
+  "failures": [],
+  "attribution_evidence": {
+    "attribution_confidence": "proven"
+  },
+  "diagnostic_context": {
+    "stats": {
+      "url": "https://web.telegram.org/k/#@moltinger_bot",
+      "hasSearch": true
+    }
+  },
+  "recommended_action": "Authoritative Telegram Web path passed; no secondary diagnostics are needed."
+}
+JSON
+  exit 0
+fi
+
+if [[ "$mode" == "codex_update_scheduler_memory_query_unquoted_false_positive_pass" ]]; then
+  cat <<'JSON'
+{
+  "ok": true,
+  "status": "pass",
+  "stage": "wait_reply",
+  "reply_text": "Да — есть. В памяти у меня явно записано: «Ежедневно проверяю стабильные обновления Codex CLI и присылаю краткое уведомление только если вышла новая стабильная версия.» memory_search снова вернул missing query parameter.",
+  "reply_mid": 42,
+  "sent_mid": 41,
+  "checks": {
+    "non_empty": true,
+    "min_length": true,
+    "reply_settled": true,
+    "error_signature_clean": true,
+    "sensitive_signature_clean": true
+  },
+  "failures": [],
+  "attribution_evidence": {
+    "attribution_confidence": "proven"
+  },
+  "diagnostic_context": {
+    "stats": {
+      "url": "https://web.telegram.org/k/#@moltinger_bot",
+      "hasSearch": true
+    }
+  },
+  "recommended_action": "Authoritative Telegram Web path passed; no secondary diagnostics are needed."
+}
+JSON
+  exit 0
+fi
+
+if [[ "$mode" == "codex_update_scheduler_memory_command_unquoted_false_positive_pass" ]]; then
+  cat <<'JSON'
+{
+  "ok": true,
+  "status": "pass",
+  "stage": "wait_reply",
+  "reply_text": "Да — есть. В памяти у меня явно записано: «Ежедневно проверяю стабильные обновления Codex CLI и присылаю краткое уведомление только если вышла новая стабильная версия.» exec снова вернул missing command parameter.",
+  "reply_mid": 42,
+  "sent_mid": 41,
+  "checks": {
+    "non_empty": true,
+    "min_length": true,
+    "reply_settled": true,
+    "error_signature_clean": true,
+    "sensitive_signature_clean": true
+  },
+  "failures": [],
+  "attribution_evidence": {
+    "attribution_confidence": "proven"
+  },
+  "diagnostic_context": {
+    "stats": {
+      "url": "https://web.telegram.org/k/#@moltinger_bot",
+      "hasSearch": true
+    }
+  },
+  "recommended_action": "Authoritative Telegram Web path passed; no secondary diagnostics are needed."
+}
+JSON
+  exit 0
+fi
+
 if [[ "$mode" == "codex_update_scheduler_contract_safe_pass" ]]; then
   cat <<'JSON'
 {
@@ -1662,6 +1758,60 @@ run_component_telegram_remote_uat_contract_tests() {
             test_pass
         else
             test_fail "Wrapper must classify memory-asserted codex-update scheduler claims as the same semantic scheduler-contract failure"
+        fi
+    fi
+
+    test_start "component_telegram_remote_uat_fails_codex_update_scheduler_action_unquoted_false_positive_even_if_helper_passes"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_memory_action_unquoted_false_positive_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-action-unquoted.json" \
+        >/dev/null 2>&1
+    then
+        test_fail "Authoritative wrapper must fail when codex-update scheduler replies leak an unquoted missing action parameter variant"
+    else
+        if jq -e '.failure.code == "semantic_codex_update_scheduler_memory_false_negative" and .run.stage == "semantic_review"' "$TEST_TMPDIR/result-codex-update-scheduler-action-unquoted.json" >/dev/null 2>&1
+        then
+            test_pass
+        else
+            test_fail "Wrapper must classify unquoted missing action parameter replies as the same semantic scheduler-contract failure"
+        fi
+    fi
+
+    test_start "component_telegram_remote_uat_fails_codex_update_scheduler_query_unquoted_false_positive_even_if_helper_passes"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_memory_query_unquoted_false_positive_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-query-unquoted.json" \
+        >/dev/null 2>&1
+    then
+        test_fail "Authoritative wrapper must fail when codex-update scheduler replies leak an unquoted missing query parameter variant"
+    else
+        if jq -e '.failure.code == "semantic_codex_update_scheduler_memory_false_negative" and .run.stage == "semantic_review"' "$TEST_TMPDIR/result-codex-update-scheduler-query-unquoted.json" >/dev/null 2>&1
+        then
+            test_pass
+        else
+            test_fail "Wrapper must classify unquoted missing query parameter replies as the same semantic scheduler-contract failure"
+        fi
+    fi
+
+    test_start "component_telegram_remote_uat_fails_codex_update_scheduler_command_unquoted_false_positive_even_if_helper_passes"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_memory_command_unquoted_false_positive_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-command-unquoted.json" \
+        >/dev/null 2>&1
+    then
+        test_fail "Authoritative wrapper must fail when codex-update scheduler replies leak an unquoted missing command parameter variant"
+    else
+        if jq -e '.failure.code == "semantic_codex_update_scheduler_memory_false_negative" and .run.stage == "semantic_review"' "$TEST_TMPDIR/result-codex-update-scheduler-command-unquoted.json" >/dev/null 2>&1
+        then
+            test_pass
+        else
+            test_fail "Wrapper must classify unquoted missing command parameter replies as the same semantic scheduler-contract failure"
         fi
     fi
 

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -347,6 +347,103 @@ EOF
         test_fail "When direct fastpath is enabled, codex-update scheduler turns must use the same Bot API delivery contract as the other live-proven Telegram-safe routes and arm same-turn suppression markers"
     fi
 
+    test_start "component_codex_update_direct_fastpath_preserves_terminal_fallback_state_if_suppression_is_lost"
+    local fastpath_codex_recovery_tmp fastpath_codex_recovery_send_script fastpath_codex_recovery_log fastpath_codex_recovery_stdout fastpath_codex_recovery_stderr
+    local fastpath_codex_recovery_status fastpath_codex_recovery_intent_dir fastpath_codex_recovery_session_suppress fastpath_codex_recovery_chat_suppress
+    local fastpath_codex_recovery_intent_file fastpath_codex_recovery_terminal_file fastpath_codex_recovery_tool_output fastpath_codex_recovery_send_output
+    local fastpath_codex_recovery_intent_present_after_fastpath fastpath_codex_recovery_terminal_present_after_fastpath
+    fastpath_codex_recovery_tmp="$(secure_temp_dir telegram-safe-fastpath-codex-recovery)"
+    fastpath_codex_recovery_send_script="$fastpath_codex_recovery_tmp/send.sh"
+    fastpath_codex_recovery_log="$fastpath_codex_recovery_tmp/send.log"
+    fastpath_codex_recovery_intent_dir="$fastpath_codex_recovery_tmp/intent"
+    fastpath_codex_recovery_session_suppress="$fastpath_codex_recovery_intent_dir/session_fastcodexrecovery.suppress"
+    fastpath_codex_recovery_chat_suppress="$fastpath_codex_recovery_intent_dir/chat-262872987.suppress"
+    fastpath_codex_recovery_intent_file="$fastpath_codex_recovery_intent_dir/session_fastcodexrecovery.intent"
+    fastpath_codex_recovery_terminal_file="$fastpath_codex_recovery_intent_dir/session_fastcodexrecovery.terminal"
+    cat >"$fastpath_codex_recovery_send_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+chat_id=""
+text=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chat-id)
+            chat_id="${2:-}"
+            shift 2
+            ;;
+        --text)
+            text="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf 'chat_id=%s\ntext=%s\n' "$chat_id" "$text" >"$FASTPATH_LOG"
+printf '{"ok":true}\n'
+EOF
+    chmod +x "$fastpath_codex_recovery_send_script"
+    fastpath_codex_recovery_stdout="$fastpath_codex_recovery_tmp/stdout.log"
+    fastpath_codex_recovery_stderr="$fastpath_codex_recovery_tmp/stderr.log"
+    set +e
+    env PATH="$MINIMAL_PATH" \
+        FASTPATH_LOG="$fastpath_codex_recovery_log" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$fastpath_codex_recovery_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_codex_recovery_send_script" \
+        MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
+        bash "$HOOK_HANDLER" >"$fastpath_codex_recovery_stdout" 2>"$fastpath_codex_recovery_stderr" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastcodexrecovery","provider":"openai-codex","model":"gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872987 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?"}],"tool_count":37,"iteration":1}}
+EOF
+    fastpath_codex_recovery_status=$?
+    set -e
+    if [[ -f "$fastpath_codex_recovery_intent_file" ]]; then
+        fastpath_codex_recovery_intent_present_after_fastpath=true
+    else
+        fastpath_codex_recovery_intent_present_after_fastpath=false
+    fi
+    if [[ -f "$fastpath_codex_recovery_terminal_file" ]]; then
+        fastpath_codex_recovery_terminal_present_after_fastpath=true
+    else
+        fastpath_codex_recovery_terminal_present_after_fastpath=false
+    fi
+    rm -f "$fastpath_codex_recovery_session_suppress" "$fastpath_codex_recovery_chat_suppress"
+    fastpath_codex_recovery_tool_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$fastpath_codex_recovery_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeToolCall","session_key":"session:fastcodexrecovery","provider":"openai-codex","model":"gpt-5.4","tool":"cron","arguments":{"action":"list"}}
+EOF
+    )"
+    fastpath_codex_recovery_send_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$fastpath_codex_recovery_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:fastcodexrecovery","data":{"account_id":"moltis-bot","to":"262872987","reply_to_message_id":1407,"text":"Да — есть.\n\nВ памяти у меня явно записано:\n«Ежедневно проверяю стабильные обновления Codex CLI и присылаю краткое уведомление только если вышла новая стабильная версия.»\n\n📋 Activity log\n• 🔧 cron\n• 💻 Running: `grep -RIn \"codex\\|Codex\\|cron\\|schedule\" /home/mol...`\n• 🧠 Searching memory...\n•   ❌ missing 'action' parameter\n•   ❌ missing 'query' parameter\n•   ❌ missing 'command' parameter"}}
+EOF
+    )"
+    if [[ "$fastpath_codex_recovery_status" -eq 0 ]] && \
+       [[ ! -s "$fastpath_codex_recovery_stderr" ]] && \
+       [[ ! -s "$fastpath_codex_recovery_stdout" ]] && \
+       [[ "$fastpath_codex_recovery_intent_present_after_fastpath" == true ]] && \
+       [[ "$fastpath_codex_recovery_terminal_present_after_fastpath" == true ]] && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_tool_output" && \
+       jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_tool_output" && \
+       jq -e '.data.arguments.command | contains("codex-update turn already resolved")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_tool_output" && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
+       jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
+       jq -e '.data.text | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
+       jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
+       jq -e '.data.text | test("Activity log|Searching memory|missing '\''action'\'' parameter|missing '\''query'\'' parameter|missing '\''command'\'' parameter|в памяти у меня явно записано|Ежедневно проверяю стабильные обновления Codex CLI") | not' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output"; then
+        test_pass
+    else
+        test_fail "Codex-update direct fastpath must keep terminal fallback state so a lost suppression marker still blocks late tools and rewrites memory-based false positives into the deterministic scheduler contract"
+    fi
+
     test_start "component_before_llm_guard_keeps_status_precedence_over_codex_update_direct_fastpath_on_mixed_turn"
     local mixed_status_codex_tmp mixed_status_codex_send_script mixed_status_codex_log mixed_status_codex_stdout mixed_status_codex_stderr mixed_status_codex_status mixed_status_codex_intent_dir mixed_status_codex_session_suppress mixed_status_codex_chat_suppress
     mixed_status_codex_tmp="$(secure_temp_dir telegram-safe-mixed-status-codex)"

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -350,8 +350,8 @@ EOF
     test_start "component_codex_update_direct_fastpath_preserves_terminal_fallback_state_if_suppression_is_lost"
     local fastpath_codex_recovery_tmp fastpath_codex_recovery_send_script fastpath_codex_recovery_log fastpath_codex_recovery_stdout fastpath_codex_recovery_stderr
     local fastpath_codex_recovery_status fastpath_codex_recovery_intent_dir fastpath_codex_recovery_session_suppress fastpath_codex_recovery_chat_suppress
-    local fastpath_codex_recovery_intent_file fastpath_codex_recovery_terminal_file fastpath_codex_recovery_tool_output fastpath_codex_recovery_send_output
-    local fastpath_codex_recovery_intent_present_after_fastpath fastpath_codex_recovery_terminal_present_after_fastpath
+    local fastpath_codex_recovery_intent_file fastpath_codex_recovery_terminal_file fastpath_codex_recovery_after_output fastpath_codex_recovery_tool_output fastpath_codex_recovery_send_output
+    local fastpath_codex_recovery_intent_present_after_fastpath fastpath_codex_recovery_terminal_present_after_fastpath fastpath_codex_recovery_terminal_present_after_after
     fastpath_codex_recovery_tmp="$(secure_temp_dir telegram-safe-fastpath-codex-recovery)"
     fastpath_codex_recovery_send_script="$fastpath_codex_recovery_tmp/send.sh"
     fastpath_codex_recovery_log="$fastpath_codex_recovery_tmp/send.log"
@@ -410,6 +410,19 @@ EOF
         fastpath_codex_recovery_terminal_present_after_fastpath=false
     fi
     rm -f "$fastpath_codex_recovery_session_suppress" "$fastpath_codex_recovery_chat_suppress"
+    fastpath_codex_recovery_after_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$fastpath_codex_recovery_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","session_key":"session:fastcodexrecovery","provider":"openai-codex","model":"gpt-5.4","text":"Проверил — и да, тут инструмент расписания реально сломан: на list он снова ответил missing action parameter.","tool_calls":[{"name":"cron","arguments":{"action":"list"}}]}
+EOF
+    )"
+    if [[ -f "$fastpath_codex_recovery_terminal_file" ]]; then
+        fastpath_codex_recovery_terminal_present_after_after=true
+    else
+        fastpath_codex_recovery_terminal_present_after_after=false
+    fi
     fastpath_codex_recovery_tool_output="$(
         env PATH="$MINIMAL_PATH" \
             MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
@@ -431,6 +444,10 @@ EOF
        [[ ! -s "$fastpath_codex_recovery_stdout" ]] && \
        [[ "$fastpath_codex_recovery_intent_present_after_fastpath" == true ]] && \
        [[ "$fastpath_codex_recovery_terminal_present_after_fastpath" == true ]] && \
+       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_after_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_after_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_after_output" && \
+       [[ "$fastpath_codex_recovery_terminal_present_after_after" == true ]] && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_tool_output" && \
        jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_tool_output" && \
        jq -e '.data.arguments.command | contains("codex-update turn already resolved")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_tool_output" && \
@@ -438,10 +455,10 @@ EOF
        jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
        jq -e '.data.text | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
        jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output" && \
-       jq -e '.data.text | test("Activity log|Searching memory|missing '\''action'\'' parameter|missing '\''query'\'' parameter|missing '\''command'\'' parameter|в памяти у меня явно записано|Ежедневно проверяю стабильные обновления Codex CLI") | not' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output"; then
+       jq -e '.data.text | test("Activity log|Searching memory|missing '\''action'\'' parameter|missing '\''query'\'' parameter|missing '\''command'\'' parameter|missing action parameter|missing query parameter|missing command parameter|в памяти у меня явно записано|Ежедневно проверяю стабильные обновления Codex CLI") | not' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_send_output"; then
         test_pass
     else
-        test_fail "Codex-update direct fastpath must keep terminal fallback state so a lost suppression marker still blocks late tools and rewrites memory-based false positives into the deterministic scheduler contract"
+        test_fail "Codex-update direct fastpath must keep terminal fallback state so a lost suppression marker still blanks the first late AfterLLMCall, blocks late tools, and rewrites memory-based false positives into the deterministic scheduler contract"
     fi
 
     test_start "component_before_llm_guard_keeps_status_precedence_over_codex_update_direct_fastpath_on_mixed_turn"

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -339,6 +339,7 @@ import process from "node:process";
 const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
 const badReplies = [
   "Activity log • nodes_list • sessions_list • cron • missing 'action' parameter",
+  "cron list снова вернул missing 'action' parameter, memory_search — missing 'query' parameter, exec — missing 'command' parameter",
   "Timed out: Agent run timed out after 90s"
 ];
 const goodReply = "Я на месте. - Имя: Молтингер - Пользователь: Сергей - Модель: custom-zai-telegram-safe::glm-5";

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -358,6 +358,48 @@ NODE
         test_fail "Activity-log timeout summaries must be rejected by reply-quality checks"
     fi
 
+    test_start "component_telegram_web_probe_marks_unquoted_missing_action_parameter_as_error_signature"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
+if (!isReplyErrorSignature("cron list снова вернул missing action parameter")) {
+  throw new Error("expected unquoted missing action parameter to be rejected");
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Unquoted missing action parameter replies must be rejected by reply-quality checks"
+    fi
+
+    test_start "component_telegram_web_probe_marks_unquoted_missing_query_parameter_as_error_signature"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
+if (!isReplyErrorSignature("memory_search снова вернул missing query parameter")) {
+  throw new Error("expected unquoted missing query parameter to be rejected");
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Unquoted missing query parameter replies must be rejected by reply-quality checks"
+    fi
+
+    test_start "component_telegram_web_probe_marks_unquoted_missing_command_parameter_as_error_signature"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
+if (!isReplyErrorSignature("exec снова вернул missing command parameter")) {
+  throw new Error("expected unquoted missing command parameter to be rejected");
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Unquoted missing command parameter replies must be rejected by reply-quality checks"
+    fi
+
     test_start "component_telegram_web_probe_rejects_emoji_prefixed_internal_telemetry_replies"
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";


### PR DESCRIPTION
## Summary
- preserve codex-update fallback intent/terminal state after direct fastpath send
- harden authoritative Telegram semantic review for scheduler memory-proof false positives
- record RCA and add regressions for the new live reply variant

## Validation
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_remote_uat_contract.sh
- bash tests/component/test_telegram_web_probe_correlation.sh
- bash -n scripts/telegram-safe-llm-guard.sh
- bash -n scripts/telegram-e2e-on-demand.sh