### PR TITLE
fix(worktree): support branch-only cleanup without false conflict

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-15
-**Total Lessons**: 79
+**Total Lessons**: 80
 
 ---
 
@@ -54,7 +54,8 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (24 lessons)
+#### P2 (25 lessons)
+- [Worktree cleanup helper treated derived branch-only path as a path/branch conflict](../docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md)
 - [Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard](../docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md)
 - [Telegram skill-detail remained non-terminal and repo skills lacked a shared Telegram-safe summary contract](../docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md)
 - [Tracked deploy empty stdout broke GitHub Actions JSON contract](../docs/rca/2026-04-02-tracked-deploy-empty-stdout-broke-json-contract.md)
@@ -196,13 +197,14 @@
 - [Child worktree reconciliation renames authoritative feature worktree](../docs/rca/2026-03-08-topology-child-worktree-identity-drift.md)
 - [Команда false завершилась с кодом 1](../docs/rca/2026-03-07-false-command-exit-code.md)
 
-#### tooling (1 lessons)
+#### tooling (2 lessons)
+- [Worktree cleanup helper treated derived branch-only path as a path/branch conflict](../docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md)
 - [Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard](../docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md)
 
 
 ### Popular Tags
 
-- `rca` (27 lessons)
+- `rca` (28 lessons)
 - `moltis` (26 lessons)
 - `telegram` (20 lessons)
 - `deploy` (19 lessons)
@@ -210,8 +212,8 @@
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `skills` (11 lessons)
+- `beads` (10 lessons)
 - `process` (9 lessons)
-- `lessons` (9 lessons)
 
 
 ---
@@ -220,10 +222,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 79 |
+| Total Lessons | 80 |
 | Critical (P0/P1) | 39 |
 | Categories | 8 |
-| Unique Tags | 160 |
+| Unique Tags | 161 |
 
 ---
 

