### PR TITLE
docs(topology): publish remote-governance snapshot

### DIFF
--- a/docs/GIT-TOPOLOGY-REGISTRY.md
+++ b/docs/GIT-TOPOLOGY-REGISTRY.md
@@ -11,8 +11,7 @@
 
 | Remote Branch | Current Intent |
 |---|---|
-| `origin/chore/topology-registry-publish` | Needs decision |
-| `origin/feat/moltinger-jb6-1-gpt54-oauth-persistence-fix` | Needs decision |
+| `origin/fix/moltinger-mvy8-live-codex-update-scheduler-regression` | Needs decision |
 
 ## Reviewed Intent Awaiting Reconciliation
 


### PR DESCRIPTION
## Summary
- publish the refreshed shared git topology registry snapshot
- capture the latest post-cleanup worktree topology in the tracked governance doc

## Validation
- topology-registry-publish workflow run 24427149510 completed successfully
