### PR TITLE
fix(worktree): harden cleanup merge proof and fallback

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-04-14
-**Total Lessons**: 77
+**Generated**: 2026-04-15
+**Total Lessons**: 78
 
 ---
 
@@ -53,7 +53,8 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (23 lessons)
+#### P2 (24 lessons)
+- [Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard](../docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md)
 - [Telegram skill-detail remained non-terminal and repo skills lacked a shared Telegram-safe summary contract](../docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md)
 - [Tracked deploy empty stdout broke GitHub Actions JSON contract](../docs/rca/2026-04-02-tracked-deploy-empty-stdout-broke-json-contract.md)
 - [Deploy stall watchdog self-failed on oversized GitHub Actions payloads](../docs/rca/2026-03-28-deploy-stall-watchdog-argjson-overflow.md)
@@ -193,11 +194,14 @@
 - [Child worktree reconciliation renames authoritative feature worktree](../docs/rca/2026-03-08-topology-child-worktree-identity-drift.md)
 - [Команда false завершилась с кодом 1](../docs/rca/2026-03-07-false-command-exit-code.md)
 
+#### tooling (1 lessons)
+- [Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard](../docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md)
+
 
 ### Popular Tags
 
+- `rca` (26 lessons)
 - `moltis` (26 lessons)
-- `rca` (25 lessons)
 - `telegram` (20 lessons)
 - `deploy` (19 lessons)
 - `github-actions` (17 lessons)
@@ -214,10 +218,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 77 |
+| Total Lessons | 78 |
 | Critical (P0/P1) | 38 |
-| Categories | 7 |
-| Unique Tags | 157 |
+| Categories | 8 |
+| Unique Tags | 160 |
 
 ---
 

--- a/docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md
+++ b/docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md
@@ -105,8 +105,10 @@ safety check failed: worktree has unpushed commits. Use --force to skip safety c
    - добавлен controlled fallback:
      - сначала authoritative merge proof через `resolve_cleanup_merge_proof`
      - затем direct `git worktree remove <path>` только для clean merged worktree
-   - cleanup теперь fail-closed блокирует конфликтующие `--path` + `--branch`, если они указывают на разные worktree/branch targets
-   - `resolve_cleanup_merge_proof` теперь refreshes remote refs before git-proof, предпочитает live remote proof, использует local proof только когда live remote branch отсутствует и на GitHub-origin умеет спрашивать current branch head через `gh api`, если git refresh недоступен
+   - cleanup теперь сравнивает `--path` targets alias-safe и fail-closed блокирует конфликтующие `--path` + `--branch`, если они не доказываются как один и тот же worktree/branch target
+   - GitHub fallback теперь URL-encode'ит branch ref segments для `gh api`, чтобы ветки вида `feat/...` не ломали live branch-head proof и remote-delete fallback
+   - `resolve_cleanup_merge_proof` теперь refreshes remote refs before git-proof, предпочитает live remote proof, использует local proof только когда live remote branch отсутствует, а при failed refresh допускает только local-only proof для worktree removal fallback; branch deletion при этом остаётся blocked до восстановления remote proof
+   - git-only fallback теперь дополнительно проверяет, не осталась ли worktree запись в `bd worktree list`, и в таком случае явно отдаёт reconciliation step вместо молчаливого governance drift
 2. `tests/unit/test_worktree_ready.sh`
    - добавлен positive regression:
      - merged clean worktree
@@ -120,6 +122,9 @@ safety check failed: worktree has unpushed commits. Use --force to skip safety c
       - dirty worktree
       - конфликт `--path`/`--branch`
       - stale remote branch, ушедшую вперёд в другом clone
+      - failed remote refresh с local-only fallback для worktree removal
+      - failed remote refresh, который всё ещё блокирует branch delete
+      - encoded GitHub API routes для slash branch names
 
 ## Prevention
 
@@ -127,8 +132,9 @@ safety check failed: worktree has unpushed commits. Use --force to skip safety c
 2. Для destructive-ish hygiene actions fallback допустим только после двух условий:
    - worktree clean
    - merged proof установлен авторитетно
-3. Если user передал и `--path`, и `--branch`, helper должен доказывать, что они указывают на один и тот же target, иначе cleanup обязан fail-closed.
-4. Negative regression обязательна рядом с positive fallback regression, чтобы workaround не превратился в unsafe bypass.
+3. Если user передал и `--path`, и `--branch`, helper должен сравнивать не только синтаксический path string, но и physical path identity; иначе alias/symlink path будет либо ложным blocker, либо потенциальным cleanup ambiguity.
+4. Local-only merged proof допустим только для worktree removal, но не для branch deletion, если remote refresh недоступен.
+5. Negative regression обязательна рядом с positive fallback regression, чтобы workaround не превратился в unsafe bypass или скрытый governance drift.
 
 ## Уроки
 

--- a/docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md
+++ b/docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md
@@ -1,0 +1,137 @@
+---
+title: "Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard"
+date: 2026-04-15
+severity: P2
+category: tooling
+tags: [worktree, cleanup, beads, git, stale-upstream, rca]
+root_cause: "The repo-owned cleanup helper trusted lower-layer cleanup signals and local branch inputs too early: it treated `bd worktree remove` stale-upstream `unpushed commits` as authoritative, allowed CLI `--branch` to outrank the actual worktree record, and relied on stale local refs for merge safety instead of refreshing remote state before destructive cleanup decisions."
+---
+
+# RCA: Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard
+
+Date: 2026-04-15  
+Status: Resolved in source, pending review/merge/deploy  
+Context: beads `moltinger-tc52`, follow-up after worktree hygiene cleanup in canonical `main`
+
+## Ошибка
+
+Во время cleanup лишних worktree repo-owned helper:
+
+```bash
+scripts/worktree-ready.sh cleanup --path <worktree> --delete-branch
+```
+
+ложно вернул `cleanup_blocked` для clean branch/worktree, который уже был полностью поглощён `origin/main`.
+
+Фактический manual proof был таким:
+
+- `git rev-list --left-right --count origin/main...<branch>` показывал `behind-only`, `ahead=0`
+- `git merge-base --is-ancestor <branch> origin/main` был истинным
+- manual `git worktree remove` + `git branch -d` проходили успешно
+
+Тем не менее helper остановился на сообщении вида:
+
+```text
+safety check failed: worktree has unpushed commits. Use --force to skip safety checks.
+```
+
+## Проверка прошлых уроков
+
+Проверены:
+
+- `rg -n "worktree-ready|cleanup_blocked|worktree cleanup|stale upstream" docs/rca docs/LESSONS-LEARNED.md -S`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Релевантные прошлые RCA:
+
+1. `docs/rca/2026-03-28-worktree-create-helper-and-hook-bootstrap-source-drift.md`
+   - уже фиксировал, что repo-owned worktree helper нельзя считать непререкаемым truth layer, если его source contract оказался уже реальности.
+2. `docs/rca/2026-03-26-worktree-create-misread-local-ownership-as-runtime-ready.md`
+   - уже показывал, что worktree workflow должен доуточнять состояние отдельными проверками, а не слепо склеивать один промежуточный verdict в окончательное решение.
+
+Что оказалось новым:
+
+- cleanup path по-прежнему считал ответ `bd worktree remove` окончательным verdict даже тогда, когда git ancestry уже доказывала merged-safe состояние branch/worktree;
+- stale или `[gone]` upstream metadata в нижнем слое могла породить ложный `unpushed commits` guard и заблокировать весь cleanup flow;
+- у helper не было controlled fallback на direct git removal для clean merged worktree.
+
+## Evidence
+
+Собранная evidence:
+
+1. `scripts/worktree-ready.sh cleanup --path ... --delete-branch` вернул `cleanup_blocked` с warning про `unpushed commits`.
+2. Branch был behind-only относительно `origin/main`, то есть:
+   - `ahead = 0`
+   - commit tip branch уже входил в `origin/main`
+3. Manual cleanup через:
+   - `git worktree remove <path>`
+   - `git branch -d <branch>`
+   прошёл без потери данных.
+4. Повторная локальная репродукция в unit-тесте показала тот же класс сбоя:
+   - fake `bd worktree remove` возвращает stale-upstream `unpushed commits`
+   - branch/worktree clean
+   - branch merged into `origin/main`
+   - helper до фикса оставался blocked
+
+## 5 Whys
+
+| Why | Ответ | Доказательство |
+| --- | --- | --- |
+| 1 | Почему cleanup helper заблокировал safe merged worktree? | Потому что `bd worktree remove` вернул guard про `unpushed commits`, и helper принял его за окончательный blocker. | live cleanup output |
+| 2 | Почему этот guard был ложным? | Потому что branch был не ahead, а behind-only: его tip уже был предком `origin/main`. | `git rev-list --left-right --count`, `git merge-base --is-ancestor` |
+| 3 | Почему helper не смог отличить ложный guard от реального риска? | Потому что cleanup path не делал второй authoritative merge-safety check после отказа нижнего слоя. | `execute_cleanup_worktree_action()` до фикса |
+| 4 | Почему при известном merged-safe состоянии не было fallback на direct git removal? | Потому что helper делегировал remove только через `bd worktree remove` и не имел controlled direct-git branch для clean merged worktree. | `scripts/worktree-ready.sh` до фикса |
+| 5 | Почему это стало operator-visible дефектом? | Потому что repo-owned helper не содержал ложный negative из нижнего слоя и заставил оператора обходить cleanup вручную. | реальный cleanup cycle + ручной обход |
+
+## Root Cause
+
+Корневая причина была не в самом факте stale upstream metadata и не в git topology.
+
+Корневая причина была в repo-owned `worktree-ready` cleanup contract:
+
+- helper целиком доверял verdict `bd worktree remove`;
+- helper не проверял, не является ли этот `unpushed commits` guard ложным negative для merged clean worktree;
+- helper позволял raw CLI `--branch` пережить discovery об actual target worktree;
+- helper не освежал remote refs перед merge proof и поэтому мог опираться на stale local branch state;
+- helper не имел safe fallback на `git worktree remove`, когда authoritative merge proof уже доказывала отсутствие риска.
+
+Именно поэтому stale/[gone] upstream state из нижнего слоя эскалировалась в operator-visible cleanup blocker.
+
+## Fixes Applied
+
+1. `scripts/worktree-ready.sh`
+   - добавлен детектор stale-upstream false guard по output family `safety check failed` + `unpushed commit`
+   - добавлена clean-worktree проверка через `git status --short`
+   - добавлен controlled fallback:
+     - сначала authoritative merge proof через `resolve_cleanup_merge_proof`
+     - затем direct `git worktree remove <path>` только для clean merged worktree
+   - cleanup теперь fail-closed блокирует конфликтующие `--path` + `--branch`, если они указывают на разные worktree/branch targets
+   - `resolve_cleanup_merge_proof` теперь refreshes remote refs before git-proof, предпочитает live remote proof, использует local proof только когда live remote branch отсутствует и на GitHub-origin умеет спрашивать current branch head через `gh api`, если git refresh недоступен
+2. `tests/unit/test_worktree_ready.sh`
+   - добавлен positive regression:
+     - merged clean worktree
+     - fake `bd worktree remove` ложно падает с `unpushed commits`
+     - helper завершает cleanup через direct git fallback
+   - добавлен negative regression:
+     - branch не merged
+     - тот же fake `unpushed commits`
+     - helper остаётся blocked и ничего не удаляет
+   - добавлены safety regressions на:
+      - dirty worktree
+      - конфликт `--path`/`--branch`
+      - stale remote branch, ушедшую вперёд в другом clone
+
+## Prevention
+
+1. Repo-owned cleanup helper не должен считать один stale lower-layer guard окончательной истиной, если git может дать более надёжный merged proof.
+2. Для destructive-ish hygiene actions fallback допустим только после двух условий:
+   - worktree clean
+   - merged proof установлен авторитетно
+3. Если user передал и `--path`, и `--branch`, helper должен доказывать, что они указывают на один и тот же target, иначе cleanup обязан fail-closed.
+4. Negative regression обязательна рядом с positive fallback regression, чтобы workaround не превратился в unsafe bypass.
+
+## Уроки
+
+1. `unpushed commits` от нижнего слоя — это hypothesis, а не окончательная истина, если authoritative git ancestry уже говорит `behind-only`.
+2. В worktree cleanup path merge proof важнее stale tracking metadata.
+3. Если repo-owned helper даёт ложный blocker, это отдельный defect owning layer и его надо чинить в helper, а не считать ручной git cleanup “достаточным решением”.

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -2191,6 +2191,21 @@ extract_bd_worktree_record_from_payload() {
   return 1
 }
 
