### PR TITLE
fix(worktree): harden branch governance helpers

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-15
-**Total Lessons**: 78
+**Total Lessons**: 79
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (37 lessons)
+#### P1 (38 lessons)
+- [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
 - [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
 - [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
@@ -150,7 +151,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (25 lessons)
+#### process (26 lessons)
+- [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram chat probe skill pointed to a missing wrapper entrypoint](../docs/rca/2026-04-14-telegram-chat-probe-skill-pointed-to-missing-wrapper-entrypoint.md)
 - [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
 - [Telegram skill-detail remained non-terminal and repo skills lacked a shared Telegram-safe summary contract](../docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md)
@@ -200,7 +202,7 @@
 
 ### Popular Tags
 
-- `rca` (26 lessons)
+- `rca` (27 lessons)
 - `moltis` (26 lessons)
 - `telegram` (20 lessons)
 - `deploy` (19 lessons)
@@ -218,8 +220,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 78 |
-| Critical (P0/P1) | 38 |
+| Total Lessons | 79 |
+| Critical (P0/P1) | 39 |
 | Categories | 8 |
 | Unique Tags | 160 |
 

--- a/docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md
+++ b/docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md
@@ -1,0 +1,129 @@
+---
+title: "Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence"
+date: 2026-04-15
+severity: P1
+category: process
+tags: [worktree, beads, command-worktree, phase-a, runtime, governance, rca]
+root_cause: "Repo-owned worktree governance helpers still trusted contextual proxy signals such as stale tracked `.beads/issues.jsonl`, current-cwd `bd worktree list` output, noisy `bd status`, and unsafe empty-array rendering, instead of canonical owner-layer import sources, direct runtime probes, and fail-closed renderer contracts."
+---
+
+# RCA: Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence
+
+**Дата:** 2026-04-15  
+**Статус:** Resolved in source  
+**Влияние:** worktree/branch governance repeatedly produced false blockers, misleading ownership state, and unsafe cleanup/readiness decisions  
+**Контекст:** beads `moltinger-crq6`, repo-owned `command-worktree` / `worktree-ready` / `worktree-phase-a` / Beads localization stack
+
+## Ошибка
+
+Ветка `moltinger-crq6` была заведена после серии governance-аномалий вокруг worktree lifecycle:
+
+- fresh managed Phase A worktree не видел только что созданный canonical Beads issue;
+- `beads-worktree-localize --check` и `worktree-ready doctor` могли ставить `runtime_bootstrap_required`, хотя live backlog уже открывался нормально;
+- `worktree-ready plan/cleanup --format env` логически успешно завершались, но падали в финальном render path на пустых массивах под `set -u`;
+- `bd worktree list --json` в non-main cwd контекстно помечал текущий worktree как `shared`, и repo-owned helper мог принять эту ложь за реальное ownership состояние.
+
+Итог: инструменты branch/worktree governance выглядели “починенными” по отдельности, но в реальном цепочечном использовании снова срывались на source-contract drift.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag worktree`
+- `./scripts/query-lessons.sh --tag beads`
+- `./scripts/query-lessons.sh --tag topology`
+
+**Релевантные прошлые RCA/уроки:**
+1. `docs/rca/2026-03-26-beads-worktree-localize-used-stale-bootstrap-contract.md`  
+   уже фиксировал, что owner-layer localize не должен materialize-ить stale runtime shell из неверного bootstrap path.
+2. `docs/rca/2026-03-26-worktree-create-misread-local-ownership-as-runtime-ready.md`  
+   уже фиксировал, что ownership и runtime health нужно проверять отдельно.
+3. `docs/rca/2026-03-29-runtime-only-repair-contract-still-pointed-at-raw-bootstrap.md`  
+   уже требовал не доверять bare CLI repair/noisy probes без managed helper path.
+4. `docs/rca/2026-03-08-topology-child-worktree-identity-drift.md`  
+   уже показывал, что worktree identity/state не должны зависеть от observer context.
+
+**Что могло быть упущено без этой сверки:**
+- можно было бы снова “починить” только поверхностный Phase A слой и оставить stale/localize drift в owner-layer helper-е;
+- можно было бы принять `bd worktree list` из текущего cwd за truth и снова строить cleanup/doctor решения на ложном `shared`.
+
+**Что в текущем инциденте действительно новое:**
+- truthful canonical issue import пришлось пронести глубже, в `beads-worktree-localize` и `beads-resolve-db`, а не оставлять только в Phase A wrapper-е;
+- `bd worktree list` оказался observer-dependent не только для main, но и для любого non-main cwd, поэтому repo-owned helper должен брать его из canonical root;
+- renderer path сам стал blocker-ом: корректное решение ломалось в финальном env output из-за empty-array contract under `set -u`.
+
+## Evidence
+
+Подтверждённые факты из live repo/tooling:
+
+1. fresh Phase A worktree из текущего repo initially не видел freshly created issue, пока canonical backlog не импортировался явно из live export;
+2. `bash tests/unit/test_bd_dispatch.sh` после owner-layer fix проходит `28/28 PASS`;
+3. `bash tests/unit/test_worktree_phase_a.sh` после canonical export plumbing проходит `10/10 PASS`;
+4. `bash tests/unit/test_worktree_ready.sh` сначала падал на:
+   - `items[@]: unbound variable` в env renderer;
+   - false-negative readiness/cleanup paths;
+5. отдельный live repro показал, что `bd worktree list --json` зависит от cwd:
+   - из canonical `main` current feature worktree выглядел `local`;
+   - из самого feature worktree тот же path выглядел `shared`;
+6. после canonical-root sourcing и regression test `worktree-ready` проходит `43/43 PASS`.
+
+## Анализ 5 Почему (with Evidence)
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему worktree governance продолжал давать ложные blocker-ы и неоднозначный cleanup state? | Потому что helper stack опирался на proxy-сигналы, которые менялись от слоя к слою и от observer context. | fresh Phase A repro, `bd worktree list --json` from different cwd |
+| 2 | Почему proxy-сигналы были ненадёжными? | Потому что разные helper-ы брали разные “истины”: stale tracked `.beads/issues.jsonl`, noisy `bd status`, current-cwd `bd worktree list`, shell-render side effects under `set -u`. | unit failures, manual repro `items[@]: unbound variable`, contextual `shared` output |
+| 3 | Почему это не было поймано раньше? | Потому что часть старых fixes закрывала только отдельный слой (например, Phase A), но не переносила truthful source contract в owner-layer helpers. | `worktree-phase-a.sh` had canonical export, but `beads-worktree-localize.sh` still defaulted to stale tracked foundation |
+| 4 | Почему helper-ы снова путали ownership и runtime state? | Потому что repo stack по-прежнему принимал “что сказал ближайший probe/list” за truth, вместо приоритета canonical/root evidence + direct runtime proof. | `bd info` healthy while `bd status` noisy; `bd worktree list` current-cwd false-positive |
+| 5 | Почему проблема стала системной, а не точечной? | Потому что contract drift жил сразу в нескольких owning layers: Phase A, localize, resolver, readiness helper и renderer. Пока они не были выровнены вместе, любой один частичный fix снова оставлял дыру. | combined fixes across `worktree-phase-a.sh`, `beads-worktree-localize.sh`, `beads-resolve-db.sh`, `worktree-ready.sh` and unit suites |
+
+## Корневая причина
+
+Корневая причина была не в одном конкретном shell баге, а в общем design drift worktree governance stack:
+
+- owner-layer materialization всё ещё мог брать stale source вместо live canonical backlog;
+- runtime health мог трактоваться через шумный probe, хотя direct `bd info` уже давал truth;
+- readiness helper мог принимать observer-dependent `bd worktree list` за истинное ownership состояние;
+- final env renderer не был fail-closed для пустых массивов under `set -u`.
+
+Иными словами, stack доверял contextual proxy-state, а не canonical ownership/runtime evidence.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| □ Actionable? | yes | fixes лежат в repo-owned shell helpers/tests |
+| □ Systemic? | yes | defect span-ил несколько helper layers |
+| □ Preventable? | yes | через owner-layer source-of-truth, canonical-root probing и regression coverage |
+
+## Принятые меры
+
+1. **Немедленное исправление**
+   - `scripts/beads-worktree-localize.sh` получил explicit `--import-source` и теперь materialize-ит local runtime из truthful canonical export, если он передан.
+   - `scripts/beads-resolve-db.sh localize` выровнен с тем же explicit import-source contract.
+   - `scripts/worktree-phase-a.sh` теперь не только экспортирует live canonical backlog, но и пробрасывает этот source в owner-layer localization.
+   - `scripts/worktree-ready.sh`:
+     - использует canonical root для `bd worktree list --json`;
+     - больше не падает на empty env arrays under `set -u`.
+2. **Предотвращение**
+   - добавлены regression tests:
+     - explicit import source wins over stale tracked foundation;
+     - fresh Phase A worktree sees live canonical backlog;
+     - `worktree-ready` canonical-root `bd` lookup does not inherit current-cwd false `shared`;
+     - env renderer stays safe on empty arrays.
+3. **Документация**
+   - этот RCA зафиксирован;
+   - lessons index будет пересобран после landing пакета.
+
+## Связанные обновления
+
+- [x] Тесты добавлены
+- [x] Индекс уроков будет пересобран
+- [ ] Новый rule file не понадобился: контракт ужесточён в owning helpers и regression suites
+
+## Уроки
+
+1. **Owner-layer truth важнее wrapper-local truth.** Если truthful source живёт только в Phase A wrapper-е, drift обязательно вернётся через direct localize/repair path.
+2. **`bd worktree list` нельзя читать буквально из произвольного cwd.** Для repo-owned governance helper-ов observer context должен быть canonicalized.
+3. **Renderer тоже часть safety contract.** Если helper логически уже решил задачу, но падает на финальной сериализации, для оператора это всё ещё broken workflow.
+4. **Worktree governance требует связанного покрытия.** Phase A, localize, resolver, readiness и cleanup нельзя чинить как независимые shell snippets.

--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -20,13 +20,14 @@ beads_resolve_usage() {
   cat <<'EOF'
 Usage:
   scripts/beads-resolve-db.sh [--repo <path>] [--format <human|env>] [--] [bd args...]
-  scripts/beads-resolve-db.sh localize [--repo <path>] [--format <human|env>]
+  scripts/beads-resolve-db.sh localize [--repo <path>] [--format <human|env>] [--import-source <issues.jsonl>]
 
 Description:
   Resolve whether plain `bd` can safely use the current worktree-local tracker,
   should pass through unchanged, or must fail closed before a root fallback.
   The `localize` subcommand materializes a local beads.db from the current
-  worktree's tracked `.beads/issues.jsonl`.
+  worktree's tracked `.beads/issues.jsonl` unless an explicit `--import-source`
+  JSONL path is provided.
 
   When `.beads/pilot-mode.json` or `.beads/cutover-mode.json` exists in a
   dedicated worktree, legacy-only operator paths such as `bd sync` fail
@@ -947,6 +948,16 @@ beads_resolve_probe_local_runtime_health() {
   BEADS_RESOLVE_LAST_BD_RC=0
   BEADS_RESOLVE_LAST_BD_TIMED_OUT="false"
 
+  if ! beads_resolve_run_system_bd_probe "${repo_root}" true info; then
+    BEADS_RESOLVE_RUNTIME_PROBE_STATE="unavailable"
+    return 1
+  fi
+
+  if [[ "${BEADS_RESOLVE_LAST_BD_TIMED_OUT}" != "true" && "${BEADS_RESOLVE_LAST_BD_RC}" -eq 0 ]]; then
+    BEADS_RESOLVE_RUNTIME_PROBE_STATE="healthy"
+    return 0
+  fi
+
   if ! beads_resolve_run_system_bd_probe "${repo_root}" true status; then
     BEADS_RESOLVE_RUNTIME_PROBE_STATE="unavailable"
     return 1
@@ -1005,6 +1016,7 @@ beads_resolve_render_human() {
 beads_localize_worktree() {
   local repo_root="$1"
   local output_format="$2"
+  local explicit_import_source="${3:-}"
   local current_db=""
   local current_dolt=""
   local current_redirect=""
@@ -1029,6 +1041,10 @@ beads_localize_worktree() {
   BEADS_LOCALIZE_FORMAT="${output_format}"
 
   repo_root="$(beads_resolve_normalize_path "${repo_root}")"
+  if [[ -n "${explicit_import_source}" ]]; then
+    explicit_import_source="$(beads_resolve_normalize_path "${explicit_import_source}")"
+    [[ -f "${explicit_import_source}" ]] || beads_resolve_die "--import-source must point to an existing file: ${explicit_import_source}"
+  fi
   current_config="${repo_root}/.beads/config.yaml"
   current_issues="${repo_root}/.beads/issues.jsonl"
   current_db="${repo_root}/.beads/beads.db"
@@ -1107,7 +1123,7 @@ beads_localize_worktree() {
   (
     cd "${repo_root}"
     "${system_bd}" bootstrap >/dev/null 2>&1
-    "${system_bd}" --db "${current_db}" import "${current_issues}" >/dev/null 2>&1
+    "${system_bd}" --db "${current_db}" import "${explicit_import_source:-${current_issues}}" >/dev/null 2>&1
   )
   rm -f "${current_redirect}"
 
@@ -1130,6 +1146,7 @@ beads_localize_worktree() {
 beads_resolve_main() {
   local repo_override=""
   local output_format="human"
+  local import_source=""
   local -a bd_args=()
   local localize_mode="false"
 
@@ -1148,6 +1165,11 @@ beads_resolve_main() {
       --format)
         output_format="${2:-}"
         [[ -n "${output_format}" ]] || beads_resolve_die "--format requires a value"
+        shift 2
+        ;;
+      --import-source)
+        import_source="${2:-}"
+        [[ -n "${import_source}" ]] || beads_resolve_die "--import-source requires a value"
         shift 2
         ;;
       --)
@@ -1176,9 +1198,12 @@ beads_resolve_main() {
   if [[ -n "${repo_override}" ]]; then
     repo_override="$(beads_resolve_normalize_path "${repo_override}")"
   fi
+  if [[ -n "${import_source}" ]]; then
+    import_source="$(beads_resolve_normalize_path "${import_source}")"
+  fi
 
   if [[ "${localize_mode}" == "true" ]]; then
-    beads_localize_worktree "${repo_override:-$PWD}" "${output_format}"
+    beads_localize_worktree "${repo_override:-$PWD}" "${output_format}" "${import_source}"
     return 0
   fi
 

--- a/scripts/beads-worktree-localize.sh
+++ b/scripts/beads-worktree-localize.sh
@@ -10,7 +10,7 @@ source "${REPO_ROOT}/scripts/beads-resolve-db.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/beads-worktree-localize.sh [--path <worktree>] [--format <human|env>] [--check] [--bootstrap-source <ref>]
+  scripts/beads-worktree-localize.sh [--path <worktree>] [--format <human|env>] [--check] [--bootstrap-source <ref>] [--import-source <issues.jsonl>]
 
 Description:
   Localize Beads ownership for an existing git worktree by removing legacy
@@ -33,6 +33,7 @@ target_path=""
 output_format="human"
 check_only="false"
 bootstrap_source=""
+import_source=""
 
 report_state=""
 report_action=""
@@ -42,6 +43,7 @@ report_message=""
 report_notice=""
 report_bootstrap_source=""
 report_runtime_repair_mode=""
+report_import_source=""
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -63,6 +65,11 @@ parse_args() {
       --bootstrap-source)
         bootstrap_source="${2:-}"
         [[ -n "${bootstrap_source}" ]] || die "--bootstrap-source requires a value"
+        shift 2
+        ;;
+      --import-source)
+        import_source="${2:-}"
+        [[ -n "${import_source}" ]] || die "--import-source requires a value"
         shift 2
         ;;
       -h|--help)
@@ -93,6 +100,11 @@ ensure_worktree_context() {
   [[ -n "${target_path}" ]] || die "Unable to resolve target worktree path"
   git -C "${target_path}" rev-parse --show-toplevel >/dev/null 2>&1 || die "Not a git worktree: ${target_path}"
   report_worktree="${target_path}"
+
+  if [[ -n "${import_source}" ]]; then
+    import_source="$(beads_resolve_normalize_path "${import_source}")"
+    [[ -f "${import_source}" ]] || die "--import-source must point to an existing file: ${import_source}"
+  fi
 }
 
 detect_active_migration_mode() {
@@ -128,6 +140,7 @@ classify_state() {
   report_notice=""
   report_bootstrap_source=""
   report_runtime_repair_mode=""
+  report_import_source=""
 
   if beads_resolve_has_local_runtime "${beads_dir}"; then
     has_local_runtime="true"
@@ -351,6 +364,11 @@ materialize_local_db() {
 localize_state() {
   local redirect_path="${target_path}/.beads/redirect"
   local bootstrap_source_used=""
+  local effective_import_source=""
+  local explicit_import_source_used=""
+
+  explicit_import_source_used="${import_source}"
+  report_import_source="${explicit_import_source_used}"
 
   case "${report_state}" in
     current)
@@ -362,10 +380,12 @@ localize_state() {
     runtime_bootstrap_required)
       case "${report_runtime_repair_mode}" in
         rebuild_local_foundation)
-          materialize_local_db "${target_path}/.beads/issues.jsonl"
+          effective_import_source="${import_source:-${target_path}/.beads/issues.jsonl}"
+          materialize_local_db "${effective_import_source}"
           ;;
         repair_runtime_only)
-          materialize_local_db "$(find_runtime_import_source "${target_path}/.beads" 2>/dev/null || true)"
+          effective_import_source="${import_source:-$(find_runtime_import_source "${target_path}/.beads" 2>/dev/null || true)}"
+          materialize_local_db "${effective_import_source}"
           ;;
         *)
           return 1
@@ -374,16 +394,19 @@ localize_state() {
       ;;
     migratable_legacy)
       rm -f "${redirect_path}"
-      materialize_local_db "${target_path}/.beads/issues.jsonl"
+      effective_import_source="${import_source:-${target_path}/.beads/issues.jsonl}"
+      materialize_local_db "${effective_import_source}"
       ;;
     bootstrap_required)
       bootstrap_source_used="${report_bootstrap_source}"
       bootstrap_foundation
       rm -f "${redirect_path}"
-      materialize_local_db "${target_path}/.beads/issues.jsonl"
+      effective_import_source="${import_source:-${target_path}/.beads/issues.jsonl}"
+      materialize_local_db "${effective_import_source}"
       ;;
     partial_foundation)
-      materialize_local_db "${target_path}/.beads/issues.jsonl"
+      effective_import_source="${import_source:-${target_path}/.beads/issues.jsonl}"
+      materialize_local_db "${effective_import_source}"
       ;;
     damaged_blocked)
       return 1
@@ -397,6 +420,9 @@ localize_state() {
   if [[ -n "${bootstrap_source_used}" ]]; then
     report_bootstrap_source="${bootstrap_source_used}"
   fi
+  if [[ -n "${explicit_import_source_used}" ]]; then
+    report_import_source="${explicit_import_source_used}"
+  fi
 }
 
 render_env() {
@@ -409,6 +435,7 @@ render_env() {
   printf 'notice=%q\n' "${report_notice}"
   printf 'bootstrap_source=%q\n' "${report_bootstrap_source}"
   printf 'runtime_repair_mode=%q\n' "${report_runtime_repair_mode}"
+  printf 'import_source=%q\n' "${report_import_source}"
 }
 
 render_human() {
@@ -422,6 +449,9 @@ render_human() {
   fi
   if [[ -n "${report_runtime_repair_mode}" ]]; then
     printf 'Runtime Repair Mode: %s\n' "${report_runtime_repair_mode}"
+  fi
+  if [[ -n "${report_import_source}" ]]; then
+    printf 'Import Source: %s\n' "${report_import_source}"
   fi
   if [[ -n "${report_notice}" ]]; then
     printf 'Notice: %s\n' "${report_notice}"

--- a/scripts/worktree-phase-a.sh
+++ b/scripts/worktree-phase-a.sh
@@ -38,6 +38,8 @@ base_ref="main"
 branch=""
 target_path=""
 output_format="human"
+phase_a_export_path=""
+phase_a_localize_seeded_from_export="false"
 
 parse_args() {
   if [[ $# -eq 0 ]]; then
@@ -167,11 +169,38 @@ phase_a_fail_runtime() {
   exit 23
 }
 
+phase_a_cleanup_export_artifact() {
+  if [[ -n "${phase_a_export_path}" && -f "${phase_a_export_path}" ]]; then
+    rm -f "${phase_a_export_path}"
+  fi
+}
+
+phase_a_export_canonical_backlog() {
+  local export_dir="${canonical_root}/.tmp/worktree-phase-a"
+
+  mkdir -p "${export_dir}"
+  phase_a_export_path="$(mktemp "${export_dir}/canonical-backlog.XXXXXX.jsonl")"
+
+  if ! (
+    cd "${canonical_root}"
+    bd export -o "${phase_a_export_path}" >/dev/null 2>&1
+  ); then
+    phase_a_fail_runtime \
+      "canonical_export_failed" \
+      "Phase A could not export the live canonical Beads backlog before creating the new worktree." \
+      "Run bd export from the canonical root and inspect canonical Beads runtime health there before retrying."
+  fi
+}
+
 phase_a_prepare_beads_runtime() {
   local loop_count=0
   local bootstrap_attempted="false"
+  local -a localize_args=("--path" "${target_path}")
 
   [[ -x "${SCRIPT_DIR}/beads-worktree-localize.sh" ]] || die "Missing beads-worktree-localize.sh; cannot verify worktree-local Beads ownership"
+  if [[ -n "${phase_a_export_path}" ]]; then
+    localize_args+=("--import-source" "${phase_a_export_path}")
+  fi
 
   while [[ "${loop_count}" -lt 4 ]]; do
     loop_count=$((loop_count + 1))
@@ -182,15 +211,21 @@ phase_a_prepare_beads_runtime() {
         return 0
         ;;
       migratable_legacy|bootstrap_required|partial_foundation)
-        "${SCRIPT_DIR}/beads-worktree-localize.sh" --path "${target_path}" >/dev/null \
+        "${SCRIPT_DIR}/beads-worktree-localize.sh" "${localize_args[@]}" >/dev/null \
           || phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
+        if [[ -n "${phase_a_export_path}" ]]; then
+          phase_a_localize_seeded_from_export="true"
+        fi
         ;;
       runtime_bootstrap_required)
         if [[ "${bootstrap_attempted}" == "true" ]]; then
           phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
         fi
-        "${SCRIPT_DIR}/beads-worktree-localize.sh" --path "${target_path}" >/dev/null \
+        "${SCRIPT_DIR}/beads-worktree-localize.sh" "${localize_args[@]}" >/dev/null \
           || phase_a_fail_runtime "${phase_a_localize_state}" "${phase_a_localize_message}" "${phase_a_localize_notice}"
+        if [[ -n "${phase_a_export_path}" ]]; then
+          phase_a_localize_seeded_from_export="true"
+        fi
         bootstrap_attempted="true"
         ;;
       *)
@@ -200,6 +235,25 @@ phase_a_prepare_beads_runtime() {
   done
 
   phase_a_fail_runtime "${phase_a_localize_state:-unknown}" "Beads runtime did not converge to a healthy localized state during Phase A." "${phase_a_localize_notice}"
+}
+
+phase_a_import_canonical_backlog() {
+  if [[ "${phase_a_localize_seeded_from_export}" == "true" ]]; then
+    return 0
+  fi
+
+  [[ -n "${phase_a_export_path}" && -f "${phase_a_export_path}" ]] || phase_a_fail_runtime \
+    "canonical_export_missing" \
+    "Phase A lost the exported canonical Beads backlog before importing it into the new worktree." \
+    "Retry the worktree create flow; the canonical backlog export artifact is required for a truthful handoff."
+
+  (
+    cd "${target_path}"
+    bd import "${phase_a_export_path}" >/dev/null 2>&1
+  ) || phase_a_fail_runtime \
+    "canonical_import_failed" \
+    "Phase A created the git worktree but could not import the live canonical Beads backlog into the new local runtime." \
+    "Run /usr/local/bin/bd doctor --json and ./scripts/beads-worktree-localize.sh --path . inside the target worktree before retrying."
 }
 
 create_from_base() {
@@ -220,12 +274,15 @@ create_from_base() {
     fi
   fi
 
+  phase_a_export_canonical_backlog
+
   if [[ "${branch_exists}" -eq 0 ]]; then
     git -C "${canonical_root}" branch "${branch}" "${base_sha}" >/dev/null
   fi
 
   git -C "${canonical_root}" worktree add "${target_path}" "${branch}" >/dev/null
   phase_a_prepare_beads_runtime
+  phase_a_import_canonical_backlog
 
   head_sha="$(git -C "${target_path}" rev-parse HEAD)"
   if [[ "${head_sha}" != "${base_sha}" ]]; then
@@ -240,6 +297,7 @@ create_from_base() {
 }
 
 main() {
+  trap phase_a_cleanup_export_artifact EXIT
   parse_args "$@"
   ensure_prerequisites
 

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -613,7 +613,7 @@ add_bootstrap_path() {
     return 0
   fi
 
-  for existing_path in "${report_bootstrap_paths[@]}"; do
+  for existing_path in "${report_bootstrap_paths[@]+"${report_bootstrap_paths[@]}"}"; do
     if [[ "${existing_path}" == "${artifact_path}" ]]; then
       return 0
     fi
@@ -646,7 +646,7 @@ build_bootstrap_import_command() {
   fi
 
   command_text="git checkout $(shell_quote "${source_ref}") --"
-  for artifact_path in "${report_bootstrap_paths[@]}"; do
+  for artifact_path in "${report_bootstrap_paths[@]+"${report_bootstrap_paths[@]}"}"; do
     command_text+=" $(shell_quote "${artifact_path}")"
   done
 
@@ -1969,25 +1969,23 @@ remote_branch_exists() {
 count_shared_tokens() {
   local left="$1"
   local right="$2"
-  local token=""
+  local left_token=""
+  local right_token=""
   local count=0
   local -a left_tokens=()
   local -a right_tokens=()
-  declare -A seen_right=()
 
   IFS='-' read -r -a left_tokens <<< "${left}"
   IFS='-' read -r -a right_tokens <<< "${right}"
 
-  for token in "${right_tokens[@]}"; do
-    if [[ ${#token} -ge 3 ]]; then
-      seen_right["${token}"]=1
-    fi
-  done
-
-  for token in "${left_tokens[@]}"; do
-    if [[ ${#token} -ge 3 && -n "${seen_right[${token}]:-}" ]]; then
-      count=$((count + 1))
-    fi
+  for left_token in "${left_tokens[@]}"; do
+    [[ ${#left_token} -ge 3 ]] || continue
+    for right_token in "${right_tokens[@]}"; do
+      if [[ "${left_token}" == "${right_token}" && ${#right_token} -ge 3 ]]; then
+        count=$((count + 1))
+        break
+      fi
+    done
   done
 
   printf '%s\n' "${count}"
@@ -2141,16 +2139,21 @@ find_bd_worktree_by_path() {
   local bd_command=""
   local line=""
   local record_path=""
+  local bd_probe_root=""
+  local normalized_search_path=""
 
   if ! bd_command="$(resolve_bd_command)" || ! command -v jq >/dev/null 2>&1; then
     printf '__PROBE_STATE__\tprobe_unavailable\n'
     return 0
   fi
 
+  normalized_search_path="$(normalize_path "${search_path}" "${resolved_repo_root}")"
+  bd_probe_root="${resolved_canonical_root:-${resolved_repo_root}}"
+
   set +e
   output="$(
-    cd "${resolved_repo_root}" && "${bd_command}" worktree list --json 2>/dev/null \
-      | jq -r '
+    cd "${bd_probe_root}" && "${bd_command}" worktree list --json 2>/dev/null \
+      | jq -r --arg path "${normalized_search_path}" '
         .[]
         | [(.name // ""), (.path // ""), (.branch // ""), (.beads_state // ""), (.redirect_to // "")]
         | @tsv
@@ -2276,6 +2279,8 @@ discover_beads_runtime_state() {
   local has_local_runtime="false"
   local has_runtime_shell="false"
   local doctor_output=""
+  local saw_probe_timeout="false"
+  local saw_probe_execution_failure="false"
 
   discovered_beads_runtime_state=""
   discovered_beads_runtime_probe_state="not_run"
@@ -2308,25 +2313,56 @@ discover_beads_runtime_state() {
   fi
 
   if [[ "${has_local_runtime}" == "true" ]]; then
-    if run_bd_probe_for_path "${worktree_path}" true status; then
+    if run_bd_probe_for_path "${worktree_path}" true info; then
       if [[ "${WORKTREE_READY_LAST_BD_TIMED_OUT}" == "true" ]]; then
-        discovered_beads_runtime_state="probe_unavailable"
-        discovered_beads_runtime_probe_state="timed_out"
-        discovered_beads_runtime_reason="The local plain bd status probe timed out before the target worktree proved runtime health."
-        return 0
-      fi
-
-      if [[ "${WORKTREE_READY_LAST_BD_RC}" -eq 0 ]]; then
+        saw_probe_timeout="true"
+      elif [[ "${WORKTREE_READY_LAST_BD_RC}" -eq 0 ]]; then
         discovered_beads_runtime_state="healthy"
         discovered_beads_runtime_probe_state="ok"
-        discovered_beads_runtime_reason="The local plain bd status probe opened the target runtime successfully."
+        discovered_beads_runtime_reason="The local plain bd info probe opened the target runtime successfully."
         return 0
       fi
     else
-      discovered_beads_runtime_state="probe_unavailable"
-      discovered_beads_runtime_probe_state="probe_unavailable"
-      discovered_beads_runtime_reason="The local plain bd status probe could not be executed from this session."
-      return 0
+      saw_probe_execution_failure="true"
+    fi
+
+    if run_bd_probe_for_path "${worktree_path}" true status; then
+      if [[ "${WORKTREE_READY_LAST_BD_TIMED_OUT}" == "true" ]]; then
+        saw_probe_timeout="true"
+      elif [[ "${WORKTREE_READY_LAST_BD_RC}" -eq 0 ]]; then
+        discovered_beads_runtime_state="healthy"
+        discovered_beads_runtime_probe_state="ok"
+        discovered_beads_runtime_reason="The local plain bd fallback status probe opened the target runtime successfully."
+        return 0
+      fi
+    else
+      saw_probe_execution_failure="true"
+    fi
+
+    if run_system_bd_probe_for_path "${worktree_path}" true info; then
+      if [[ "${WORKTREE_READY_LAST_BD_TIMED_OUT}" == "true" ]]; then
+        saw_probe_timeout="true"
+      elif [[ "${WORKTREE_READY_LAST_BD_RC}" -eq 0 ]]; then
+        discovered_beads_runtime_state="healthy"
+        discovered_beads_runtime_probe_state="ok"
+        discovered_beads_runtime_reason="The fallback system bd info probe opened the target runtime successfully."
+        return 0
+      fi
+    else
+      saw_probe_execution_failure="true"
+    fi
+
+    if run_system_bd_probe_for_path "${worktree_path}" true status; then
+      if [[ "${WORKTREE_READY_LAST_BD_TIMED_OUT}" == "true" ]]; then
+        saw_probe_timeout="true"
+      elif [[ "${WORKTREE_READY_LAST_BD_RC}" -eq 0 ]]; then
+        discovered_beads_runtime_state="healthy"
+        discovered_beads_runtime_probe_state="ok"
+        discovered_beads_runtime_reason="The fallback system bd status probe opened the target runtime successfully."
+        return 0
+      fi
+    else
+      saw_probe_execution_failure="true"
     fi
 
     if run_system_bd_probe_for_path "${worktree_path}" true doctor --json; then
@@ -2344,11 +2380,25 @@ discover_beads_runtime_state() {
         discovered_beads_runtime_reason="The local runtime exists only as a partial Dolt shell; the named 'beads' DB is not materialized yet."
         return 0
       fi
+    else
+      saw_probe_execution_failure="true"
+    fi
+
+    if [[ "${saw_probe_timeout}" == "true" ]]; then
+      discovered_beads_runtime_state="probe_unavailable"
+      discovered_beads_runtime_probe_state="timed_out"
+      discovered_beads_runtime_reason="Wrapper and system bd health probes timed out before the target worktree proved runtime health."
+      return 0
     fi
 
     discovered_beads_runtime_state="probe_unavailable"
-    discovered_beads_runtime_probe_state="status_failed"
-    discovered_beads_runtime_reason="The local runtime exists, but the current session could not prove that plain bd can read it safely."
+    if [[ "${saw_probe_execution_failure}" == "true" ]]; then
+      discovered_beads_runtime_probe_state="probe_unavailable"
+      discovered_beads_runtime_reason="Wrapper and system bd health probes could not be executed from this session."
+    else
+      discovered_beads_runtime_probe_state="status_failed"
+      discovered_beads_runtime_reason="The local runtime exists, but neither wrapper nor system bd probes could prove that plain bd can read it safely."
+    fi
     return 0
   fi
 
@@ -3102,7 +3152,7 @@ set_doctor_next_steps() {
       ;;
   esac
 
-  if [[ "${#report_next_steps[@]}" -gt 0 ]]; then
+  if [[ -n "${report_next_steps[*]-}" ]]; then
     return 0
   fi
 
@@ -3742,7 +3792,7 @@ render_plan_candidates() {
     return 0
   fi
 
-  for candidate in "${planning_candidates[@]}"; do
+  for candidate in "${planning_candidates[@]+"${planning_candidates[@]}"}"; do
     IFS=$'\t' read -r candidate_type candidate_name candidate_path candidate_reason <<< "${candidate}"
     printf '  %d. type=%s name=%s' "${index}" "${candidate_type}" "${candidate_name}"
     if [[ -n "${candidate_path}" && "${candidate_path}" != "-" ]]; then
@@ -3775,9 +3825,9 @@ render_plan_report() {
     if [[ -n "${planning_question}" ]]; then
       render_env_kv "question" "${planning_question}"
     fi
-    render_env_array "next" "${planning_next_steps[@]}"
-    render_env_array "warning" "${planning_warnings[@]}"
-    render_env_array "candidate" "${planning_candidates[@]}"
+    render_env_array "next" "${planning_next_steps[@]+"${planning_next_steps[@]}"}"
+    render_env_array "warning" "${planning_warnings[@]+"${planning_warnings[@]}"}"
+    render_env_array "candidate" "${planning_candidates[@]+"${planning_candidates[@]}"}"
     return 0
   fi
 
@@ -3798,9 +3848,9 @@ render_plan_report() {
     printf 'Question: %s\n' "${planning_question}"
   fi
   printf 'Next:\n'
-  render_numbered_list "${planning_next_steps[@]}"
+  render_numbered_list "${planning_next_steps[@]+"${planning_next_steps[@]}"}"
   render_plan_candidates
-  render_warning_list "${planning_warnings[@]}"
+  render_warning_list "${planning_warnings[@]+"${planning_warnings[@]}"}"
 }
 
 render_readiness_report() {
@@ -3842,16 +3892,16 @@ render_readiness_report() {
       render_env_kv "phase_b_seed_payload" "${report_phase_b_seed_payload}"
     fi
     if [[ "${#report_issue_artifacts[@]}" -gt 0 ]]; then
-      render_env_array "issue_artifact" "${report_issue_artifacts[@]}"
+      render_env_array "issue_artifact" "${report_issue_artifacts[@]+"${report_issue_artifacts[@]}"}"
     fi
     if [[ -n "${report_bootstrap_source_ref}" ]]; then
       render_env_kv "bootstrap_source" "${report_bootstrap_source_ref}"
     fi
     if [[ "${#report_bootstrap_paths[@]}" -gt 0 ]]; then
-      render_env_array "bootstrap_file" "${report_bootstrap_paths[@]}"
+      render_env_array "bootstrap_file" "${report_bootstrap_paths[@]+"${report_bootstrap_paths[@]}"}"
     fi
-    render_env_array "next" "${report_next_steps[@]}"
-    render_env_array "warning" "${report_warnings[@]}"
+    render_env_array "next" "${report_next_steps[@]+"${report_next_steps[@]}"}"
+    render_env_array "warning" "${report_warnings[@]+"${report_warnings[@]}"}"
     return 0
   fi
 
@@ -3864,12 +3914,12 @@ render_readiness_report() {
   fi
   if [[ "${#report_issue_artifacts[@]}" -gt 0 ]]; then
     printf 'Issue Artifacts:\n'
-    render_numbered_list "${report_issue_artifacts[@]}"
+    render_numbered_list "${report_issue_artifacts[@]+"${report_issue_artifacts[@]}"}"
   fi
   if [[ -n "${report_bootstrap_source_ref}" && "${#report_bootstrap_paths[@]}" -gt 0 ]]; then
     printf 'Bootstrap Source: %s\n' "${report_bootstrap_source_ref}"
     printf 'Bootstrap Files:\n'
-    render_numbered_list "${report_bootstrap_paths[@]}"
+    render_numbered_list "${report_bootstrap_paths[@]+"${report_bootstrap_paths[@]}"}"
   fi
   printf 'Status: %s\n' "${report_status}"
   printf 'Phase: %s\n' "${report_phase}"
@@ -3898,10 +3948,10 @@ render_readiness_report() {
     printf 'Pending: %s\n' "${report_pending_work}"
   fi
   printf 'Next:\n'
-  render_numbered_list "${report_next_steps[@]}"
-  render_warning_list "${report_warnings[@]}"
+  render_numbered_list "${report_next_steps[@]+"${report_next_steps[@]}"}"
+  render_warning_list "${report_warnings[@]+"${report_warnings[@]}"}"
   if [[ "${report_handoff_mode}" == "manual" ]]; then
-    render_fenced_bash_block "${report_next_steps[@]}"
+    render_fenced_bash_block "${report_next_steps[@]+"${report_next_steps[@]}"}"
     render_phase_b_seed_prompt
     render_phase_b_seed_payload
   fi
@@ -3936,8 +3986,8 @@ render_finish_report() {
     if [[ -n "${report_repair_command}" ]]; then
       render_env_kv "repair_command" "${report_repair_command}"
     fi
-    render_env_array "next" "${report_next_steps[@]}"
-    render_env_array "warning" "${report_warnings[@]}"
+    render_env_array "next" "${report_next_steps[@]+"${report_next_steps[@]}"}"
+    render_env_array "warning" "${report_warnings[@]+"${report_warnings[@]}"}"
     return 0
   fi
 
@@ -3964,9 +4014,9 @@ render_finish_report() {
     printf 'Repair Command: %s\n' "${report_repair_command}"
   fi
   printf 'Next:\n'
-  render_numbered_list "${report_next_steps[@]}"
-  render_warning_list "${report_warnings[@]}"
-  render_fenced_bash_block "${report_next_steps[@]}"
+  render_numbered_list "${report_next_steps[@]+"${report_next_steps[@]}"}"
+  render_warning_list "${report_warnings[@]+"${report_warnings[@]}"}"
+  render_fenced_bash_block "${report_next_steps[@]+"${report_next_steps[@]}"}"
 }
 
 render_cleanup_report() {
@@ -3990,8 +4040,8 @@ render_cleanup_report() {
     if [[ -n "${report_repair_command}" ]]; then
       render_env_kv "repair_command" "${report_repair_command}"
     fi
-    render_env_array "next" "${report_next_steps[@]}"
-    render_env_array "warning" "${report_warnings[@]}"
+    render_env_array "next" "${report_next_steps[@]+"${report_next_steps[@]}"}"
+    render_env_array "warning" "${report_warnings[@]+"${report_warnings[@]}"}"
     return 0
   fi
 
@@ -4015,11 +4065,11 @@ render_cleanup_report() {
   fi
   if [[ "${#report_next_steps[@]}" -gt 0 ]]; then
     printf 'Next:\n'
-    render_numbered_list "${report_next_steps[@]}"
+    render_numbered_list "${report_next_steps[@]+"${report_next_steps[@]}"}"
   fi
-  render_warning_list "${report_warnings[@]}"
+  render_warning_list "${report_warnings[@]+"${report_warnings[@]}"}"
   if [[ "${#report_next_steps[@]}" -gt 0 ]]; then
-    render_fenced_bash_block "${report_next_steps[@]}"
+    render_fenced_bash_block "${report_next_steps[@]+"${report_next_steps[@]}"}"
   fi
 }
 
@@ -4098,7 +4148,7 @@ set_planning_decision() {
   planning_question=""
   planning_next_steps=()
 
-  for candidate in "${planning_candidates[@]}"; do
+  for candidate in "${planning_candidates[@]+"${planning_candidates[@]}"}"; do
     IFS=$'\t' read -r candidate_type candidate_name candidate_path candidate_reason <<< "${candidate}"
     case "${candidate_reason}" in
       exact-attached-branch)

--- a/tests/unit/test_bd_dispatch.sh
+++ b/tests/unit/test_bd_dispatch.sh
@@ -56,6 +56,25 @@ if [[ "${args[0]:-}" == "import" ]]; then
   exit 0
 fi
 
+if [[ "${args[0]:-}" == "info" ]]; then
+  if [[ -e ".beads/dolt/beads/.fake-broken" ]]; then
+    printf 'Error: failed to open database: simulated broken named db\n' >&2
+    exit 1
+  fi
+  if [[ -n "${db_path}" ]]; then
+    mkdir -p "$(dirname "${db_path}")"
+    if [[ -d "${db_path}" ]]; then
+      : > "${db_path}/.fake-db-touch"
+    else
+      : > "${db_path}"
+    fi
+  fi
+  printf 'INFO_OK\n'
+  printf 'DB=%s\n' "${db_path}"
+  printf 'ARGS=%s\n' "${args[*]}"
+  exit 0
+fi
+
 if [[ "${args[0]:-}" == "status" ]]; then
   if [[ -e ".beads/dolt/beads/.fake-broken" ]]; then
     printf 'Error: failed to open database: failed to initialize schema: failed to run dolt migrations: dolt migration "uuid_primary_keys" failed: migrate events to UUID PK: check column type: Error 1105 (HY000): no root value found in session\n' >&2
@@ -875,6 +894,36 @@ test_localize_materializes_local_db_and_removes_redirect() {
     test_pass
 }
 
+test_localize_prefers_explicit_import_source_over_tracked_foundation() {
+    test_start "localize_prefers_explicit_import_source_over_tracked_foundation"
+
+    local fixture_root repo_dir worktree_path fake_bin output import_source
+    fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    seed_repo_local_bd_tools "${repo_dir}"
+    worktree_path="${fixture_root}/moltinger-localize-explicit-import"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/localize-explicit-import" "main"
+    worktree_path="$(canonicalize_path "${worktree_path}")"
+    seed_local_beads_foundation "${worktree_path}"
+    printf '%s\n' "${repo_dir}/.beads" > "${worktree_path}/.beads/redirect"
+    mkdir -p "${fixture_root}/exports"
+    import_source="$(cd "${fixture_root}/exports" && pwd -P)/live-canonical.jsonl"
+    cat > "${import_source}" <<'EOF'
+{"id":"demo-live","title":"live canonical export","status":"open","type":"task","priority":1}
+EOF
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    output="$(run_localize "${worktree_path}" "${fake_bin}" --path "${worktree_path}" --import-source "${import_source}")"
+
+    assert_contains "${output}" "State: current" "Localization should still converge when an explicit import source is provided"
+    assert_contains "${output}" "Import Source: ${import_source}" "Localization should report the truthful import source it consumed"
+    assert_imported_source_equals "${worktree_path}" "${import_source}" "Localization must materialize the local runtime from the explicit import source"
+    assert_named_beads_runtime_present "${worktree_path}" "Localization should materialize the named local Beads runtime from the explicit import source"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
 test_localize_bootstraps_missing_foundation_from_source_ref() {
     test_start "localize_bootstraps_missing_foundation_from_source_ref"
 
@@ -1038,6 +1087,7 @@ run_all_tests() {
     test_plain_bd_blocks_broken_runtime_shell_with_localize_guidance
     test_localize_reports_runtime_bootstrap_required_for_broken_runtime_shell
     test_localize_materializes_local_db_and_removes_redirect
+    test_localize_prefers_explicit_import_source_over_tracked_foundation
     test_localize_bootstraps_missing_foundation_from_source_ref
     test_localize_repairs_stale_dolt_shell_by_rebuilding_local_runtime
     test_plain_bd_blocks_unhealthy_named_runtime_with_localize_guidance

--- a/tests/unit/test_worktree_phase_a.sh
+++ b/tests/unit/test_worktree_phase_a.sh
@@ -23,28 +23,110 @@ if [[ "${1:-}" == "--no-daemon" ]]; then
   shift
 fi
 
-  if [[ "${1:-}" == "--db" ]]; then
-    db_path="${2:-}"
-    shift 2
-    if [[ "${1:-}" == "info" ]]; then
-      mkdir -p "$(dirname "${db_path}")"
-      : > "${db_path}"
-      exit 0
-    fi
-    if [[ "${1:-}" == "import" ]]; then
-      mkdir -p .beads/dolt/beads/.dolt
-      rm -f .beads/dolt/beads/.fake-broken
-      : > .beads/last-touched
-      exit 0
-    fi
-  fi
+db_path=""
+if [[ "${1:-}" == "--db" ]]; then
+  db_path="${2:-}"
+  shift 2
+fi
 
-if [[ "${1:-}" == "status" ]]; then
+if [[ -n "${FAKE_BD_CALL_LOG:-}" ]]; then
+  printf '%s\n' "${1:-}" >> "${FAKE_BD_CALL_LOG}"
+fi
+
+if [[ "${1:-}" == "info" ]]; then
+  if [[ -n "${FAKE_BD_INFO_SLEEP_SECONDS:-}" ]]; then
+    sleep "${FAKE_BD_INFO_SLEEP_SECONDS}"
+  fi
+  if [[ -n "${db_path}" ]]; then
+    mkdir -p "$(dirname "${db_path}")"
+    : > "${db_path}"
+  fi
   if [[ -e ".beads/dolt/beads/.fake-broken" ]]; then
     printf 'simulated broken named db\n' >&2
     exit 1
   fi
+  if [[ -n "${FAKE_BD_INFO_STDOUT:-}" ]]; then
+    printf '%s\n' "${FAKE_BD_INFO_STDOUT}"
+  fi
+  if [[ -n "${FAKE_BD_INFO_STDERR:-}" ]]; then
+    printf '%s\n' "${FAKE_BD_INFO_STDERR}" >&2
+  fi
+  exit "${FAKE_BD_INFO_RC:-0}"
+fi
+
+if [[ "${1:-}" == "import" ]]; then
+  import_source="${2:-}"
+  mkdir -p .beads/dolt/beads/.dolt
+  rm -f .beads/dolt/beads/.fake-broken
+  : > .beads/last-touched
+  if [[ -n "${import_source}" && -f "${import_source}" ]]; then
+    cp "${import_source}" .beads/last-import.jsonl
+  fi
   exit 0
+fi
+
+if [[ "${1:-}" == "export" ]]; then
+  output_path=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output)
+        output_path="${2:-}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  if [[ "${FAKE_BD_EXPORT_MODE:-success}" != "success" ]]; then
+    printf 'simulated export failure\n' >&2
+    exit 1
+  fi
+
+  [[ -n "${output_path}" ]] || {
+    printf 'missing export output path\n' >&2
+    exit 1
+  }
+
+  if [[ -n "${FAKE_BD_EXPORT_SOURCE_FILE:-}" && -f "${FAKE_BD_EXPORT_SOURCE_FILE}" ]]; then
+    cp "${FAKE_BD_EXPORT_SOURCE_FILE}" "${output_path}"
+  else
+    cp .beads/issues.jsonl "${output_path}"
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "status" ]]; then
+  if [[ -n "${FAKE_BD_STATUS_SLEEP_SECONDS:-}" ]]; then
+    sleep "${FAKE_BD_STATUS_SLEEP_SECONDS}"
+  fi
+  if [[ -n "${FAKE_BD_STATUS_STDOUT:-}" ]]; then
+    printf '%s\n' "${FAKE_BD_STATUS_STDOUT}"
+  fi
+  if [[ -n "${FAKE_BD_STATUS_STDERR:-}" ]]; then
+    printf '%s\n' "${FAKE_BD_STATUS_STDERR}" >&2
+  fi
+  if [[ -e ".beads/dolt/beads/.fake-broken" ]]; then
+    printf 'simulated broken named db\n' >&2
+    exit 1
+  fi
+  exit "${FAKE_BD_STATUS_RC:-0}"
+fi
+
+if [[ "${1:-}" == "show" ]]; then
+  issue_id="${2:-}"
+  source_file=".beads/last-import.jsonl"
+  if [[ ! -f "${source_file}" ]]; then
+    source_file=".beads/issues.jsonl"
+  fi
+  if [[ -n "${issue_id}" ]] && [[ -f "${source_file}" ]] && grep -Fq "\"id\":\"${issue_id}\"" "${source_file}"; then
+    grep -F "\"id\":\"${issue_id}\"" "${source_file}"
+    exit 0
+  fi
+  printf 'issue not found\n' >&2
+  exit 1
 fi
 
 if [[ "${1:-}" == "list" ]]; then
@@ -151,6 +233,56 @@ test_phase_a_create_from_base_anchors_new_branch_to_main() {
     test_pass
 }
 
+test_phase_a_create_imports_live_canonical_export() {
+    test_start "worktree_phase_a_create_imports_live_canonical_export"
+
+    local fixture_root repo_dir fake_bin target_path canonical_export output call_log import_count
+    fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    target_path="${fixture_root}/moltinger-live-export"
+    canonical_export="${fixture_root}/canonical-live-export.jsonl"
+    call_log="${fixture_root}/phase-a-live-export.calls"
+
+    mkdir -p "${repo_dir}/.beads"
+    printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
+    printf '{"id":"molt-1","title":"tracked fixture"}\n' > "${repo_dir}/.beads/issues.jsonl"
+    (
+        cd "${repo_dir}"
+        git add .beads/config.yaml .beads/issues.jsonl
+        git commit -m "fixture: track stale issues foundation" >/dev/null
+    )
+
+    cat > "${canonical_export}" <<'EOF'
+{"id":"molt-1","title":"tracked fixture"}
+{"id":"molt-2","title":"live canonical issue"}
+EOF
+
+    output="$(FAKE_BD_CALL_LOG="${call_log}" FAKE_BD_EXPORT_SOURCE_FILE="${canonical_export}" run_phase_a_create "$fake_bin" \
+        --canonical-root "$repo_dir" \
+        --base-ref main \
+        --branch feat/live-export \
+        --path "$target_path" \
+        --format env)"
+
+    assert_contains "$output" 'result=created_from_base' "Phase A should still succeed with a canonical export import step"
+    if [[ ! -f "${target_path}/.beads/last-import.jsonl" ]]; then
+        test_fail "Phase A should record the live canonical export as the final import source"
+    fi
+    assert_contains "$(cat "${target_path}/.beads/last-import.jsonl")" '"id":"molt-2"' "Phase A must import the live canonical export, not just the tracked issues snapshot"
+    if ! (
+        cd "${target_path}"
+        PATH="${fake_bin}:$PATH" bd show molt-2 >/dev/null
+    ); then
+        test_fail "Phase A should make the newly exported canonical issue visible in the fresh worktree without manual import repair"
+    fi
+    import_count="$(grep -c '^import$' "${call_log}" || true)"
+    assert_eq "1" "${import_count}" "Phase A should import the canonical backlog exactly once after runtime prep"
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_phase_a_create_blocks_existing_branch_on_wrong_base() {
     test_start "worktree_phase_a_create_blocks_existing_branch_on_wrong_base"
 
@@ -229,11 +361,12 @@ test_phase_a_create_bootstraps_runtime_shell_when_named_db_missing() {
 test_phase_a_create_repairs_runtime_only_state_without_tracked_issues() {
     test_start "worktree_phase_a_create_repairs_runtime_only_state_without_tracked_issues"
 
-    local fixture_root repo_dir fake_bin target_path output
+    local fixture_root repo_dir fake_bin target_path canonical_export output
     fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
     repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
     fake_bin="$(create_fake_bd_bin "$fixture_root")"
     target_path="${fixture_root}/moltinger-runtime-only"
+    canonical_export="${fixture_root}/canonical-runtime-only-export.jsonl"
 
     mkdir -p "${repo_dir}/.beads"
     printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
@@ -243,7 +376,11 @@ test_phase_a_create_repairs_runtime_only_state_without_tracked_issues() {
         git commit -m "fixture: track runtime-only local foundation" >/dev/null
     )
 
-    output="$(run_phase_a_create "$fake_bin" \
+    cat > "${canonical_export}" <<'EOF'
+{"id":"molt-1","title":"live runtime issue"}
+EOF
+
+    output="$(FAKE_BD_EXPORT_SOURCE_FILE="${canonical_export}" run_phase_a_create "$fake_bin" \
         --canonical-root "$repo_dir" \
         --base-ref main \
         --branch feat/runtime-only \
@@ -301,6 +438,89 @@ test_phase_a_create_rebuilds_unhealthy_named_runtime() {
     test_pass
 }
 
+test_phase_a_create_accepts_info_probe_when_status_probe_is_noisy() {
+    test_start "worktree_phase_a_create_accepts_info_probe_when_status_probe_is_noisy"
+
+    local fixture_root repo_dir fake_bin target_path output
+    fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    target_path="${fixture_root}/moltinger-noisy-status"
+
+    mkdir -p "${repo_dir}/.beads"
+    printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
+    printf '{"id":"molt-1","title":"fixture"}\n' > "${repo_dir}/.beads/issues.jsonl"
+    (
+        cd "${repo_dir}"
+        git add .beads/config.yaml .beads/issues.jsonl
+        git commit -m "fixture: tracked local foundation for noisy status probe" >/dev/null
+    )
+
+    output="$(FAKE_BD_STATUS_RC="1" \
+        FAKE_BD_STATUS_STDERR='failed to get statistics: dial tcp 127.0.0.1:12345: connect: connection refused' \
+        FAKE_BD_INFO_STDOUT='Beads Database Information' \
+        run_phase_a_create "$fake_bin" \
+        --canonical-root "$repo_dir" \
+        --base-ref main \
+        --branch feat/noisy-status \
+        --path "$target_path" \
+        --format env)"
+
+    assert_contains "$output" 'result=created_from_base' "Phase A should trust a successful info probe even when status is noisy"
+    if [[ ! -f "${target_path}/.beads/last-import.jsonl" && ! -f "${target_path}/.beads/last-touched" ]]; then
+        test_fail "Phase A should still finish the canonical import path when status probing is noisy"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_phase_a_create_falls_back_to_status_when_info_probe_times_out() {
+    test_start "worktree_phase_a_create_falls_back_to_status_when_info_probe_times_out"
+
+    local fixture_root repo_dir fake_bin target_path output call_log info_line status_line
+    fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    target_path="${fixture_root}/moltinger-info-timeout"
+    call_log="${fixture_root}/phase-a-info-timeout.calls"
+
+    mkdir -p "${repo_dir}/.beads"
+    printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
+    printf '{"id":"molt-1","title":"fixture"}\n' > "${repo_dir}/.beads/issues.jsonl"
+    (
+        cd "${repo_dir}"
+        git add .beads/config.yaml .beads/issues.jsonl
+        git commit -m "fixture: tracked local foundation for info-timeout fallback" >/dev/null
+    )
+
+    output="$(BEADS_RESOLVE_BD_TIMEOUT_SECONDS="1" \
+        FAKE_BD_CALL_LOG="${call_log}" \
+        FAKE_BD_INFO_SLEEP_SECONDS="2" \
+        FAKE_BD_STATUS_STDOUT='ok' \
+        run_phase_a_create "$fake_bin" \
+        --canonical-root "$repo_dir" \
+        --base-ref main \
+        --branch feat/info-timeout \
+        --path "$target_path" \
+        --format env)"
+
+    assert_contains "$output" 'result=created_from_base' "Phase A should fall back to status when info probing times out"
+    info_line="$(grep -n '^info$' "${call_log}" | head -1 | cut -d: -f1)"
+    status_line="$(grep -n '^status$' "${call_log}" | head -1 | cut -d: -f1)"
+    if [[ -z "${info_line}" || -z "${status_line}" ]]; then
+        test_fail "Phase A timeout fallback should probe both info and status"
+        return
+    fi
+    if (( info_line >= status_line )); then
+        test_fail "Phase A timeout fallback should try info before status"
+        return
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair() {
     test_start "worktree_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair"
 
@@ -338,6 +558,43 @@ test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair() {
     test_pass
 }
 
+test_phase_a_create_blocks_when_canonical_export_fails() {
+    test_start "worktree_phase_a_create_blocks_when_canonical_export_fails"
+
+    local fixture_root repo_dir fake_bin target_path output rc
+    fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    target_path="${fixture_root}/moltinger-export-fail"
+
+    mkdir -p "${repo_dir}/.beads"
+    printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
+    printf '{"id":"molt-1","title":"fixture"}\n' > "${repo_dir}/.beads/issues.jsonl"
+    (
+        cd "${repo_dir}"
+        git add .beads/config.yaml .beads/issues.jsonl
+        git commit -m "fixture: track export failure baseline" >/dev/null
+    )
+
+    output="$(
+        set +e
+        FAKE_BD_EXPORT_MODE="fail" run_phase_a_create "$fake_bin" \
+            --canonical-root "$repo_dir" \
+            --base-ref main \
+            --branch feat/export-fail \
+            --path "$target_path" 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Phase A must fail closed when canonical backlog export fails"
+    assert_contains "$output" "could not export the live canonical Beads backlog" "Phase A must explain the canonical export blocker"
+    assert_file_missing "$target_path" "Phase A should not create a worktree when canonical export fails"
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 run_all_tests() {
     start_timer
 
@@ -358,9 +615,13 @@ run_all_tests() {
     test_phase_a_create_from_base_anchors_new_branch_to_main
     test_phase_a_create_blocks_existing_branch_on_wrong_base
     test_phase_a_create_bootstraps_runtime_shell_when_named_db_missing
+    test_phase_a_create_imports_live_canonical_export
     test_phase_a_create_repairs_runtime_only_state_without_tracked_issues
     test_phase_a_create_rebuilds_unhealthy_named_runtime
+    test_phase_a_create_accepts_info_probe_when_status_probe_is_noisy
+    test_phase_a_create_falls_back_to_status_when_info_probe_times_out
     test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair
+    test_phase_a_create_blocks_when_canonical_export_fails
     generate_report
 }
 

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -41,6 +41,10 @@ if [[ "${1:-}" == "worktree" && "${2:-}" == "list" && "${3:-}" == "--json" ]]; t
   exit 0
 fi
 
+if [[ -n "${BD_CALL_LOG:-}" ]]; then
+  printf '%s\n' "${1:-}" >> "${BD_CALL_LOG}"
+fi
+
 if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
   target_path="${3:-}"
   if [[ "${BD_WORKTREE_REMOVE_CANONICALIZE:-0}" == "1" && -d "${target_path}" ]]; then
@@ -85,10 +89,96 @@ if [[ "${1:-}" == "status" ]]; then
   exit "${BD_STATUS_RC:-0}"
 fi
 
+if [[ "${1:-}" == "info" ]]; then
+  if [[ -n "${BD_INFO_SLEEP_SECONDS:-}" ]]; then
+    sleep "${BD_INFO_SLEEP_SECONDS}"
+  fi
+  if [[ -n "${BD_INFO_STDOUT:-}" ]]; then
+    printf '%s\n' "${BD_INFO_STDOUT}"
+  fi
+  if [[ -n "${BD_INFO_STDERR:-}" ]]; then
+    printf '%s\n' "${BD_INFO_STDERR}" >&2
+  fi
+  exit "${BD_INFO_RC:-0}"
+fi
+
 if [[ "${1:-}" == "doctor" && "${2:-}" == "--json" ]]; then
   if [[ -n "${BD_DOCTOR_SLEEP_SECONDS:-}" ]]; then
     sleep "${BD_DOCTOR_SLEEP_SECONDS}"
   fi
+  printf '%s\n' "${BD_DOCTOR_STDOUT:-{\"checks\":[],\"overall_ok\":true}}"
+  exit "${BD_DOCTOR_RC:-0}"
+fi
+
+printf 'unsupported fake bd invocation\n' >&2
+exit 1
+EOF
+    chmod +x "${fake_bin}/bd"
+
+    printf '%s\n' "${fake_bin}"
+}
+
+create_cwd_sensitive_bd_bin() {
+    local fixture_root="$1"
+    local fake_bin="${fixture_root}/cwd-sensitive-bd-bin"
+
+    mkdir -p "${fake_bin}"
+    cat > "${fake_bin}/bd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "worktree" && "${2:-}" == "list" && "${3:-}" == "--json" ]]; then
+  if [[ -n "${BD_WORKTREE_LIST_SHARED_CWD:-}" && "${PWD}" == "${BD_WORKTREE_LIST_SHARED_CWD}" ]]; then
+    printf '%s\n' "${BD_WORKTREE_LIST_JSON_SHARED:-[]}"
+    exit 0
+  fi
+  if [[ -n "${BD_WORKTREE_LIST_CANONICAL_CWD:-}" && "${PWD}" == "${BD_WORKTREE_LIST_CANONICAL_CWD}" ]]; then
+    printf '%s\n' "${BD_WORKTREE_LIST_JSON_CANONICAL:-[]}"
+    exit 0
+  fi
+  printf '%s\n' "${BD_WORKTREE_LIST_JSON:-[]}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
+  target_path="${3:-}"
+  if [[ "${BD_WORKTREE_REMOVE_NOOP:-0}" != "1" && -n "${target_path}" ]]; then
+    git worktree remove "${target_path}" >/dev/null 2>&1 || true
+  fi
+  exit "${BD_WORKTREE_REMOVE_RC:-0}"
+fi
+
+if [[ "${1:-}" == "list" && "${2:-}" == "--all" && "${3:-}" == "--json" ]]; then
+  printf '%s\n' "${BD_LIST_ALL_JSON:-[]}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "show" && "${3:-}" == "--json" ]]; then
+  printf '%s\n' "${BD_SHOW_JSON:-[]}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "status" ]]; then
+  if [[ -n "${BD_STATUS_STDOUT:-}" ]]; then
+    printf '%s\n' "${BD_STATUS_STDOUT}"
+  fi
+  if [[ -n "${BD_STATUS_STDERR:-}" ]]; then
+    printf '%s\n' "${BD_STATUS_STDERR}" >&2
+  fi
+  exit "${BD_STATUS_RC:-0}"
+fi
+
+if [[ "${1:-}" == "info" ]]; then
+  if [[ -n "${BD_INFO_STDOUT:-}" ]]; then
+    printf '%s\n' "${BD_INFO_STDOUT}"
+  fi
+  if [[ -n "${BD_INFO_STDERR:-}" ]]; then
+    printf '%s\n' "${BD_INFO_STDERR}" >&2
+  fi
+  exit "${BD_INFO_RC:-0}"
+fi
+
+if [[ "${1:-}" == "doctor" && "${2:-}" == "--json" ]]; then
   printf '%s\n' "${BD_DOCTOR_STDOUT:-{\"checks\":[],\"overall_ok\":true}}"
   exit "${BD_DOCTOR_RC:-0}"
 fi
@@ -340,6 +430,27 @@ EOF
     printf '%s\n' "${fake_bin}"
 }
 
+seed_timeouting_worktree_bd_wrapper() {
+    local worktree_dir="$1"
+
+    mkdir -p "${worktree_dir}/bin"
+    cat > "${worktree_dir}/bin/bd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "info" || "${1:-}" == "status" ]]; then
+  if [[ -n "${WORKTREE_WRAPPER_CALL_LOG:-}" ]]; then
+    printf '%s\n' "${1:-}" >> "${WORKTREE_WRAPPER_CALL_LOG}"
+  fi
+  sleep "${WORKTREE_WRAPPER_PROBE_SLEEP_SECONDS:-2}"
+  exit 0
+fi
+
+exec bd "$@"
+EOF
+    chmod +x "${worktree_dir}/bin/bd"
+}
+
 create_fake_osascript_failure_bin() {
     local fixture_root="$1"
     local fake_bin="${fixture_root}/osascript-failure-bin"
@@ -473,6 +584,11 @@ test_plan_creates_clean_slug_without_issue() {
     assert_contains "$output" 'Branch: feat/remote-uat-hardening' "Slug-only plan should derive a clean feature branch"
     assert_contains "$output" 'Preview: ../moltinger-remote-uat-hardening' "Slug-only plan should derive a clean sibling worktree path"
     assert_contains "$output" 'Decision: create_clean' "Slug-only plan should choose clean creation when there are no collisions"
+
+    output="$(run_worktree_plan "$repo_dir" "$fake_bin" --slug remote-uat-hardening --format env)"
+
+    assert_contains "$output" 'warning_count=0' "Env planning output should serialize empty warnings arrays safely"
+    assert_contains "$output" 'candidate_count=0' "Env planning output should serialize empty candidate arrays safely"
 
     rm -rf "$fixture_root"
     test_pass
@@ -981,6 +1097,45 @@ test_doctor_accepts_local_beads_state() {
     test_pass
 }
 
+test_doctor_uses_canonical_root_for_bd_worktree_listing() {
+    test_start "worktree_ready_doctor_uses_canonical_root_for_bd_worktree_listing"
+
+    local fixture_root canonical_repo_dir fake_bin existing_path output rc shared_json canonical_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    canonical_repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    canonical_repo_dir="$(cd "$canonical_repo_dir" && pwd -P)"
+    fake_bin="$(create_cwd_sensitive_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-current-cwd-local"
+    git_topology_fixture_add_worktree_branch_from "$canonical_repo_dir" "$existing_path" "feat/current-cwd-local" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    seed_fake_guard_script "${existing_path}" "ok"
+    seed_fake_local_beads_runtime "${existing_path}"
+    shared_json="$(printf '[{"name":"current-cwd-local","path":"%s","branch":"feat/current-cwd-local","beads_state":"shared"}]\n' "${existing_path}")"
+    canonical_json="$(printf '[{"name":"current-cwd-local","path":"%s","branch":"feat/current-cwd-local","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        cd "$existing_path"
+        BD_WORKTREE_LIST_SHARED_CWD="$existing_path" \
+        BD_WORKTREE_LIST_JSON_SHARED="${shared_json}" \
+        BD_WORKTREE_LIST_CANONICAL_CWD="${canonical_repo_dir}" \
+        BD_WORKTREE_LIST_JSON_CANONICAL="${canonical_json}" \
+        PATH="${fake_bin}:$PATH" "$WORKTREE_READY_SCRIPT" doctor --repo "$existing_path" --branch feat/current-cwd-local 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Doctor should accept a local worktree even when bd mislabels the current cwd as shared"
+    assert_contains "$output" 'Beads: local' "Doctor should source bd worktree discovery from the canonical root"
+    if [[ "$output" == *'Beads: shared'* ]]; then
+        test_fail "Doctor should not inherit the current cwd shared false-positive"
+        return
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_doctor_blocks_runtime_bootstrap_required_when_external_state_says_local() {
     test_start "worktree_ready_doctor_blocks_runtime_bootstrap_required_when_external_state_says_local"
 
@@ -1006,6 +1161,7 @@ EOF
     output="$(
         set +e
         BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_INFO_RC="1" \
         BD_STATUS_RC="1" \
         BD_STATUS_STDERR='database "beads" not found' \
         BD_DOCTOR_STDOUT="${doctor_json}" \
@@ -1021,6 +1177,92 @@ EOF
     assert_contains "$output" './scripts/beads-worktree-localize.sh --path .' "Doctor must route broken local runtimes through the managed runtime repair helper"
     if [[ "$output" == *"./scripts/git-session-guard.sh --refresh"* ]]; then
         test_fail "Doctor should not prioritize guard refresh ahead of a broken local runtime"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_doctor_accepts_info_probe_when_status_probe_is_noisy() {
+    test_start "worktree_ready_doctor_accepts_info_probe_when_status_probe_is_noisy"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-noisy-status-doctor"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/noisy-status-doctor" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    seed_fake_guard_script "${existing_path}" "ok"
+    seed_fake_local_beads_runtime "${existing_path}"
+    bd_json="$(printf '[{"name":"noisy-status-doctor","path":"%s","branch":"feat/noisy-status-doctor","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_INFO_STDOUT='Beads Database Information' \
+        BD_STATUS_RC="1" \
+        BD_STATUS_STDERR='failed to get statistics: dial tcp 127.0.0.1:12345: connect: connection refused' \
+        run_worktree_doctor "$repo_dir" "$fake_bin" --branch feat/noisy-status-doctor 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Doctor should accept a successful info probe even when status is noisy"
+    assert_contains "$output" 'Status: ready_for_codex' "Doctor should keep the worktree ready when info proves runtime health"
+    assert_contains "$output" 'Beads Runtime: healthy' "Doctor should mark the runtime healthy when info succeeds"
+    if [[ "$output" == *'/usr/local/bin/bd doctor --json'* ]]; then
+        test_fail "Doctor should not drop into runtime repair when info already proved health"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_doctor_uses_system_info_fallback_when_wrapper_probes_time_out() {
+    test_start "worktree_ready_doctor_uses_system_info_fallback_when_wrapper_probes_time_out"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json wrapper_call_log system_call_log
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-wrapper-timeout-doctor"
+    wrapper_call_log="${fixture_root}/wrapper-probe.calls"
+    system_call_log="${fixture_root}/system-probe.calls"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/wrapper-timeout-doctor" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    seed_fake_guard_script "${existing_path}" "ok"
+    seed_fake_local_beads_runtime "${existing_path}"
+    seed_timeouting_worktree_bd_wrapper "${existing_path}"
+    bd_json="$(printf '[{"name":"wrapper-timeout-doctor","path":"%s","branch":"feat/wrapper-timeout-doctor","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        WORKTREE_READY_BD_TIMEOUT_SECONDS="1" \
+        WORKTREE_WRAPPER_PROBE_SLEEP_SECONDS="2" \
+        WORKTREE_WRAPPER_CALL_LOG="${wrapper_call_log}" \
+        BD_CALL_LOG="${system_call_log}" \
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_INFO_STDOUT='Beads Database Information' \
+        run_worktree_doctor "$repo_dir" "$fake_bin" --branch feat/wrapper-timeout-doctor 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Doctor should fall back to the system bd probe when wrapper probes time out"
+    assert_contains "$output" 'Status: ready_for_codex' "Doctor should keep the worktree ready when system info proves runtime health"
+    assert_contains "$output" 'Beads Runtime: healthy' "Doctor should mark runtime healthy after system probe fallback"
+    assert_contains "$output" 'The fallback system bd info probe opened the target runtime successfully.' "Doctor should report the exact system-info fallback reason"
+    if [[ "$output" == *'timed out before the target worktree proved runtime health'* ]]; then
+        test_fail "Doctor should not surface wrapper probe timeout once system fallback proves runtime health"
+    fi
+    if ! grep -q '^info$' "${wrapper_call_log}" || ! grep -q '^status$' "${wrapper_call_log}"; then
+        test_fail "Doctor should try wrapper info and wrapper status before falling back"
+        return
+    fi
+    if ! grep -q '^info$' "${system_call_log}"; then
+        test_fail "Doctor should eventually try the system info probe after wrapper timeouts"
+        return
     fi
 
     rm -rf "$fixture_root"
@@ -1252,6 +1494,7 @@ EOF
     output="$(
         set +e
         BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_INFO_RC="1" \
         BD_STATUS_RC="1" \
         BD_STATUS_STDERR='database "beads" not found' \
         BD_DOCTOR_STDOUT="${doctor_json}" \
@@ -1493,6 +1736,7 @@ test_cleanup_removes_linked_worktree_without_branch_delete() {
     assert_contains "$output" 'worktree_action=removed' "Cleanup should mark the linked worktree as removed"
     assert_contains "$output" 'local_branch_action=not_requested' "Cleanup without --delete-branch should not touch local branches"
     assert_contains "$output" 'remote_branch_action=not_requested' "Cleanup without --delete-branch should not touch remote branches"
+    assert_contains "$output" 'warning_count=0' "Cleanup env output should serialize empty warnings arrays safely"
     if [[ -d "${existing_path}" ]]; then
         test_fail "Cleanup should remove the linked worktree directory"
     fi
@@ -2408,7 +2652,10 @@ run_all_tests() {
     test_create_without_existing_worktree_points_to_phase_a_executor
     test_doctor_branch_only_suppresses_already_attached_warning
     test_doctor_accepts_local_beads_state
+    test_doctor_uses_canonical_root_for_bd_worktree_listing
     test_doctor_blocks_runtime_bootstrap_required_when_external_state_says_local
+    test_doctor_accepts_info_probe_when_status_probe_is_noisy
+    test_doctor_uses_system_info_fallback_when_wrapper_probes_time_out
     test_doctor_does_not_block_on_beads_probe_unavailable
     test_doctor_missing_guard_script_does_not_suggest_refresh
     test_doctor_missing_worktree_routes_back_to_managed_attach


### PR DESCRIPTION
## Summary
- harden beads/worktree helper stack against contextual Beads state drift
- pass explicit backlog import sources through localize/phase-a flows and improve runtime health probing
- add RCA, lessons update, and unit regressions for branch/worktree governance paths

## Testing
- bash tests/unit/test_bd_dispatch.sh
- bash tests/unit/test_worktree_phase_a.sh
- bash tests/unit/test_worktree_ready.sh
- bash scripts/build-lessons-index.sh

## Issue
- moltinger-crq6