--- a/docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md
+++ b/docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md
@@ -1,0 +1,113 @@
+---
+title: "Worktree cleanup helper treated derived branch-only path as a path/branch conflict"
+date: 2026-04-15
+severity: P2
+category: tooling
+tags: [worktree, cleanup, branches, git, beads, rca]
+root_cause: "The repo-owned cleanup helper synthesized a sibling worktree path from `--branch` too early and then treated the absence of a discovered managed worktree as a path/branch conflict, blocking legitimate branch-only cleanup."
+---
+
+# RCA: Worktree cleanup helper treated derived branch-only path as a path/branch conflict
+
+Date: 2026-04-15  
+Status: Resolved in source, pending review/merge  
+Context: beads `moltinger-zjgi`, follow-up governance cleanup after merged lane `moltinger-crq6`
+
+## Ошибка
+
+Во время cleanup stale local-only branches:
+
+```bash
+scripts/worktree-ready.sh cleanup --branch pr-159-review --delete-branch --format env
+scripts/worktree-ready.sh cleanup --branch review-mempalace-skill --delete-branch --format env
+```
+
+repo-owned helper возвращал `cleanup_blocked` и warning такого вида:
+
+```text
+Cleanup arguments conflict: --path /Users/.../moltinger-main-pr-159-review resolves to branch 'unknown', not requested branch 'pr-159-review'.
+```
+
+При этом фактическое состояние было другим:
+
+- у branch вообще не было связанного worktree;
+- `git diff --stat origin/main...<branch>` был пустым;
+- `git rev-list --left-right --count origin/main...<branch>` показывал behind-only merge-safe состояние;
+- PR по этим head-веткам отсутствовал;
+- branch требовал именно branch-only cleanup, а не path/branch disambiguation.
+
+## Проверка прошлых уроков
+
+Проверены:
+
+- `docs/LESSONS-LEARNED.md`
+- `rg -n "cleanup helper|worktree cleanup|path/branch conflict|merged behind-only" docs/rca docs/LESSONS-LEARNED.md -S`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Релевантные прошлые RCA:
+
+1. `docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md`
+   - уже закрывал cleanup path, где lower-layer `unpushed commits` ошибочно блокировал safe cleanup merged clean worktree.
+2. `docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md`
+   - уже фиксировал, что worktree governance helpers нельзя строить на раннем предположении о target identity без canonical discovery.
+
+Что оказалось новым:
+
+- cleanup branch-only path мог сломаться ещё до merge-proof и delete-branch stage;
+- сама branch-only операция ошибочно считалась конфликтом только потому, что helper заранее синтезировал ожидаемый sibling path;
+- отсутствие managed worktree трактовалось как ambiguity, хотя для stale local-only branch это и было нормальным cleanup target state.
+
+## Evidence
+
+Собранная evidence:
+
+1. Live cleanup на `pr-159-review` и `review-mempalace-skill` reproducibly возвращал `cleanup_blocked` с `Cleanup arguments conflict`.
+2. `git worktree list --porcelain` не показывал worktree для этих веток.
+3. `git diff --stat origin/main...pr-159-review` и `git diff --stat origin/main...review-mempalace-skill` были пустыми.
+4. После source fix те же команды завершились успешно:
+   - `worktree_action=already_missing`
+   - `local_branch_action=deleted`
+   - `merge_check=git_ancestor_local`
+5. Новый unit regression воспроизвёл именно сценарий:
+   - branch существует;
+   - branch уже merged into remote default branch;
+   - worktree отсутствует;
+   - cleanup должен пройти без ложного `Cleanup arguments conflict`.
+
+## 5 Whys
+
+| Why | Ответ | Доказательство |
+| --- | --- | --- |
+| 1 | Почему helper блокировал branch-only cleanup? | Потому что cleanup path решил, что `--branch` конфликтует с `--path`. | live helper output |
+| 2 | Почему появился `--path`, хотя user передал только `--branch`? | Потому что `prepare_cleanup_context()` заранее вызывал `derive_sibling_worktree_path "${branch}"`. | `scripts/worktree-ready.sh` cleanup preparation |
+| 3 | Почему derived path считался конфликтом? | Потому что `cleanup_target_arguments_conflict()` трактовал отсутствие `discovered_worktree_path` как конфликтное состояние. | pre-fix function behavior |
+| 4 | Почему это неверно для stale local-only branch? | Потому что при branch-only cleanup отсутствие managed worktree — ожидаемое состояние, а не ambiguity. | `git worktree list --porcelain`, live repo evidence |
+| 5 | Почему helper не был защищён тестом? | Потому что suite покрывал branch cleanup только когда branch резолвится в существующий worktree, но не branch-only cleanup без worktree. | pre-fix `tests/unit/test_worktree_ready.sh` coverage |
+
+## Корневая причина
+
+Repo-owned cleanup helper слишком рано превращал `--branch` в ожидаемый sibling path и затем воспринимал отсутствие найденного managed worktree как path/branch ambiguity. В результате legitimate branch-only cleanup ошибочно блокировался ещё до branch deletion logic и merge-proof stage.
+
+## Fixes Applied
+
+1. `scripts/worktree-ready.sh`
+   - `cleanup_target_arguments_conflict()` теперь срабатывает только когда helper действительно обнаружил managed worktree и может сравнить его с target path;
+   - отсутствие `discovered_worktree_path` больше не считается конфликтом для branch-only cleanup.
+2. `tests/unit/test_worktree_ready.sh`
+   - добавлен positive regression для `--branch ... --delete-branch` без существующего worktree;
+   - добавлен companion regression для branch-only cleanup без `--delete-branch`, чтобы helper не трогал branch и не выдавал ложный conflict.
+3. Live cleanup replay
+   - `pr-159-review` и `review-mempalace-skill` после фикса реально удалились через repo-owned helper, а не через ручной git workaround.
+
+## Prevention
+
+1. Derived preview/path нельзя путать с authoritative discovered target.
+2. Для cleanup branch-only режима отсутствие worktree — это нормальное состояние target, а не признак ambiguity.
+3. Если repo-owned helper synthesizes operator-visible state, любой synthetic field должен быть помечен как hypothesis до discovery.
+4. У каждого conflict guard должен быть unit test не только на positive conflict, но и на no-worktree branch-only non-conflict path.
+
+## Уроки
+
+1. В worktree cleanup synthetic sibling path — это только preview, не доказанный target.
+2. Branch-only cleanup должен работать и без живого worktree, если merge-safe branch proof уже существует.
+3. Если helper блокирует cleanup из-за собственного derived path, это defect owning layer, а не повод делать ручной git cleanup и считать задачу закрытой.

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -1408,7 +1408,11 @@ cleanup_target_arguments_conflict() {
     return 1
   fi
 
-  if [[ -z "${discovered_worktree_path}" ]] || ! paths_refer_to_same_location "${discovered_worktree_path}" "${target_path}"; then
+  if [[ -z "${discovered_worktree_path}" ]]; then
+    return 1
+  fi
+
+  if ! paths_refer_to_same_location "${discovered_worktree_path}" "${target_path}"; then
     return 0
   fi
 

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -1818,6 +1818,91 @@ test_cleanup_delete_branch_uses_git_ancestor_proof() {
     test_pass
 }
 
+test_cleanup_delete_branch_without_existing_worktree_does_not_false_conflict() {
+    test_start "worktree_ready_cleanup_delete_branch_without_existing_worktree_does_not_false_conflict"
+
+    local fixture_root repo_dir fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+
+    (
+        cd "$repo_dir"
+        git checkout -b feat/cleanup-branch-only >/dev/null
+        printf 'branch-only\n' > cleanup.txt
+        git add cleanup.txt
+        git commit -m "fixture: branch-only cleanup commit" >/dev/null
+        git checkout main >/dev/null
+        git merge --no-ff feat/cleanup-branch-only -m "fixture: merge branch-only cleanup" >/dev/null
+        git push origin main >/dev/null
+    )
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON='[]' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/cleanup-branch-only --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should allow branch-only delete when the managed worktree is already missing"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should complete once branch-only deletion succeeds"
+    assert_contains "$output" 'Worktree Action: already_missing' "Cleanup should report that the managed worktree is already gone"
+    assert_contains "$output" 'Merge Check: git_ancestor_local' "Cleanup should use local merged ancestry against the remote default branch when no remote feature branch exists"
+    assert_contains "$output" 'Local Branch Action: deleted' "Cleanup should delete the local branch after merged-proof branch-only cleanup"
+    if printf '%s' "$output" | grep -Fq 'Cleanup arguments conflict'; then
+        test_fail "Branch-only cleanup should not report a false path/branch conflict when no worktree exists"
+    fi
+    if git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/cleanup-branch-only; then
+        test_fail "Cleanup should remove the local branch even when no worktree exists anymore"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_branch_only_without_existing_worktree_preserves_branch_without_delete_flag() {
+    test_start "worktree_ready_cleanup_branch_only_without_existing_worktree_preserves_branch_without_delete_flag"
+
+    local fixture_root repo_dir fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+
+    (
+        cd "$repo_dir"
+        git checkout -b feat/cleanup-branch-only >/dev/null
+        printf 'branch-only\n' > cleanup.txt
+        git add cleanup.txt
+        git commit -m "fixture: branch-only cleanup commit" >/dev/null
+        git checkout main >/dev/null
+        git merge --no-ff feat/cleanup-branch-only -m "fixture: merge branch-only cleanup" >/dev/null
+        git push origin main >/dev/null
+    )
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON='[]' \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/cleanup-branch-only 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should still complete for branch-only targets when no delete flag is requested"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should complete for branch-only targets without delete flag"
+    assert_contains "$output" 'Worktree Action: already_missing' "Cleanup should report the missing worktree even without branch deletion"
+    assert_contains "$output" 'Local Branch Action: not_requested' "Cleanup should preserve the local branch without --delete-branch"
+    if printf '%s' "$output" | grep -Fq 'Cleanup arguments conflict'; then
+        test_fail "Branch-only cleanup without delete flag should not trip the conflict guard"
+    fi
+    if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/cleanup-branch-only; then
+        test_fail "Cleanup should preserve the local branch when --delete-branch is not requested"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard() {
     test_start "worktree_ready_cleanup_uses_git_remove_fallback_for_false_unpushed_guard"
 
@@ -2667,6 +2752,8 @@ run_all_tests() {
     test_cleanup_removes_linked_worktree_without_branch_delete
     test_cleanup_prunes_stale_missing_worktree_entry
     test_cleanup_delete_branch_uses_git_ancestor_proof
+    test_cleanup_delete_branch_without_existing_worktree_does_not_false_conflict
+    test_cleanup_branch_only_without_existing_worktree_preserves_branch_without_delete_flag
     test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard
     test_cleanup_does_not_bypass_false_unpushed_guard_without_merge_proof
     test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree


### PR DESCRIPTION
## Summary
- fix repo-owned cleanup helper so branch-only cleanup no longer trips a false path/branch conflict when the worktree is already missing
- add regressions for branch-only cleanup with and without --delete-branch
- record RCA and refresh lessons learned

## Issue
- moltinger-zjgi