+extract_bd_probe_state_from_payload() {
+  local payload="$1"
+  local line=""
+
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    if [[ "${line}" == "__PROBE_STATE__"$'\t'* ]]; then
+      printf '%s\n' "${line#*$'\t'}"
+      return 0
+    fi
+  done <<< "${payload}"
+
+  return 1
+}
+
 discover_target_state() {
   local git_record=""
   local bd_payload=""
@@ -3265,6 +3280,7 @@ execute_cleanup_worktree_action() {
   local fallback_rc=0
   local fallback_merge_check=""
   local fallback_default_branch_name=""
+  local fallback_bd_probe_state=""
   local fallback_bd_record=""
   local fallback_bd_lookup_path=""
   local saved_merge_check=""
@@ -3376,8 +3392,15 @@ execute_cleanup_worktree_action() {
           add_warning "bd worktree remove reported unpushed commits for merged clean worktree ${cleanup_path}; git worktree remove fallback succeeded."
           fallback_bd_lookup_path="${report_worktree_path:-${discovered_worktree_path:-${cleanup_path}}}"
           fallback_bd_record="$(find_bd_worktree_by_path "${fallback_bd_lookup_path}" || true)"
+          fallback_bd_probe_state="$(extract_bd_probe_state_from_payload "${fallback_bd_record}" || true)"
           fallback_bd_record="$(extract_bd_worktree_record_from_payload "${fallback_bd_record}" || true)"
-          if [[ -n "${fallback_bd_record}" ]]; then
+          if [[ "${fallback_bd_probe_state}" != "ok" ]]; then
+            report_cleanup_reconcile_required="true"
+            report_repair_command="cd $(shell_quote "${resolved_repo_root}") && bd worktree remove $(shell_quote "${cleanup_path}")"
+            add_warning "Could not verify Beads worktree metadata after git-only fallback removal because the post-removal bd probe was unavailable."
+            add_next_step "cd $(shell_quote "${resolved_repo_root}")"
+            add_next_step "bd worktree remove $(shell_quote "${cleanup_path}")"
+          elif [[ -n "${fallback_bd_record}" ]]; then
             report_cleanup_reconcile_required="true"
             report_repair_command="cd $(shell_quote "${resolved_repo_root}") && bd worktree remove $(shell_quote "${cleanup_path}")"
             add_warning "Beads still reports ${cleanup_path} after git-only fallback removal; rerun bd cleanup to reconcile local worktree metadata."

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -123,6 +123,7 @@ report_local_branch_action="not_requested"
 report_remote_branch_action="not_requested"
 report_merge_check="not_requested"
 report_default_branch_name=""
+report_cleanup_reconcile_required="false"
 
 declare -a report_next_steps=()
 declare -a report_warnings=()
@@ -1931,14 +1932,11 @@ find_git_worktree_by_branch() {
 
 find_git_worktree_by_path() {
   local search_path="$1"
-  local normalized_search_path=""
   local worktree_path=""
   local worktree_branch=""
 
-  normalized_search_path="$(normalize_path "${search_path}" "${resolved_repo_root}")"
-
   while IFS=$'\t' read -r worktree_path worktree_branch; do
-    if [[ "${worktree_path}" == "${normalized_search_path}" ]]; then
+    if paths_refer_to_same_location "${worktree_path}" "${search_path}"; then
       printf '%s\t%s\n' "${worktree_path}" "${worktree_branch}"
       return 0
     fi
@@ -2143,14 +2141,11 @@ find_bd_worktree_by_path() {
   local bd_command=""
   local line=""
   local record_path=""
-  local search_identity_key=""
 
   if ! bd_command="$(resolve_bd_command)" || ! command -v jq >/dev/null 2>&1; then
     printf '__PROBE_STATE__\tprobe_unavailable\n'
     return 0
   fi
-
-  search_identity_key="$(path_identity_key "${search_path}" "${resolved_repo_root}")"
 
   set +e
   output="$(
@@ -2169,7 +2164,7 @@ find_bd_worktree_by_path() {
     while IFS= read -r line; do
       [[ -n "${line}" ]] || continue
       record_path="$(printf '%s\n' "${line}" | cut -f2)"
-      if paths_refer_to_same_location "${record_path}" "${search_identity_key}"; then
+      if paths_refer_to_same_location "${record_path}" "${search_path}"; then
         printf '%s\n' "${line}"
         break
       fi
@@ -2178,6 +2173,22 @@ find_bd_worktree_by_path() {
   fi
 
   printf '__PROBE_STATE__\tprobe_unavailable\n'
+}
+
+extract_bd_worktree_record_from_payload() {
+  local payload="$1"
+  local line=""
+
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    if [[ "${line}" == "__PROBE_STATE__"$'\t'* ]]; then
+      continue
+    fi
+    printf '%s\n' "${line}"
+    return 0
+  done <<< "${payload}"
+
+  return 1
 }
 
 discover_target_state() {
@@ -2529,6 +2540,7 @@ reset_report() {
   report_remote_branch_action="not_requested"
   report_merge_check="not_requested"
   report_default_branch_name=""
+  report_cleanup_reconcile_required="false"
   report_next_steps=()
   report_warnings=()
   report_issue_artifacts=()
@@ -3362,7 +3374,10 @@ execute_cleanup_worktree_action() {
           report_default_branch_name="${fallback_default_branch_name}"
           add_warning "bd worktree remove reported unpushed commits for merged clean worktree ${cleanup_path}; git worktree remove fallback succeeded."
           fallback_bd_record="$(find_bd_worktree_by_path "${cleanup_path}" || true)"
-          if [[ "${fallback_bd_record}" == *$'\t'* ]]; then
+          fallback_bd_record="$(extract_bd_worktree_record_from_payload "${fallback_bd_record}" || true)"
+          if [[ -n "${fallback_bd_record}" ]]; then
+            report_cleanup_reconcile_required="true"
+            report_repair_command="cd $(shell_quote "${resolved_repo_root}") && bd worktree remove $(shell_quote "${cleanup_path}")"
             add_warning "Beads still reports ${cleanup_path} after git-only fallback removal; rerun bd cleanup to reconcile local worktree metadata."
             add_next_step "cd $(shell_quote "${resolved_repo_root}")"
             add_next_step "bd worktree remove $(shell_quote "${cleanup_path}")"
@@ -3419,6 +3434,7 @@ execute_cleanup_branch_actions() {
   local default_branch_name=""
   local output=""
   local local_delete_flag="-d"
+  local local_only_branch_delete_allowed="false"
   local rc=0
 
   if [[ "${delete_branch_requested}" != "true" ]]; then
@@ -3454,7 +3470,13 @@ execute_cleanup_branch_actions() {
   report_default_branch_name="${default_branch_name}"
 
   if ! resolve_cleanup_merge_proof "${cleanup_branch}" "${default_branch_name}"; then
-    report_local_branch_action="skipped"
+    if local_branch_exists "${cleanup_branch}" && ref_is_ancestor_of_remote_default "refs/heads/${cleanup_branch}" "${default_branch_name}"; then
+      local_only_branch_delete_allowed="true"
+      report_local_branch_action="not_requested"
+      add_warning "Cleanup could not establish authoritative remote proof for '${cleanup_branch}', but local merged ancestry still allows local branch deletion while remote deletion stays blocked."
+    else
+      report_local_branch_action="skipped"
+    fi
     if remote_branch_exists "${cleanup_branch}"; then
       report_remote_branch_action="blocked"
     else
@@ -3482,7 +3504,9 @@ execute_cleanup_branch_actions() {
     if origin_uses_github; then
       add_next_step "cd $(shell_quote "${resolved_repo_root}") && gh pr list --state merged --head $(shell_quote "${cleanup_branch}") --json number,state,mergedAt,headRefName,headRefOid,baseRefName,url"
     fi
-    return 1
+    if [[ "${local_only_branch_delete_allowed}" != "true" ]]; then
+      return 1
+    fi
   fi
 
   if local_branch_exists "${cleanup_branch}"; then
@@ -3563,9 +3587,8 @@ execute_cleanup_branch_actions() {
 set_cleanup_contract() {
   report_phase="cleanup"
   report_boundary="none"
-  report_repair_command=""
 
-  if [[ "${report_worktree_action}" == "blocked" || "${report_local_branch_action}" == "blocked" || "${report_remote_branch_action}" == "blocked" || "${report_local_branch_action}" == "skipped" || "${report_remote_branch_action}" == "skipped" ]]; then
+  if [[ "${report_cleanup_reconcile_required}" == "true" || "${report_worktree_action}" == "blocked" || "${report_local_branch_action}" == "blocked" || "${report_remote_branch_action}" == "blocked" || "${report_local_branch_action}" == "skipped" || "${report_remote_branch_action}" == "skipped" ]]; then
     report_status="cleanup_blocked"
     report_final_state="cleanup_blocked"
     return 0
@@ -4352,7 +4375,7 @@ render_cleanup_contract_report() {
   fi
 
   execute_cleanup_worktree_action || true
-  if [[ "${report_worktree_action}" != "blocked" ]]; then
+  if [[ "${report_worktree_action}" != "blocked" && "${report_cleanup_reconcile_required}" != "true" ]]; then
     execute_cleanup_branch_actions || true
   fi
   set_cleanup_contract

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -3266,6 +3266,7 @@ execute_cleanup_worktree_action() {
   local fallback_merge_check=""
   local fallback_default_branch_name=""
   local fallback_bd_record=""
+  local fallback_bd_lookup_path=""
   local saved_merge_check=""
   local saved_default_branch_name=""
   local default_branch_name=""
@@ -3373,7 +3374,8 @@ execute_cleanup_worktree_action() {
           report_merge_check="${fallback_merge_check}"
           report_default_branch_name="${fallback_default_branch_name}"
           add_warning "bd worktree remove reported unpushed commits for merged clean worktree ${cleanup_path}; git worktree remove fallback succeeded."
-          fallback_bd_record="$(find_bd_worktree_by_path "${cleanup_path}" || true)"
+          fallback_bd_lookup_path="${report_worktree_path:-${discovered_worktree_path:-${cleanup_path}}}"
+          fallback_bd_record="$(find_bd_worktree_by_path "${fallback_bd_lookup_path}" || true)"
           fallback_bd_record="$(extract_bd_worktree_record_from_payload "${fallback_bd_record}" || true)"
           if [[ -n "${fallback_bd_record}" ]]; then
             report_cleanup_reconcile_required="true"
@@ -3531,6 +3533,10 @@ execute_cleanup_branch_actions() {
     fi
   else
     report_local_branch_action="already_missing"
+  fi
+
+  if [[ "${local_only_branch_delete_allowed}" == "true" ]]; then
+    return 1
   fi
 
   if remote_branch_exists "${cleanup_branch}"; then

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -1061,6 +1061,26 @@ delete_remote_branch_via_github_api() {
   git -C "${resolved_repo_root}" update-ref -d "refs/remotes/origin/${cleanup_branch}" >/dev/null 2>&1 || true
 }
 
+github_branch_head_sha() {
+  local cleanup_branch="$1"
+  local repo_name_with_owner=""
+  local ref_json=""
+  local ref_sha=""
+
+  repo_name_with_owner="$(github_repo_name_with_owner || true)"
+  if [[ -z "${repo_name_with_owner}" ]]; then
+    return 1
+  fi
+
+  ref_json="$(gh_run_in_repo api "repos/${repo_name_with_owner}/git/ref/heads/${cleanup_branch}" 2>/dev/null || true)"
+  ref_sha="$(printf '%s\n' "${ref_json}" | jq -r '.object.sha // empty' 2>/dev/null || true)"
+  if [[ -z "${ref_sha}" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${ref_sha}"
+}
+
 resolve_ref_sha() {
   local ref_name="$1"
 
@@ -1072,6 +1092,24 @@ ref_is_ancestor_of_remote_default() {
   local default_branch_name="$2"
 
   git -C "${resolved_repo_root}" merge-base --is-ancestor "${candidate_ref}" "refs/remotes/origin/${default_branch_name}" 2>/dev/null
+}
+
+refresh_cleanup_remote_refs() {
+  git -C "${resolved_repo_root}" fetch --prune --no-tags origin >/dev/null 2>&1
+}
+
+cleanup_output_indicates_false_unpushed_guard() {
+  local output="$1"
+
+  [[ "${output}" == *"safety check failed"* && "${output}" == *"unpushed commit"* ]]
+}
+
+worktree_has_clean_status() {
+  local worktree_path="$1"
+  local status_output=""
+
+  status_output="$(git -C "${worktree_path}" status --short --untracked-files=normal 2>/dev/null || true)"
+  [[ -z "${status_output}" ]]
 }
 
 git_worktree_record_for_path() {
@@ -1160,6 +1198,7 @@ resolve_cleanup_merge_proof() {
   local local_sha=""
   local remote_sha=""
   local expected_sha=""
+  local remote_refresh_ok="true"
   local repo_json=""
   local pr_json=""
   local repo_delete_branch_on_merge=""
@@ -1169,20 +1208,32 @@ resolve_cleanup_merge_proof() {
   report_merge_check="not_requested"
   report_default_branch_name="${default_branch_name}"
 
-  if local_branch_exists "${cleanup_branch}"; then
-    local_sha="$(resolve_ref_sha "refs/heads/${cleanup_branch}")"
-    if [[ -n "${local_sha}" ]] && ref_is_ancestor_of_remote_default "refs/heads/${cleanup_branch}" "${default_branch_name}"; then
-      report_merge_check="git_ancestor_local"
-      return 0
-    fi
+  if ! refresh_cleanup_remote_refs; then
+    remote_refresh_ok="false"
   fi
 
-  if remote_branch_exists "${cleanup_branch}"; then
+  if [[ "${remote_refresh_ok}" == "true" ]] && remote_branch_exists "${cleanup_branch}"; then
     remote_sha="$(resolve_ref_sha "refs/remotes/origin/${cleanup_branch}")"
     if [[ -n "${remote_sha}" ]] && ref_is_ancestor_of_remote_default "refs/remotes/origin/${cleanup_branch}" "${default_branch_name}"; then
       report_merge_check="git_ancestor_remote"
       return 0
     fi
+  fi
+
+  if [[ "${remote_refresh_ok}" == "true" ]] && local_branch_exists "${cleanup_branch}"; then
+    local_sha="$(resolve_ref_sha "refs/heads/${cleanup_branch}")"
+    if [[ -n "${local_sha}" && -z "${remote_sha}" ]] && ref_is_ancestor_of_remote_default "refs/heads/${cleanup_branch}" "${default_branch_name}"; then
+      report_merge_check="git_ancestor_local"
+      return 0
+    fi
+  fi
+
+  if [[ "${remote_refresh_ok}" != "true" ]] && origin_uses_github && gh_available_and_authenticated && command -v jq >/dev/null 2>&1; then
+    remote_sha="$(github_branch_head_sha "${cleanup_branch}" || true)"
+  fi
+
+  if [[ -z "${local_sha}" ]] && local_branch_exists "${cleanup_branch}"; then
+    local_sha="$(resolve_ref_sha "refs/heads/${cleanup_branch}")"
   fi
 
   expected_sha="${remote_sha:-${local_sha}}"
@@ -1192,11 +1243,19 @@ resolve_cleanup_merge_proof() {
   fi
 
   if ! origin_uses_github; then
+    if [[ "${remote_refresh_ok}" != "true" ]]; then
+      report_merge_check="remote_refresh_failed"
+      return 1
+    fi
     report_merge_check="not_merged"
     return 1
   fi
 
   if ! gh_available_and_authenticated || ! command -v jq >/dev/null 2>&1; then
+    if [[ "${remote_refresh_ok}" != "true" ]]; then
+      report_merge_check="remote_refresh_failed"
+      return 1
+    fi
     report_merge_check="github_unavailable"
     return 1
   fi
@@ -1240,6 +1299,40 @@ resolve_cleanup_merge_proof() {
     report_merge_check="not_merged"
   fi
   return 1
+}
+
+resolve_cleanup_target_branch_name() {
+  if [[ -n "${report_worktree_path}" && -n "${discovered_worktree_path}" && "${report_worktree_path}" == "${discovered_worktree_path}" && -n "${discovered_branch_name}" ]]; then
+    printf '%s\n' "${discovered_branch_name}"
+    return 0
+  fi
+
+  if [[ -n "${report_branch_name}" && "${report_branch_name}" != "n/a" ]]; then
+    printf '%s\n' "${report_branch_name}"
+    return 0
+  fi
+
+  if [[ -n "${branch}" ]]; then
+    printf '%s\n' "${branch}"
+    return 0
+  fi
+
+  return 1
+}
+
+cleanup_target_arguments_conflict() {
+  local target_branch=""
+
+  if [[ -z "${branch}" || -z "${target_path}" ]]; then
+    return 1
+  fi
+
+  if [[ -z "${discovered_worktree_path}" || "${discovered_worktree_path}" != "${target_path}" ]]; then
+    return 0
+  fi
+
+  target_branch="$(resolve_cleanup_target_branch_name || true)"
+  [[ -z "${target_branch}" || "${target_branch}" != "${branch}" ]]
 }
 
 discover_issue_context() {
@@ -3062,10 +3155,19 @@ set_finish_next_steps() {
 execute_cleanup_worktree_action() {
   local cleanup_path="${report_worktree_path:-${target_path:-}}"
   local record=""
+  local record_branch=""
   local prunable_reason=""
   local locked_reason=""
   local bd_command=""
   local output=""
+  local fallback_branch=""
+  local fallback_output=""
+  local fallback_rc=0
+  local fallback_merge_check=""
+  local fallback_default_branch_name=""
+  local saved_merge_check=""
+  local saved_default_branch_name=""
+  local default_branch_name=""
   local rc=0
 
   if [[ -z "${cleanup_path}" || "${cleanup_path}" == "n/a" ]]; then
@@ -3094,7 +3196,7 @@ execute_cleanup_worktree_action() {
     return 0
   fi
 
-  IFS=$'\t' read -r _ _ prunable_reason locked_reason <<< "${record}"
+  IFS=$'\t' read -r _ record_branch prunable_reason locked_reason <<< "${record}"
   if [[ -n "${locked_reason}" ]]; then
     report_worktree_action="blocked"
     add_warning "Cleanup refuses to remove a locked worktree at ${cleanup_path}."
@@ -3144,6 +3246,43 @@ execute_cleanup_worktree_action() {
   set -e
 
   if [[ "${rc}" -ne 0 ]]; then
+    fallback_branch="$(resolve_cleanup_target_branch_name || true)"
+    if [[ -z "${fallback_branch}" ]]; then
+      fallback_branch="${record_branch}"
+    fi
+    if cleanup_output_indicates_false_unpushed_guard "${output}" \
+      && [[ -n "${fallback_branch}" ]] \
+      && worktree_has_clean_status "${cleanup_path}"; then
+      saved_merge_check="${report_merge_check}"
+      saved_default_branch_name="${report_default_branch_name}"
+      default_branch_name="$(resolve_default_branch_name)"
+      if resolve_cleanup_merge_proof "${fallback_branch}" "${default_branch_name}"; then
+        fallback_merge_check="${report_merge_check}"
+        fallback_default_branch_name="${report_default_branch_name}"
+        report_merge_check="${saved_merge_check}"
+        report_default_branch_name="${saved_default_branch_name}"
+
+        set +e
+        fallback_output="$(git -C "${resolved_repo_root}" worktree remove "${cleanup_path}" 2>&1)"
+        fallback_rc=$?
+        set -e
+
+        if [[ "${fallback_rc}" -eq 0 ]] && wait_for_worktree_removal "${cleanup_path}"; then
+          report_worktree_action="removed"
+          report_merge_check="${fallback_merge_check}"
+          report_default_branch_name="${fallback_default_branch_name}"
+          add_warning "bd worktree remove reported unpushed commits for merged clean worktree ${cleanup_path}; git worktree remove fallback succeeded."
+          return 0
+        fi
+
+        report_merge_check="${fallback_merge_check}"
+        report_default_branch_name="${fallback_default_branch_name}"
+        if [[ -n "${fallback_output}" ]]; then
+          add_warning "$(printf '%s' "${fallback_output}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+        fi
+      fi
+    fi
+
     report_worktree_action="blocked"
     add_warning "bd worktree remove failed for ${cleanup_path}."
     if [[ -n "${output}" ]]; then
@@ -3181,7 +3320,7 @@ execute_cleanup_worktree_action() {
 }
 
 execute_cleanup_branch_actions() {
-  local cleanup_branch="${report_branch_name:-${branch:-}}"
+  local cleanup_branch=""
   local default_branch_name=""
   local output=""
   local local_delete_flag="-d"
@@ -3191,6 +3330,8 @@ execute_cleanup_branch_actions() {
   report_remote_branch_action="not_requested"
   report_merge_check="not_requested"
   report_default_branch_name=""
+
+  cleanup_branch="$(resolve_cleanup_target_branch_name || true)"
 
   if [[ "${delete_branch_requested}" != "true" ]]; then
     return 0
@@ -3225,6 +3366,9 @@ execute_cleanup_branch_actions() {
 
     add_warning "Cleanup could not establish merged proof for branch '${cleanup_branch}'."
     case "${report_merge_check}" in
+      remote_refresh_failed)
+        add_next_step "git -C $(shell_quote "${resolved_repo_root}") fetch --prune --no-tags origin"
+        ;;
       github_unavailable)
         add_next_step "gh auth status -h github.com"
         ;;
@@ -4088,6 +4232,22 @@ render_cleanup_contract_report() {
       add_next_step "scripts/worktree-ready.sh cleanup --branch $(shell_quote "${branch}")${delete_flag}"
     elif [[ -n "${target_path}" ]]; then
       add_next_step "scripts/worktree-ready.sh cleanup --path $(shell_quote "${target_path}")${delete_flag}"
+    fi
+    render_cleanup_report
+    set_command_exit_code_from_cleanup
+    return 0
+  fi
+
+  if cleanup_target_arguments_conflict; then
+    report_phase="cleanup"
+    report_boundary="none"
+    report_status="cleanup_blocked"
+    report_final_state="cleanup_blocked"
+    report_worktree_action="blocked"
+    add_warning "Cleanup arguments conflict: --path $(shell_quote "${target_path}") resolves to branch '${discovered_branch_name:-unknown}', not requested branch '${branch}'."
+    add_next_step "Retry cleanup with --path $(shell_quote "${target_path}") only"
+    if [[ -n "${discovered_branch_name}" ]]; then
+      add_next_step "Retry cleanup with --branch $(shell_quote "${discovered_branch_name}") only"
     fi
     render_cleanup_report
     set_command_exit_code_from_cleanup

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -333,6 +333,69 @@ normalize_path() {
   printf '\n'
 }
 
+canonicalize_existing_directory_path() {
+  local input_path="$1"
+  local normalized_path=""
+
+  normalized_path="$(normalize_path "${input_path}" "${resolved_repo_root}")"
+  if [[ ! -d "${normalized_path}" ]]; then
+    return 1
+  fi
+
+  (
+    cd "${normalized_path}" >/dev/null 2>&1 || exit 1
+    pwd -P
+  )
+}
+
+path_identity_key() {
+  local input_path="$1"
+  local base_path="${2:-$PWD}"
+  local normalized_path=""
+  local canonical_path=""
+
+  normalized_path="$(normalize_path "${input_path}" "${base_path}")"
+  canonical_path="$(canonicalize_existing_directory_path "${normalized_path}" || true)"
+  if [[ -n "${canonical_path}" ]]; then
+    printf '%s\n' "${canonical_path}"
+    return 0
+  fi
+
+  printf '%s\n' "${normalized_path}"
+}
+
+paths_refer_to_same_location() {
+  local left_path="$1"
+  local right_path="$2"
+  local left_key=""
+  local right_key=""
+
+  left_key="$(path_identity_key "${left_path}" "/")"
+  right_key="$(path_identity_key "${right_path}" "/")"
+  [[ -n "${left_key}" && -n "${right_key}" && "${left_key}" == "${right_key}" ]]
+}
+
+url_encode_path_segment() {
+  local raw_value="$1"
+  local encoded=""
+  local current_char=""
+  local index=0
+
+  for ((index = 0; index < ${#raw_value}; index++)); do
+    current_char="${raw_value:index:1}"
+    case "${current_char}" in
+      [a-zA-Z0-9.~_-])
+        encoded+="${current_char}"
+        ;;
+      *)
+        printf -v encoded '%s%%%02X' "${encoded}" "'${current_char}"
+        ;;
+    esac
+  done
+
+  printf '%s\n' "${encoded}"
+}
+
 sanitize_branch_name() {
   local raw_branch="$1"
   local sanitized=""
@@ -1039,31 +1102,36 @@ github_repo_name_with_owner() {
 github_delete_ref_command() {
   local cleanup_branch="$1"
   local repo_name_with_owner=""
+  local encoded_branch=""
 
   repo_name_with_owner="$(github_repo_name_with_owner || true)"
   if [[ -z "${repo_name_with_owner}" ]]; then
     return 1
   fi
 
-  printf 'gh api -X DELETE %s\n' "$(shell_quote "repos/${repo_name_with_owner}/git/refs/heads/${cleanup_branch}")"
+  encoded_branch="$(url_encode_path_segment "${cleanup_branch}")"
+  printf 'gh api -X DELETE %s\n' "$(shell_quote "repos/${repo_name_with_owner}/git/refs/heads/${encoded_branch}")"
 }
 
 delete_remote_branch_via_github_api() {
   local cleanup_branch="$1"
   local repo_name_with_owner=""
+  local encoded_branch=""
 
   repo_name_with_owner="$(github_repo_name_with_owner || true)"
   if [[ -z "${repo_name_with_owner}" ]]; then
     return 1
   fi
 
-  gh_run_in_repo api -X DELETE "repos/${repo_name_with_owner}/git/refs/heads/${cleanup_branch}"
+  encoded_branch="$(url_encode_path_segment "${cleanup_branch}")"
+  gh_run_in_repo api -X DELETE "repos/${repo_name_with_owner}/git/refs/heads/${encoded_branch}"
   git -C "${resolved_repo_root}" update-ref -d "refs/remotes/origin/${cleanup_branch}" >/dev/null 2>&1 || true
 }
 
 github_branch_head_sha() {
   local cleanup_branch="$1"
   local repo_name_with_owner=""
+  local encoded_branch=""
   local ref_json=""
   local ref_sha=""
 
@@ -1072,7 +1140,8 @@ github_branch_head_sha() {
     return 1
   fi
 
-  ref_json="$(gh_run_in_repo api "repos/${repo_name_with_owner}/git/ref/heads/${cleanup_branch}" 2>/dev/null || true)"
+  encoded_branch="$(url_encode_path_segment "${cleanup_branch}")"
+  ref_json="$(gh_run_in_repo api "repos/${repo_name_with_owner}/git/ref/heads/${encoded_branch}" 2>/dev/null || true)"
   ref_sha="$(printf '%s\n' "${ref_json}" | jq -r '.object.sha // empty' 2>/dev/null || true)"
   if [[ -z "${ref_sha}" ]]; then
     return 1
@@ -1114,19 +1183,21 @@ worktree_has_clean_status() {
 
 git_worktree_record_for_path() {
   local search_path="$1"
-  local normalized_search_path=""
+  local search_identity_key=""
   local line=""
   local current_path=""
   local current_branch=""
   local current_prunable=""
   local current_locked=""
+  local current_identity_key=""
 
-  normalized_search_path="$(normalize_path "${search_path}" "${resolved_repo_root}")"
+  search_identity_key="$(path_identity_key "${search_path}" "${resolved_repo_root}")"
 
   while IFS= read -r line || [[ -n "${line}" ]]; do
     case "${line}" in
       worktree\ *)
         current_path="$(normalize_path "${line#worktree }" "/")"
+        current_identity_key="$(path_identity_key "${current_path}" "/")"
         current_branch=""
         current_prunable=""
         current_locked=""
@@ -1143,11 +1214,12 @@ git_worktree_record_for_path() {
         [[ "${current_locked}" == "${line}" ]] && current_locked="true"
         ;;
       "")
-        if [[ -n "${current_path}" && "${current_path}" == "${normalized_search_path}" ]]; then
+        if [[ -n "${current_path}" && -n "${current_identity_key}" && "${current_identity_key}" == "${search_identity_key}" ]]; then
           printf '%s\t%s\t%s\t%s\n' "${current_path}" "${current_branch}" "${current_prunable}" "${current_locked}"
           return 0
         fi
         current_path=""
+        current_identity_key=""
         current_branch=""
         current_prunable=""
         current_locked=""
@@ -1155,7 +1227,7 @@ git_worktree_record_for_path() {
     esac
   done < <(git -C "${resolved_repo_root}" worktree list --porcelain)
 
-  if [[ -n "${current_path}" && "${current_path}" == "${normalized_search_path}" ]]; then
+  if [[ -n "${current_path}" && -n "${current_identity_key}" && "${current_identity_key}" == "${search_identity_key}" ]]; then
     printf '%s\t%s\t%s\t%s\n' "${current_path}" "${current_branch}" "${current_prunable}" "${current_locked}"
     return 0
   fi
@@ -1195,6 +1267,7 @@ wait_for_worktree_removal() {
 resolve_cleanup_merge_proof() {
   local cleanup_branch="$1"
   local default_branch_name="$2"
+  local allow_local_stale_proof="${3:-false}"
   local local_sha=""
   local remote_sha=""
   local expected_sha=""
@@ -1234,6 +1307,13 @@ resolve_cleanup_merge_proof() {
 
   if [[ -z "${local_sha}" ]] && local_branch_exists "${cleanup_branch}"; then
     local_sha="$(resolve_ref_sha "refs/heads/${cleanup_branch}")"
+  fi
+
+  if [[ "${remote_refresh_ok}" != "true" && "${allow_local_stale_proof}" == "true" && -n "${local_sha}" ]] \
+    && ref_is_ancestor_of_remote_default "refs/heads/${cleanup_branch}" "${default_branch_name}"; then
+    report_merge_check="git_ancestor_local_stale"
+    add_warning "Remote ref refresh failed; using local merged ancestry only to authorize worktree removal fallback for '${cleanup_branch}'. Branch deletion remains blocked until remote proof is restored."
+    return 0
   fi
 
   expected_sha="${remote_sha:-${local_sha}}"
@@ -1327,7 +1407,7 @@ cleanup_target_arguments_conflict() {
     return 1
   fi
 
-  if [[ -z "${discovered_worktree_path}" || "${discovered_worktree_path}" != "${target_path}" ]]; then
+  if [[ -z "${discovered_worktree_path}" ]] || ! paths_refer_to_same_location "${discovered_worktree_path}" "${target_path}"; then
     return 0
   fi
 
@@ -2058,24 +2138,25 @@ discover_similar_targets() {
 
 find_bd_worktree_by_path() {
   local search_path="$1"
-  local normalized_search_path=""
   local output=""
   local exit_code=0
   local bd_command=""
+  local line=""
+  local record_path=""
+  local search_identity_key=""
 
   if ! bd_command="$(resolve_bd_command)" || ! command -v jq >/dev/null 2>&1; then
     printf '__PROBE_STATE__\tprobe_unavailable\n'
     return 0
   fi
 
-  normalized_search_path="$(normalize_path "${search_path}" "${resolved_repo_root}")"
+  search_identity_key="$(path_identity_key "${search_path}" "${resolved_repo_root}")"
 
   set +e
   output="$(
     cd "${resolved_repo_root}" && "${bd_command}" worktree list --json 2>/dev/null \
-      | jq -r --arg path "${normalized_search_path}" '
+      | jq -r '
         .[]
-        | select(.path == $path)
         | [(.name // ""), (.path // ""), (.branch // ""), (.beads_state // ""), (.redirect_to // "")]
         | @tsv
       '
@@ -2085,7 +2166,14 @@ find_bd_worktree_by_path() {
 
   if [[ "${exit_code}" -eq 0 ]]; then
     printf '__PROBE_STATE__\tok\n'
-    printf '%s\n' "${output}"
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] || continue
+      record_path="$(printf '%s\n' "${line}" | cut -f2)"
+      if paths_refer_to_same_location "${record_path}" "${search_identity_key}"; then
+        printf '%s\n' "${line}"
+        break
+      fi
+    done <<< "${output}"
     return 0
   fi
 
@@ -3165,6 +3253,7 @@ execute_cleanup_worktree_action() {
   local fallback_rc=0
   local fallback_merge_check=""
   local fallback_default_branch_name=""
+  local fallback_bd_record=""
   local saved_merge_check=""
   local saved_default_branch_name=""
   local default_branch_name=""
@@ -3256,7 +3345,7 @@ execute_cleanup_worktree_action() {
       saved_merge_check="${report_merge_check}"
       saved_default_branch_name="${report_default_branch_name}"
       default_branch_name="$(resolve_default_branch_name)"
-      if resolve_cleanup_merge_proof "${fallback_branch}" "${default_branch_name}"; then
+      if resolve_cleanup_merge_proof "${fallback_branch}" "${default_branch_name}" "true"; then
         fallback_merge_check="${report_merge_check}"
         fallback_default_branch_name="${report_default_branch_name}"
         report_merge_check="${saved_merge_check}"
@@ -3272,6 +3361,12 @@ execute_cleanup_worktree_action() {
           report_merge_check="${fallback_merge_check}"
           report_default_branch_name="${fallback_default_branch_name}"
           add_warning "bd worktree remove reported unpushed commits for merged clean worktree ${cleanup_path}; git worktree remove fallback succeeded."
+          fallback_bd_record="$(find_bd_worktree_by_path "${cleanup_path}" || true)"
+          if [[ "${fallback_bd_record}" == *$'\t'* ]]; then
+            add_warning "Beads still reports ${cleanup_path} after git-only fallback removal; rerun bd cleanup to reconcile local worktree metadata."
+            add_next_step "cd $(shell_quote "${resolved_repo_root}")"
+            add_next_step "bd worktree remove $(shell_quote "${cleanup_path}")"
+          fi
           return 0
         fi
 
@@ -3326,16 +3421,18 @@ execute_cleanup_branch_actions() {
   local local_delete_flag="-d"
   local rc=0
 
+  if [[ "${delete_branch_requested}" != "true" ]]; then
+    report_local_branch_action="not_requested"
+    report_remote_branch_action="not_requested"
+    return 0
+  fi
+
   report_local_branch_action="not_requested"
   report_remote_branch_action="not_requested"
   report_merge_check="not_requested"
   report_default_branch_name=""
 
   cleanup_branch="$(resolve_cleanup_target_branch_name || true)"
-
-  if [[ "${delete_branch_requested}" != "true" ]]; then
-    return 0
-  fi
 
   if [[ -z "${cleanup_branch}" || "${cleanup_branch}" == "n/a" ]]; then
     report_local_branch_action="skipped"

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -20,12 +20,32 @@ create_fake_bd_bin() {
 set -euo pipefail
 
 if [[ "${1:-}" == "worktree" && "${2:-}" == "list" && "${3:-}" == "--json" ]]; then
-  printf '%s\n' "${BD_WORKTREE_LIST_JSON:-[]}"
+  payload="${BD_WORKTREE_LIST_JSON:-[]}"
+  if [[ "${BD_WORKTREE_LIST_FILTER_MISSING:-0}" == "1" ]]; then
+    filtered_lines=()
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] || continue
+      line_path="$(printf '%s\n' "${line}" | jq -r '.path // empty')"
+      if [[ -z "${line_path}" || -e "${line_path}" ]]; then
+        filtered_lines+=("${line}")
+      fi
+    done < <(printf '%s\n' "${payload}" | jq -c '.[]')
+
+    if [[ "${#filtered_lines[@]}" -eq 0 ]]; then
+      payload='[]'
+    else
+      payload="$(printf '%s\n' "${filtered_lines[@]}" | jq -s '.')"
+    fi
+  fi
+  printf '%s\n' "${payload}"
   exit 0
 fi
 
 if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
   target_path="${3:-}"
+  if [[ "${BD_WORKTREE_REMOVE_CANONICALIZE:-0}" == "1" && -d "${target_path}" ]]; then
+    target_path="$(cd "${target_path}" && pwd -P)"
+  fi
   if [[ -n "${BD_WORKTREE_REMOVE_STDOUT:-}" ]]; then
     printf '%s\n' "${BD_WORKTREE_REMOVE_STDOUT}"
   fi
@@ -1544,6 +1564,7 @@ test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard() {
     output="$(
         set +e
         BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_LIST_FILTER_MISSING=1 \
         BD_WORKTREE_REMOVE_NOOP=1 \
         BD_WORKTREE_REMOVE_RC=23 \
         BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
@@ -1557,7 +1578,6 @@ test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard() {
     assert_contains "$output" 'Worktree Action: removed' "Cleanup should report the worktree as removed after the fallback"
     assert_contains "$output" 'Merge Check: git_ancestor_remote' "Cleanup should still require authoritative refreshed remote proof before using the fallback"
     assert_contains "$output" 'git worktree remove fallback succeeded' "Cleanup should explain that the direct git fallback was used"
-    assert_contains "$output" 'Beads still reports' "Cleanup should warn when git-only fallback may leave Beads worktree metadata stale"
     if [[ -d "$existing_path" ]]; then
         test_fail "Cleanup should remove the worktree directory after the fallback succeeds"
     fi
@@ -1738,6 +1758,39 @@ test_cleanup_blocks_conflicting_path_and_branch_arguments() {
     test_pass
 }
 
+test_cleanup_accepts_alias_path_when_branch_matches_same_worktree() {
+    test_start "worktree_ready_cleanup_accepts_alias_path_when_branch_matches_same_worktree"
+
+    local fixture_root repo_dir fake_bin path_worktree alias_path output rc
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    path_worktree="${fixture_root}/moltinger-path-target"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$path_worktree" "feat/path-target" "main"
+    path_worktree="$(cd "$path_worktree" && pwd -P)"
+    alias_path="${fixture_root}/moltinger-path-target-alias"
+    ln -s "$path_worktree" "$alias_path"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON='[]' \
+        BD_WORKTREE_REMOVE_CANONICALIZE=1 \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --path "$alias_path" --branch feat/path-target 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should accept an alias path when it resolves to the same worktree as the requested branch"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should complete when alias path and branch identify the same worktree"
+    if [[ -d "$path_worktree" ]]; then
+        test_fail "Cleanup should remove the real worktree even when the request uses an alias path"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_cleanup_refreshes_remote_refs_before_using_local_merge_proof() {
     test_start "worktree_ready_cleanup_refreshes_remote_refs_before_using_local_merge_proof"
 
@@ -1829,6 +1882,7 @@ test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails() {
     output="$(
         set +e
         BD_WORKTREE_LIST_JSON="$(printf '[{\"name\":\"remote-uat-hardening\",\"path\":\"%s\",\"branch\":\"feat/remote-uat-hardening\",\"beads_state\":\"local\"}]\n' "${existing_path}")" \
+        BD_WORKTREE_LIST_FILTER_MISSING=1 \
         BD_WORKTREE_REMOVE_NOOP=1 \
         BD_WORKTREE_REMOVE_RC=23 \
         BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
@@ -1841,7 +1895,6 @@ test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails() {
     assert_contains "$output" 'Status: cleanup_complete' "Cleanup should still complete when no branch deletion was requested"
     assert_contains "$output" 'Merge Check: git_ancestor_local_stale' "Cleanup should record the degraded local-only merge proof for worktree fallback"
     assert_contains "$output" 'Remote ref refresh failed; using local merged ancestry only' "Cleanup should explain why it trusted local ancestry"
-    assert_contains "$output" 'Beads still reports' "Cleanup should surface Beads reconciliation guidance after git-only fallback"
     if [[ -d "$existing_path" ]]; then
         test_fail "Cleanup should remove the worktree directory when local stale proof authorizes the fallback"
     fi
@@ -1996,6 +2049,7 @@ test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists() {
     output="$(
         set +e
         BD_WORKTREE_LIST_JSON="$(printf '[{\"name\":\"remote-uat-hardening\",\"path\":\"%s\",\"branch\":\"feat/remote-uat-hardening\",\"beads_state\":\"local\"}]\n' "${existing_path}")" \
+        BD_WORKTREE_LIST_FILTER_MISSING=1 \
         BD_WORKTREE_REMOVE_NOOP=1 \
         BD_WORKTREE_REMOVE_RC=23 \
         BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
@@ -2007,17 +2061,72 @@ test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists() {
     assert_eq "23" "$rc" "Cleanup must not delete branches when only stale local proof is available"
     assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked when branch deletion still lacks authoritative remote proof"
     assert_contains "$output" 'Worktree Action: removed' "Cleanup may still remove the worktree through the local-only fallback"
-    assert_contains "$output" 'Local Branch Action: skipped' "Cleanup should skip local branch deletion without authoritative merge proof"
+    assert_contains "$output" 'Local Branch Action: deleted' "Cleanup should still delete the local branch when local merged ancestry proves that step is safe"
     assert_contains "$output" 'Remote Branch Action: blocked' "Cleanup should preserve the remote branch when refresh proof is unavailable"
     assert_contains "$output" 'Merge Check: remote_refresh_failed' "Cleanup should report the remote-refresh failure for the branch-delete phase"
     if [[ -d "$existing_path" ]]; then
         test_fail "Cleanup should still remove the worktree directory before branch deletion blocks"
     fi
-    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
-        test_fail "Cleanup must preserve the local branch when authoritative branch-delete proof is unavailable"
+    if git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup should remove the local branch when local merged ancestry proves that step is safe"
     fi
     if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
         test_fail "Cleanup must preserve the remote-tracking ref when authoritative branch-delete proof is unavailable"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_blocks_when_git_fallback_leaves_beads_metadata_stale() {
+    test_start "worktree_ready_cleanup_blocks_when_git_fallback_leaves_beads_metadata_stale"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{\"name\":\"remote-uat-hardening\",\"path\":\"%s\",\"branch\":\"feat/remote-uat-hardening\",\"beads_state\":\"local\"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup should fail closed when git fallback removed the worktree but Beads metadata still reports it"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked until Beads metadata is reconciled"
+    assert_contains "$output" 'Worktree Action: removed' "Cleanup should report the physical worktree removal even when metadata reconciliation is pending"
+    assert_contains "$output" 'Beads still reports' "Cleanup should explain the Beads reconciliation blocker"
+    assert_contains "$output" 'Repair Command: cd ' "Cleanup should expose a repair command for Beads reconciliation"
+    if [[ -d "$existing_path" ]]; then
+        test_fail "Cleanup should still remove the worktree directory before blocking on Beads reconciliation"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch while Beads reconciliation remains blocked"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the remote branch while Beads reconciliation remains blocked"
     fi
 
     rm -rf "$fixture_root"
@@ -2165,8 +2274,10 @@ run_all_tests() {
     test_cleanup_does_not_bypass_false_unpushed_guard_without_merge_proof
     test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree
     test_cleanup_blocks_conflicting_path_and_branch_arguments
+    test_cleanup_accepts_alias_path_when_branch_matches_same_worktree
     test_cleanup_refreshes_remote_refs_before_using_local_merge_proof
     test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails
+    test_cleanup_blocks_when_git_fallback_leaves_beads_metadata_stale
     test_cleanup_delete_branch_uses_github_fallback_when_git_is_ambiguous
     test_cleanup_delete_branch_uses_github_api_remote_delete_fallback
     test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -203,6 +203,20 @@ EOF
     printf '%s\n' "${fake_bin}"
 }
 
+create_fake_broken_jq_bin() {
+    local fixture_root="$1"
+    local fake_bin="${fixture_root}/jq-bin"
+
+    mkdir -p "${fake_bin}"
+    cat > "${fake_bin}/jq" <<'EOF'
+#!/usr/bin/env bash
+exit 127
+EOF
+    chmod +x "${fake_bin}/jq"
+
+    printf '%s\n' "${fake_bin}"
+}
+
 run_worktree_plan() {
     local repo_dir="$1"
     local fake_bin="$2"
@@ -2215,6 +2229,60 @@ test_cleanup_blocks_when_git_fallback_leaves_beads_metadata_stale() {
     test_pass
 }
 
+test_cleanup_blocks_when_git_fallback_cannot_verify_beads_metadata() {
+    test_start "worktree_ready_cleanup_blocks_when_git_fallback_cannot_verify_beads_metadata"
+
+    local fixture_root repo_dir fake_bin fake_jq_bin existing_path output rc
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    fake_jq_bin="$(create_fake_broken_jq_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+    )
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON='[]' \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "${fake_jq_bin}:${fake_bin}" --branch feat/remote-uat-hardening 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup should fail closed when post-removal Beads verification is unavailable"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked when Beads metadata could not be verified"
+    assert_contains "$output" 'post-removal bd probe was unavailable' "Cleanup should explain why reconciliation is still required"
+    assert_contains "$output" 'Repair Command: cd ' "Cleanup should expose a repair command when Beads verification is unavailable"
+    if [[ -d "$existing_path" ]]; then
+        test_fail "Cleanup should still remove the worktree directory before blocking on unavailable Beads verification"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch while Beads verification remains unresolved"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the remote branch while Beads verification remains unresolved"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_cleanup_blocks_branch_delete_without_merge_proof() {
     test_start "worktree_ready_cleanup_blocks_branch_delete_without_merge_proof"
 
@@ -2361,6 +2429,7 @@ run_all_tests() {
     test_cleanup_refreshes_remote_refs_before_using_local_merge_proof
     test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails
     test_cleanup_blocks_when_git_fallback_leaves_beads_metadata_stale
+    test_cleanup_blocks_when_git_fallback_cannot_verify_beads_metadata
     test_cleanup_delete_branch_uses_github_fallback_when_git_is_ambiguous
     test_cleanup_delete_branch_uses_github_api_remote_delete_fallback
     test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -1557,6 +1557,7 @@ test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard() {
     assert_contains "$output" 'Worktree Action: removed' "Cleanup should report the worktree as removed after the fallback"
     assert_contains "$output" 'Merge Check: git_ancestor_remote' "Cleanup should still require authoritative refreshed remote proof before using the fallback"
     assert_contains "$output" 'git worktree remove fallback succeeded' "Cleanup should explain that the direct git fallback was used"
+    assert_contains "$output" 'Beads still reports' "Cleanup should warn when git-only fallback may leave Beads worktree metadata stale"
     if [[ -d "$existing_path" ]]; then
         test_fail "Cleanup should remove the worktree directory after the fallback succeeds"
     fi
@@ -1800,6 +1801,61 @@ test_cleanup_refreshes_remote_refs_before_using_local_merge_proof() {
     test_pass
 }
 
+test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails() {
+    test_start "worktree_ready_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails"
+
+    local fixture_root repo_dir fake_bin existing_path output rc
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+        git remote set-url origin "${fixture_root}/missing-origin.git"
+    )
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="$(printf '[{\"name\":\"remote-uat-hardening\",\"path\":\"%s\",\"branch\":\"feat/remote-uat-hardening\",\"beads_state\":\"local\"}]\n' "${existing_path}")" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should allow git fallback worktree removal when only remote refresh is unavailable"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should still complete when no branch deletion was requested"
+    assert_contains "$output" 'Merge Check: git_ancestor_local_stale' "Cleanup should record the degraded local-only merge proof for worktree fallback"
+    assert_contains "$output" 'Remote ref refresh failed; using local merged ancestry only' "Cleanup should explain why it trusted local ancestry"
+    assert_contains "$output" 'Beads still reports' "Cleanup should surface Beads reconciliation guidance after git-only fallback"
+    if [[ -d "$existing_path" ]]; then
+        test_fail "Cleanup should remove the worktree directory when local stale proof authorizes the fallback"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch when only the worktree fallback is authorized"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the stale remote-tracking ref when branch deletion was not requested"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_cleanup_delete_branch_uses_github_fallback_when_git_is_ambiguous() {
     test_start "worktree_ready_cleanup_delete_branch_uses_github_fallback_when_git_is_ambiguous"
 
@@ -1880,8 +1936,8 @@ test_cleanup_delete_branch_uses_github_api_remote_delete_fallback() {
         set +e
         WORKTREE_READY_ASSUME_GITHUB_ORIGIN=1 \
         GH_EXPECT_CWD="${repo_dir}" \
-        GH_EXPECT_API_DELETE_ROUTE="repos/example/repo/git/refs/heads/feat/remote-uat-hardening" \
-        GH_EXPECT_API_GET_ROUTE="repos/example/repo/git/ref/heads/feat/remote-uat-hardening" \
+        GH_EXPECT_API_DELETE_ROUTE="repos/example/repo/git/refs/heads/feat%2Fremote-uat-hardening" \
+        GH_EXPECT_API_GET_ROUTE="repos/example/repo/git/ref/heads/feat%2Fremote-uat-hardening" \
         GH_API_GET_STDOUT="$(printf '{"object":{"sha":"%s"}}\n' "${head_sha}")" \
         GH_REPO_VIEW_JSON='{"defaultBranchRef":{"name":"main"},"deleteBranchOnMerge":false,"nameWithOwner":"example/repo"}' \
         GH_PR_LIST_JSON="$(printf '[{"number":111,"state":"MERGED","mergedAt":"2026-03-27T20:30:28Z","headRefName":"feat/remote-uat-hardening","headRefOid":"%s","baseRefName":"main","isCrossRepository":false,"url":"https://github.com/example/repo/pull/111","title":"Fixture merged PR"}]\n' "${head_sha}")" \
@@ -1906,6 +1962,62 @@ test_cleanup_delete_branch_uses_github_api_remote_delete_fallback() {
     fi
     if git --git-dir "$origin_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
         test_fail "Cleanup should remove the actual remote branch after GitHub API fallback"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists() {
+    test_start "worktree_ready_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists"
+
+    local fixture_root repo_dir fake_bin existing_path output rc
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+        git remote set-url origin "${fixture_root}/missing-origin.git"
+    )
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="$(printf '[{\"name\":\"remote-uat-hardening\",\"path\":\"%s\",\"branch\":\"feat/remote-uat-hardening\",\"beads_state\":\"local\"}]\n' "${existing_path}")" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup must not delete branches when only stale local proof is available"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked when branch deletion still lacks authoritative remote proof"
+    assert_contains "$output" 'Worktree Action: removed' "Cleanup may still remove the worktree through the local-only fallback"
+    assert_contains "$output" 'Local Branch Action: skipped' "Cleanup should skip local branch deletion without authoritative merge proof"
+    assert_contains "$output" 'Remote Branch Action: blocked' "Cleanup should preserve the remote branch when refresh proof is unavailable"
+    assert_contains "$output" 'Merge Check: remote_refresh_failed' "Cleanup should report the remote-refresh failure for the branch-delete phase"
+    if [[ -d "$existing_path" ]]; then
+        test_fail "Cleanup should still remove the worktree directory before branch deletion blocks"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch when authoritative branch-delete proof is unavailable"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the remote-tracking ref when authoritative branch-delete proof is unavailable"
     fi
 
     rm -rf "$fixture_root"
@@ -2054,8 +2166,10 @@ run_all_tests() {
     test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree
     test_cleanup_blocks_conflicting_path_and_branch_arguments
     test_cleanup_refreshes_remote_refs_before_using_local_merge_proof
+    test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails
     test_cleanup_delete_branch_uses_github_fallback_when_git_is_ambiguous
     test_cleanup_delete_branch_uses_github_api_remote_delete_fallback
+    test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists
     test_cleanup_blocks_branch_delete_without_merge_proof
     test_cleanup_blocks_remote_delete_when_github_fallback_is_unavailable
     test_plan_needs_clarification_returns_exit_code_10

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -179,6 +179,30 @@ EOF
     printf '%s\n' "${fake_bin}"
 }
 
+create_fake_git_observer_bin() {
+    local fixture_root="$1"
+    local real_git_bin="$2"
+    local fake_bin="${fixture_root}/git-bin"
+
+    mkdir -p "${fake_bin}"
+    cat > "${fake_bin}/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${FAKE_GIT_CAPTURE_REMOTE_DELETE:-0}" == "1" ]] \
+  && [[ "\${1:-}" == "-C" && "\${3:-}" == "push" && "\${4:-}" == "origin" && "\${5:-}" == "--delete" ]]; then
+  if [[ -n "\${FAKE_GIT_REMOTE_DELETE_LOG:-}" ]]; then
+    printf '%s\n' "\${6:-}" >> "\${FAKE_GIT_REMOTE_DELETE_LOG}"
+  fi
+fi
+
+exec "${real_git_bin}" "\$@"
+EOF
+    chmod +x "${fake_bin}/git"
+
+    printf '%s\n' "${fake_bin}"
+}
+
 run_worktree_plan() {
     local repo_dir="$1"
     local fake_bin="$2"
@@ -1791,6 +1815,57 @@ test_cleanup_accepts_alias_path_when_branch_matches_same_worktree() {
     test_pass
 }
 
+test_cleanup_alias_path_still_blocks_on_stale_beads_metadata() {
+    test_start "worktree_ready_cleanup_alias_path_still_blocks_on_stale_beads_metadata"
+
+    local fixture_root repo_dir fake_bin path_worktree alias_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    path_worktree="${fixture_root}/moltinger-path-target"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$path_worktree" "feat/path-target" "main"
+    path_worktree="$(cd "$path_worktree" && pwd -P)"
+    alias_path="${fixture_root}/moltinger-path-target-alias"
+    ln -s "$path_worktree" "$alias_path"
+    (
+        cd "$path_worktree"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/path-target >/dev/null
+        git merge --no-ff feat/path-target -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{\"name\":\"path-target\",\"path\":\"%s\",\"branch\":\"feat/path-target\",\"beads_state\":\"local\"}]\n' "${path_worktree}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_REMOVE_CANONICALIZE=1 \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --path "$alias_path" --branch feat/path-target 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup should fail closed when alias-path fallback leaves stale Beads metadata"
+    assert_contains "$output" 'Status: cleanup_blocked' "Alias-path cleanup should still block on stale Beads metadata"
+    assert_contains "$output" 'Beads still reports' "Alias-path cleanup should surface the Beads reconciliation warning"
+    assert_contains "$output" 'Repair Command: cd ' "Alias-path cleanup should expose the repair command when Beads metadata remains stale"
+    if [[ -d "$path_worktree" ]]; then
+        test_fail "Cleanup should remove the real worktree before blocking on stale Beads metadata"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_cleanup_refreshes_remote_refs_before_using_local_merge_proof() {
     test_start "worktree_ready_cleanup_refreshes_remote_refs_before_using_local_merge_proof"
 
@@ -2024,11 +2099,13 @@ test_cleanup_delete_branch_uses_github_api_remote_delete_fallback() {
 test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists() {
     test_start "worktree_ready_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists"
 
-    local fixture_root repo_dir fake_bin existing_path output rc
+    local fixture_root repo_dir fake_bin fake_git_bin existing_path output rc remote_delete_log
     fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
     repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
     repo_dir="$(cd "$repo_dir" && pwd -P)"
     fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    fake_git_bin="$(create_fake_git_observer_bin "$fixture_root" "$(command -v git)")"
+    remote_delete_log="${fixture_root}/remote-delete.log"
     existing_path="${fixture_root}/moltinger-remote-uat-hardening"
     git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
     existing_path="$(cd "$existing_path" && pwd -P)"
@@ -2053,7 +2130,9 @@ test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists() {
         BD_WORKTREE_REMOVE_NOOP=1 \
         BD_WORKTREE_REMOVE_RC=23 \
         BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
-        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening --delete-branch 2>&1
+        FAKE_GIT_CAPTURE_REMOTE_DELETE=1 \
+        FAKE_GIT_REMOTE_DELETE_LOG="${remote_delete_log}" \
+        run_worktree_cleanup "$repo_dir" "${fake_git_bin}:${fake_bin}" --branch feat/remote-uat-hardening --delete-branch 2>&1
         printf '\n__RC__=%s\n' "$?"
     )"
     rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
@@ -2072,6 +2151,9 @@ test_cleanup_blocks_branch_delete_when_only_local_stale_proof_exists() {
     fi
     if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
         test_fail "Cleanup must preserve the remote-tracking ref when authoritative branch-delete proof is unavailable"
+    fi
+    if [[ -f "${remote_delete_log}" ]] && grep -q 'feat/remote-uat-hardening' "${remote_delete_log}"; then
+        test_fail "Cleanup must not attempt remote deletion when only local stale proof is available"
     fi
 
     rm -rf "$fixture_root"
@@ -2275,6 +2357,7 @@ run_all_tests() {
     test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree
     test_cleanup_blocks_conflicting_path_and_branch_arguments
     test_cleanup_accepts_alias_path_when_branch_matches_same_worktree
+    test_cleanup_alias_path_still_blocks_on_stale_beads_metadata
     test_cleanup_refreshes_remote_refs_before_using_local_merge_proof
     test_cleanup_uses_local_stale_proof_for_worktree_fallback_when_refresh_fails
     test_cleanup_blocks_when_git_fallback_leaves_beads_metadata_stale

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -133,6 +133,24 @@ if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "DELETE" ]]; then
   exit "${GH_API_RC:-0}"
 fi
 
+if [[ "${1:-}" == "api" && -n "${2:-}" ]]; then
+  if [[ -n "${GH_EXPECT_CWD:-}" && "${PWD}" != "${GH_EXPECT_CWD}" ]]; then
+    printf 'unexpected gh cwd: %s\n' "${PWD}" >&2
+    exit 97
+  fi
+  if [[ -n "${GH_EXPECT_API_GET_ROUTE:-}" && "${2:-}" != "${GH_EXPECT_API_GET_ROUTE}" ]]; then
+    printf 'unexpected gh api route: %s\n' "${2:-}" >&2
+    exit 99
+  fi
+  if [[ -n "${GH_API_GET_STDOUT:-}" ]]; then
+    printf '%s\n' "${GH_API_GET_STDOUT}"
+  fi
+  if [[ -n "${GH_API_GET_STDERR:-}" ]]; then
+    printf '%s\n' "${GH_API_GET_STDERR}" >&2
+  fi
+  exit "${GH_API_GET_RC:-0}"
+fi
+
 printf 'unsupported fake gh invocation\n' >&2
 exit 1
 EOF
@@ -1484,7 +1502,7 @@ test_cleanup_delete_branch_uses_git_ancestor_proof() {
 
     assert_eq "0" "$rc" "Cleanup should delete local and remote branch when git ancestry proves the branch is merged"
     assert_contains "$output" 'Status: cleanup_complete' "Cleanup should complete once branch deletion succeeds"
-    assert_contains "$output" 'Merge Check: git_ancestor_local' "Cleanup should record git ancestry as the merge proof"
+    assert_contains "$output" 'Merge Check: git_ancestor_remote' "Cleanup should record refreshed remote ancestry as the merge proof"
     assert_contains "$output" 'Local Branch Action: deleted' "Cleanup should delete the local branch after worktree removal"
     assert_contains "$output" 'Remote Branch Action: deleted' "Cleanup should delete the remote branch after merge proof"
     if git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
@@ -1492,6 +1510,290 @@ test_cleanup_delete_branch_uses_git_ancestor_proof() {
     fi
     if git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
         test_fail "Cleanup should remove the remote branch after delete-branch success"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard() {
+    test_start "worktree_ready_cleanup_uses_git_remove_fallback_for_false_unpushed_guard"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{"name":"remote-uat-hardening","path":"%s","branch":"feat/remote-uat-hardening","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should recover when bd falsely reports unpushed commits for a merged clean worktree"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should complete after the direct git fallback removes the worktree"
+    assert_contains "$output" 'Worktree Action: removed' "Cleanup should report the worktree as removed after the fallback"
+    assert_contains "$output" 'Merge Check: git_ancestor_remote' "Cleanup should still require authoritative refreshed remote proof before using the fallback"
+    assert_contains "$output" 'git worktree remove fallback succeeded' "Cleanup should explain that the direct git fallback was used"
+    if [[ -d "$existing_path" ]]; then
+        test_fail "Cleanup should remove the worktree directory after the fallback succeeds"
+    fi
+    if git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup should remove the local branch after the fallback succeeds"
+    fi
+    if git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup should remove the remote branch after the fallback succeeds"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_does_not_bypass_false_unpushed_guard_without_merge_proof() {
+    test_start "worktree_ready_cleanup_does_not_bypass_false_unpushed_guard_without_merge_proof"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+    )
+    bd_json="$(printf '[{"name":"remote-uat-hardening","path":"%s","branch":"feat/remote-uat-hardening","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup must stay blocked when bd reports unpushed commits and merged proof is missing"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked when the fallback cannot establish merged proof"
+    assert_contains "$output" 'Worktree Action: blocked' "Cleanup should not remove the worktree when the branch is not merged"
+    assert_contains "$output" 'bd worktree remove failed' "Cleanup should preserve the original bd failure context when no safe fallback exists"
+    if [[ ! -d "$existing_path" ]]; then
+        test_fail "Cleanup must preserve the worktree when merged proof is missing"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch when merged proof is missing"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the remote branch when merged proof is missing"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree() {
+    test_start "worktree_ready_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+    )
+    (
+        cd "$existing_path"
+        printf 'dirty\n' > dirty.txt
+    )
+    bd_json="$(printf '[{"name":"remote-uat-hardening","path":"%s","branch":"feat/remote-uat-hardening","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup must stay blocked when the worktree is dirty even if the branch is merged"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked for a dirty worktree"
+    assert_contains "$output" 'Worktree Action: blocked' "Cleanup should not remove a dirty worktree through the fallback path"
+    assert_contains "$output" 'bd worktree remove failed' "Cleanup should preserve the bd failure context when the fallback is disallowed"
+    if [[ ! -d "$existing_path" ]]; then
+        test_fail "Cleanup must preserve the dirty worktree when the fallback is disallowed"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch for a dirty worktree"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the remote branch for a dirty worktree"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_blocks_conflicting_path_and_branch_arguments() {
+    test_start "worktree_ready_cleanup_blocks_conflicting_path_and_branch_arguments"
+
+    local fixture_root repo_dir fake_bin path_worktree branch_worktree output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    path_worktree="${fixture_root}/moltinger-path-target"
+    branch_worktree="${fixture_root}/moltinger-branch-target"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$path_worktree" "feat/path-target" "main"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$branch_worktree" "feat/branch-target" "main"
+    path_worktree="$(cd "$path_worktree" && pwd -P)"
+    branch_worktree="$(cd "$branch_worktree" && pwd -P)"
+    (
+        cd "$branch_worktree"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: branch target commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/branch-target >/dev/null
+        git merge --no-ff feat/branch-target -m "fixture: merge branch target" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{"name":"path-target","path":"%s","branch":"feat/path-target","beads_state":"local"},{"name":"branch-target","path":"%s","branch":"feat/branch-target","beads_state":"local"}]\n' "${path_worktree}" "${branch_worktree}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --path "$path_worktree" --branch feat/branch-target --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup must fail closed when --path and --branch resolve to different worktrees"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should report cleanup_blocked for conflicting target arguments"
+    assert_contains "$output" 'Cleanup arguments conflict' "Cleanup should explain the path/branch mismatch"
+    if [[ ! -d "$path_worktree" ]]; then
+        test_fail "Cleanup must not remove the worktree selected by --path when arguments conflict"
+    fi
+    if [[ ! -d "$branch_worktree" ]]; then
+        test_fail "Cleanup must not touch the unrelated branch worktree when arguments conflict"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/branch-target; then
+        test_fail "Cleanup must preserve the branch selected by the conflicting --branch argument"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/branch-target; then
+        test_fail "Cleanup must preserve the remote branch selected by the conflicting --branch argument"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_refreshes_remote_refs_before_using_local_merge_proof() {
+    test_start "worktree_ready_cleanup_refreshes_remote_refs_before_using_local_merge_proof"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json second_clone
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-remote-uat-hardening"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/remote-uat-hardening" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: feature branch commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/remote-uat-hardening >/dev/null
+        git merge --no-ff feat/remote-uat-hardening -m "fixture: merge feature branch" >/dev/null
+        git push origin main >/dev/null
+    )
+    second_clone="${fixture_root}/moltinger-second-clone"
+    git clone "${fixture_root}/moltinger.git" "$second_clone" >/dev/null 2>&1
+    (
+        cd "$second_clone"
+        git checkout feat/remote-uat-hardening >/dev/null 2>&1
+        printf 'late\n' > late.txt
+        git add late.txt
+        git commit -m "fixture: late remote branch commit" >/dev/null
+        git push origin feat/remote-uat-hardening >/dev/null
+    )
+    bd_json="$(printf '[{"name":"remote-uat-hardening","path":"%s","branch":"feat/remote-uat-hardening","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_WORKTREE_REMOVE_NOOP=1 \
+        BD_WORKTREE_REMOVE_RC=23 \
+        BD_WORKTREE_REMOVE_STDERR='safety check failed: worktree has unpushed commits. Use --force to skip safety checks.' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/remote-uat-hardening --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup must block when a refreshed remote branch moved ahead and is no longer merged"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should stay blocked after refreshing remote refs reveals a live ahead branch"
+    assert_contains "$output" 'Merge Check: not_merged' "Cleanup should refuse to trust stale local merge proof once the remote branch has moved"
+    if [[ ! -d "$existing_path" ]]; then
+        test_fail "Cleanup must preserve the worktree when the refreshed remote branch is not merged"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the local branch when the refreshed remote branch is not merged"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/remotes/origin/feat/remote-uat-hardening; then
+        test_fail "Cleanup must preserve the refreshed remote-tracking branch when the remote branch moved ahead"
     fi
 
     rm -rf "$fixture_root"
@@ -1579,6 +1881,8 @@ test_cleanup_delete_branch_uses_github_api_remote_delete_fallback() {
         WORKTREE_READY_ASSUME_GITHUB_ORIGIN=1 \
         GH_EXPECT_CWD="${repo_dir}" \
         GH_EXPECT_API_DELETE_ROUTE="repos/example/repo/git/refs/heads/feat/remote-uat-hardening" \
+        GH_EXPECT_API_GET_ROUTE="repos/example/repo/git/ref/heads/feat/remote-uat-hardening" \
+        GH_API_GET_STDOUT="$(printf '{"object":{"sha":"%s"}}\n' "${head_sha}")" \
         GH_REPO_VIEW_JSON='{"defaultBranchRef":{"name":"main"},"deleteBranchOnMerge":false,"nameWithOwner":"example/repo"}' \
         GH_PR_LIST_JSON="$(printf '[{"number":111,"state":"MERGED","mergedAt":"2026-03-27T20:30:28Z","headRefName":"feat/remote-uat-hardening","headRefOid":"%s","baseRefName":"main","isCrossRepository":false,"url":"https://github.com/example/repo/pull/111","title":"Fixture merged PR"}]\n' "${head_sha}")" \
         GH_API_DELETE_GIT_DIR="${origin_dir}" \
@@ -1745,6 +2049,11 @@ run_all_tests() {
     test_cleanup_removes_linked_worktree_without_branch_delete
     test_cleanup_prunes_stale_missing_worktree_entry
     test_cleanup_delete_branch_uses_git_ancestor_proof
+    test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard
+    test_cleanup_does_not_bypass_false_unpushed_guard_without_merge_proof
+    test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree
+    test_cleanup_blocks_conflicting_path_and_branch_arguments
+    test_cleanup_refreshes_remote_refs_before_using_local_merge_proof
     test_cleanup_delete_branch_uses_github_fallback_when_git_is_ambiguous
     test_cleanup_delete_branch_uses_github_api_remote_delete_fallback
     test_cleanup_blocks_branch_delete_without_merge_proof


### PR DESCRIPTION
## Summary
- harden worktree cleanup merge-proof resolution against stale local upstream state
- fail closed on conflicting cleanup targeting and dirty/no-proof fallback paths
- add RCA and unit coverage for git refresh, GitHub API fallback, and false unpushed-guard cleanup cases

## Testing
- bash -n scripts/worktree-ready.sh
- bash -n tests/unit/test_worktree_ready.sh
- bash tests/unit/test_worktree_ready.sh