### PR TITLE
fix(worktree): harden readiness and canonical list routing

### DIFF
--- a/bin/bd
+++ b/bin/bd
@@ -23,6 +23,10 @@ case "${BEADS_RESOLVE_DECISION}" in
   execute_local)
     exec "${SYSTEM_BD}" --db "${BEADS_RESOLVE_DB_PATH}" "$@"
     ;;
+  pass_through_canonical_root_readonly)
+    cd "${BEADS_RESOLVE_CANONICAL_ROOT}"
+    exec "${SYSTEM_BD}" "$@"
+    ;;
   pass_through_non_repo|pass_through_root_readonly|pass_through_root_cleanup_admin|pass_through_global|allow_explicit_troubleshooting)
     exec "${SYSTEM_BD}" "$@"
     ;;

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-15
-**Total Lessons**: 80
+**Total Lessons**: 81
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (38 lessons)
+#### P1 (39 lessons)
+- [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
 - [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
 - [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
@@ -152,7 +153,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (26 lessons)
+#### process (27 lessons)
+- [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
 - [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram chat probe skill pointed to a missing wrapper entrypoint](../docs/rca/2026-04-14-telegram-chat-probe-skill-pointed-to-missing-wrapper-entrypoint.md)
 - [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
@@ -204,7 +206,7 @@
 
 ### Popular Tags
 
-- `rca` (28 lessons)
+- `rca` (29 lessons)
 - `moltis` (26 lessons)
 - `telegram` (20 lessons)
 - `deploy` (19 lessons)
@@ -212,7 +214,7 @@
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `skills` (11 lessons)
-- `beads` (10 lessons)
+- `beads` (11 lessons)
 - `process` (9 lessons)
 
 
@@ -222,8 +224,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 80 |
-| Critical (P0/P1) | 39 |
+| Total Lessons | 81 |
+| Critical (P0/P1) | 40 |
 | Categories | 8 |
 | Unique Tags | 161 |
 

--- a/docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md
+++ b/docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md
@@ -1,0 +1,110 @@
+---
+title: "Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd"
+date: 2026-04-15
+severity: P1
+category: process
+tags: [worktree, beads, command-worktree, phase-a, runtime, governance, rca]
+root_cause: "Repo-owned worktree helpers still treated post-bootstrap context as ready too early and let plain `bd worktree list` inherit observer cwd instead of forcing canonical-root routing."
+---
+
+# RCA: Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd
+
+**Дата:** 2026-04-15  
+**Статус:** Resolved in source  
+**Влияние:** fresh issue-owned worktrees could report success before plain `bd status` was actually ready, and direct `bd worktree list` from a dedicated worktree could misreport ownership state  
+**Контекст:** beads `moltinger-th0e`, repo-owned `command-worktree` / `worktree-phase-a` / `bin/bd` / `beads-resolve-db`
+
+## Ошибка
+
+После создания нового governed worktree из `origin/main` были подтверждены два остаточных дефекта branch/worktree tooling:
+
+1. `scripts/worktree-phase-a.sh create-from-base` мог вернуть `created_from_base`, хотя plain `bd status` в только что созданном worktree ещё падал transient ошибкой `connect: connection refused`.
+2. `bd worktree list` из dedicated worktree всё ещё зависел от observer cwd и в части окружений мог показывать текущий worktree как `shared`, хотя тот же объект из canonical root уже выглядел `local`.
+
+Это были не независимые косметические баги, а остатки одного governance drift: readiness и ownership всё ещё зависели от контекстных прокси-сигналов после bootstrap.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+- `docs/LESSONS-LEARNED.md`
+- `bash scripts/query-lessons.sh --tag worktree --tag phase-a --tag beads --tag command-worktree`
+
+**Релевантные прошлые RCA/уроки:**
+1. `docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md` — уже требовал canonical ownership/runtime evidence вместо proxy-state.
+2. `docs/rca/2026-03-09-command-worktree-followup-uat.md` — уже требовал честного cross-worktree UX и отсутствия observer-dependent ambiguity.
+
+**Что могло быть упущено без этой сверки:**
+- можно было бы снова принять `worktree-ready doctor` из canonical root за достаточное доказательство readiness и пропустить, что plain `bd status` в новом worktree ещё не готов;
+- можно было бы считать, что canonical-root fix в `worktree-ready` автоматически чинит и direct `./bin/bd worktree list`, хотя это другой ownership layer.
+
+**Что в текущем инциденте действительно новое:**
+- readiness gap жил именно между завершением bootstrap/import path и первым usable plain `bd status`, то есть проблема была в честном completion contract Phase A;
+- canonical-root routing нужно было спустить не только в `worktree-ready`, но и в прямой repo wrapper `bin/bd` через resolver decision для `worktree list`.
+
+## Evidence
+
+Подтверждённые факты:
+
+1. Во fresh `moltinger-th0e` worktree один из первых `bd status` дал `failed to get statistics: dial tcp 127.0.0.1:55007: connect: connection refused`, а повторный вызов позже стал зелёным.
+2. До фикса `bd worktree list` зависел от cwd:
+   - из canonical root новый worktree выглядел `local`;
+   - из самого dedicated worktree тот же объект мог выглядеть `shared`.
+3. После source fix:
+   - `bash tests/unit/test_worktree_phase_a.sh` → `10/10 PASS`
+   - `bash tests/unit/test_bd_dispatch.sh` → `29/29 PASS`
+4. Живой smoke после фикса:
+   - `./bin/bd worktree list` из `moltinger-th0e` показывает согласованный `local`;
+   - `./bin/bd status` из `moltinger-th0e` проходит успешно.
+
+## Анализ 5 Почему (with Evidence)
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему fresh governed worktree мог считаться готовым слишком рано? | Потому что Phase A завершался после bootstrap/import, не дожидаясь успешного plain `bd status` в новом runtime. | live repro в `moltinger-th0e`, новый unit test `test_phase_a_create_waits_for_runtime_status_after_bootstrap` |
+| 2 | Почему plain `bd status` ещё был неготов? | Потому что локальный named runtime после bootstrap мог кратковременно поднимать сервис/сокет позже, чем wrapper уже печатал success. | transient `connect: connection refused` сразу после create |
+| 3 | Почему ownership list всё ещё зависел от cwd? | Потому что direct repo wrapper не canonicalize-ил `worktree list` к canonical root, и команда наследовала observer context. | live repro `bd worktree list` from root vs dedicated worktree |
+| 4 | Почему это не было закрыто предыдущим fix-пакетом? | Потому что прошлый пакет чинил higher-level helper path (`worktree-ready`), но не прямой `bin/bd` dispatch и не honest completion gate в Phase A. | diff scope до `th0e`; новый fix затронул `bin/bd`, `beads-resolve-db.sh`, `worktree-phase-a.sh` |
+| 5 | Почему проблема проявилась как governance drift, а не просто shell timing bug? | Потому что repo-owned tooling всё ещё принимал промежуточный post-bootstrap state за достаточную истину и не унифицировал direct wrapper path с canonical ownership contract. | combined fix across resolver + wrapper + Phase A readiness probe |
+
+## Корневая причина
+
+Корневая причина — неполное доведение canonical governance contract до всех owning layers:
+
+- `worktree-phase-a.sh` считал bootstrap/import достаточным критерием готовности, хотя операторский контракт требует usable plain `bd status`;
+- `beads-resolve-db.sh`/`bin/bd` не применяли canonical-root routing к `worktree list`, поэтому direct wrapper по-прежнему зависел от cwd.
+
+Иными словами, higher-level helper уже знал правильную модель, но lower-level repo-owned entrypoints ещё не были доведены до той же истины.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| □ Actionable? | yes | fixes находятся в repo-owned shell helpers/tests |
+| □ Systemic? | yes | defect span-ил readiness gate и direct wrapper dispatch |
+| □ Preventable? | yes | через explicit final plain-status gate и canonical-root dispatch regression coverage |
+
+## Принятые меры
+
+1. **Немедленное исправление**
+   - `scripts/worktree-phase-a.sh` теперь после bootstrap/import ждёт успешный plain `bd status` с bounded retry loop и fail-closed error, если runtime так и не стал ready.
+   - `scripts/beads-resolve-db.sh` получил отдельное решение `pass_through_canonical_root_readonly` для `worktree list`.
+   - `bin/bd` теперь исполняет этот путь через `cd "${BEADS_RESOLVE_CANONICAL_ROOT}"` и direct system `bd`.
+2. **Предотвращение**
+   - добавлен unit test на post-bootstrap readiness wait;
+   - добавлен unit test, что dedicated-worktree `bd worktree list` canonicalize-ится к root и не pin-ит local DB.
+3. **Документация**
+   - этот RCA добавлен в `docs/rca/`;
+   - lessons index будет пересобран после landing пакета.
+
+## Связанные обновления
+
+- [x] Тесты добавлены
+- [x] Индекс уроков будет пересобран
+- [ ] Новый rule file не понадобился: дефект закрыт в owning helper layer
+
+## Уроки
+
+1. **Phase A не имеет права возвращать success раньше plain operator path.** Bootstrap/import недостаточны, если первый обычный `bd status` ещё не usable.
+2. **Canonical-root routing нужно спускать до direct entrypoint.** Исправление только в orchestration helper-е не закрывает прямой `./bin/bd` path.
+3. **Observer-dependent команды должны canonicalize-иться явно.** Если semantic truth зависит от cwd, repo wrapper обязан зафиксировать контекст сам.
+4. **Readiness и ownership regression coverage должны жить рядом с owning layer.** Иначе один слой будет “починен”, а соседний entrypoint продолжит врать оператору.

--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -489,6 +489,17 @@ beads_resolve_is_canonical_root_read_only_command() {
   esac
 }
 
+beads_resolve_is_worktree_list_command() {
+  local command=""
+  local subcommand=""
+
+  beads_resolve_extract_command "$@"
+  command="${BEADS_RESOLVE_COMMAND}"
+  subcommand="${BEADS_RESOLVE_SUBCOMMAND}"
+
+  [[ "${command}" == "worktree" && "${subcommand}" == "list" ]]
+}
+
 beads_resolve_extract_worktree_remove_target() {
   local -a args=("$@")
   local index=0
@@ -659,6 +670,11 @@ beads_resolve_dispatch() {
       28 \
       "bd: 'sync' is retired in this repository's Beads workflow." \
       "Use bd status for local inspection, and use bd dolt push / bd dolt pull only when this worktree is configured with a Dolt remote."
+    return 0
+  fi
+
+  if beads_resolve_is_worktree_list_command "$@"; then
+    beads_resolve_set_decision "pass_through_canonical_root_readonly" "canonical_root" 0
     return 0
   fi
 

--- a/scripts/worktree-phase-a.sh
+++ b/scripts/worktree-phase-a.sh
@@ -257,26 +257,18 @@ phase_a_import_canonical_backlog() {
 }
 
 phase_a_wait_for_runtime_status() {
-  local system_bd=""
   local attempts="${WORKTREE_PHASE_A_STATUS_RETRY_COUNT:-5}"
   local delay_seconds="${WORKTREE_PHASE_A_STATUS_RETRY_DELAY_SECONDS:-1}"
   local attempt=1
-  local rc=0
   local output=""
 
-  system_bd="$(beads_resolve_find_system_bd "${SCRIPT_DIR}/../bin/bd")" \
-    || phase_a_fail_runtime "system_bd_missing" "Phase A could not locate the system bd binary for final runtime readiness checks."
-
   while [[ "${attempt}" -le "${attempts}" ]]; do
-    set +e
-    output="$(
-      cd "${target_path}"
-      "${system_bd}" status 2>&1
-    )"
-    rc=$?
-    set -e
+    if ! beads_resolve_run_system_bd_probe "${target_path}" true status; then
+      phase_a_fail_runtime "system_bd_missing" "Phase A could not locate the system bd binary for final runtime readiness checks."
+    fi
+    output="${BEADS_RESOLVE_LAST_BD_OUTPUT}"
 
-    if [[ "${rc}" -eq 0 ]]; then
+    if [[ "${BEADS_RESOLVE_LAST_BD_TIMED_OUT}" != "true" && "${BEADS_RESOLVE_LAST_BD_RC}" -eq 0 ]]; then
       return 0
     fi
 
@@ -287,6 +279,9 @@ phase_a_wait_for_runtime_status() {
   done
 
   output="${output//$'\n'/ }"
+  if [[ "${BEADS_RESOLVE_LAST_BD_TIMED_OUT}" == "true" ]]; then
+    output="status probe timed out after ${BEADS_RESOLVE_BD_TIMEOUT_SECONDS:-8}s; ${output}"
+  fi
   phase_a_fail_runtime \
     "runtime_not_ready" \
     "Phase A created the git worktree, but plain bd status never became ready in the new local runtime." \

--- a/scripts/worktree-phase-a.sh
+++ b/scripts/worktree-phase-a.sh
@@ -256,6 +256,43 @@ phase_a_import_canonical_backlog() {
     "Run /usr/local/bin/bd doctor --json and ./scripts/beads-worktree-localize.sh --path . inside the target worktree before retrying."
 }
 
+phase_a_wait_for_runtime_status() {
+  local system_bd=""
+  local attempts="${WORKTREE_PHASE_A_STATUS_RETRY_COUNT:-5}"
+  local delay_seconds="${WORKTREE_PHASE_A_STATUS_RETRY_DELAY_SECONDS:-1}"
+  local attempt=1
+  local rc=0
+  local output=""
+
+  system_bd="$(beads_resolve_find_system_bd "${SCRIPT_DIR}/../bin/bd")" \
+    || phase_a_fail_runtime "system_bd_missing" "Phase A could not locate the system bd binary for final runtime readiness checks."
+
+  while [[ "${attempt}" -le "${attempts}" ]]; do
+    set +e
+    output="$(
+      cd "${target_path}"
+      "${system_bd}" status 2>&1
+    )"
+    rc=$?
+    set -e
+
+    if [[ "${rc}" -eq 0 ]]; then
+      return 0
+    fi
+
+    if [[ "${attempt}" -lt "${attempts}" ]]; then
+      sleep "${delay_seconds}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  output="${output//$'\n'/ }"
+  phase_a_fail_runtime \
+    "runtime_not_ready" \
+    "Phase A created the git worktree, but plain bd status never became ready in the new local runtime." \
+    "Last status error: ${output}. Run /usr/local/bin/bd doctor --json and ./scripts/beads-worktree-localize.sh --path . inside the target worktree before retrying."
+}
+
 create_from_base() {
   local base_sha=""
   local branch_exists=0
@@ -283,6 +320,7 @@ create_from_base() {
   git -C "${canonical_root}" worktree add "${target_path}" "${branch}" >/dev/null
   phase_a_prepare_beads_runtime
   phase_a_import_canonical_backlog
+  phase_a_wait_for_runtime_status
 
   head_sha="$(git -C "${target_path}" rev-parse HEAD)"
   if [[ "${head_sha}" != "${base_sha}" ]]; then

--- a/tests/unit/test_bd_dispatch.sh
+++ b/tests/unit/test_bd_dispatch.sh
@@ -84,6 +84,13 @@ if [[ "${args[0]:-}" == "status" ]]; then
   exit 0
 fi
 
+if [[ "${args[0]:-}" == "worktree" && "${args[1]:-}" == "list" ]]; then
+  printf 'CWD=%s\n' "$(pwd -P)"
+  printf 'DB=%s\n' "${db_path}"
+  printf 'ARGS=%s\n' "${args[*]}"
+  exit 0
+fi
+
 if [[ -n "${db_path}" ]]; then
   mkdir -p "$(dirname "${db_path}")"
   if [[ -d "${db_path}" ]]; then
@@ -447,6 +454,31 @@ test_canonical_root_plain_bd_allows_worktree_remove_for_linked_worktree() {
     output="$(run_plain_bd "${repo_dir}" "${fake_bin}" worktree remove "${worktree_path}")"
 
     assert_contains "${output}" "ARGS=worktree remove ${worktree_path}" "Canonical-root cleanup admin path should pass through plain bd for linked worktree removal"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_dedicated_worktree_plain_bd_canonicalizes_worktree_list_to_root() {
+    test_start "dedicated_worktree_plain_bd_canonicalizes_worktree_list_to_root"
+
+    local fixture_root repo_dir worktree_path fake_bin output
+    fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(canonicalize_path "${repo_dir}")"
+    seed_repo_local_bd_tools "${repo_dir}"
+    seed_local_beads_foundation "${repo_dir}"
+    worktree_path="${fixture_root}/moltinger-safe-worktree"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/safe-local" "main"
+    worktree_path="$(canonicalize_path "${worktree_path}")"
+    seed_local_beads_foundation "${worktree_path}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    output="$(run_plain_bd "${worktree_path}" "${fake_bin}" worktree list)"
+
+    assert_contains "${output}" "CWD=${repo_dir}" "Dedicated-worktree bd worktree list should execute from the canonical root"
+    assert_contains "${output}" "DB=" "Dedicated-worktree bd worktree list should not pin a local worktree DB"
+    assert_contains "${output}" "ARGS=worktree list" "Dedicated-worktree bd worktree list should preserve the original arguments"
 
     rm -rf "${fixture_root}"
     test_pass
@@ -1070,6 +1102,7 @@ run_all_tests() {
     test_canonical_root_plain_bd_blocks_mutation_by_default
     test_canonical_root_plain_bd_allows_explicit_root_db_override
     test_canonical_root_plain_bd_allows_worktree_remove_for_linked_worktree
+    test_dedicated_worktree_plain_bd_canonicalizes_worktree_list_to_root
     test_canonical_root_plain_bd_blocks_worktree_remove_for_non_linked_target
     test_plain_bd_blocks_legacy_redirect
     test_plain_bd_blocks_root_fallback_when_local_foundation_is_missing

--- a/tests/unit/test_worktree_phase_a.sh
+++ b/tests/unit/test_worktree_phase_a.sh
@@ -499,6 +499,60 @@ test_phase_a_create_waits_for_runtime_status_after_bootstrap() {
     test_pass
 }
 
+test_phase_a_create_fails_closed_when_runtime_status_probe_hangs() {
+    test_start "worktree_phase_a_create_fails_closed_when_runtime_status_probe_hangs"
+
+    local fixture_root repo_dir fake_bin target_path output rc call_log status_counter
+    fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    target_path="${fixture_root}/moltinger-hung-status"
+    call_log="${fixture_root}/phase-a-hung-status.calls"
+    status_counter="${fixture_root}/phase-a-hung-status.count"
+
+    mkdir -p "${repo_dir}/.beads"
+    printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
+    printf '{"id":"molt-1","title":"fixture"}\n' > "${repo_dir}/.beads/issues.jsonl"
+    (
+        cd "${repo_dir}"
+        git add .beads/config.yaml .beads/issues.jsonl
+        git commit -m "fixture: tracked local foundation for hung status wait" >/dev/null
+    )
+
+    output="$(
+        set +e
+        BEADS_RESOLVE_BD_TIMEOUT_SECONDS="1" \
+        WORKTREE_PHASE_A_STATUS_RETRY_COUNT="2" \
+        WORKTREE_PHASE_A_STATUS_RETRY_DELAY_SECONDS="0" \
+        FAKE_BD_CALL_LOG="${call_log}" \
+        FAKE_BD_STATUS_COUNTER_FILE="${status_counter}" \
+        FAKE_BD_STATUS_SLEEP_SECONDS="2" \
+        run_phase_a_create "$fake_bin" \
+            --canonical-root "$repo_dir" \
+            --base-ref main \
+            --branch feat/hung-status \
+            --path "$target_path" 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Phase A must fail closed when the final plain bd status probe keeps timing out"
+    assert_contains "$output" "plain bd status never became ready" "Phase A should explain the final readiness blocker"
+    assert_contains "$output" "status probe timed out after 1s" "Phase A should surface the bounded watchdog timeout in its error message"
+    if [[ ! -f "${target_path}/.beads/last-import.jsonl" && ! -f "${target_path}/.beads/last-touched" ]]; then
+        test_fail "Phase A should still complete canonical import before the hung-status readiness gate fails closed"
+    fi
+    if [[ "$(<"${status_counter}")" != "2" ]]; then
+        test_fail "Phase A should honor the configured retry budget when status probes keep timing out"
+    fi
+    if [[ "$(grep -c '^status$' "${call_log}")" -ne 2 ]]; then
+        test_fail "Phase A should issue exactly the configured number of timed-out status probes"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_phase_a_create_falls_back_to_status_when_info_probe_times_out() {
     test_start "worktree_phase_a_create_falls_back_to_status_when_info_probe_times_out"
 
@@ -643,6 +697,7 @@ run_all_tests() {
     test_phase_a_create_repairs_runtime_only_state_without_tracked_issues
     test_phase_a_create_rebuilds_unhealthy_named_runtime
     test_phase_a_create_waits_for_runtime_status_after_bootstrap
+    test_phase_a_create_fails_closed_when_runtime_status_probe_hangs
     test_phase_a_create_falls_back_to_status_when_info_probe_times_out
     test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair
     test_phase_a_create_blocks_when_canonical_export_fails

--- a/tests/unit/test_worktree_phase_a.sh
+++ b/tests/unit/test_worktree_phase_a.sh
@@ -99,6 +99,18 @@ if [[ "${1:-}" == "export" ]]; then
 fi
 
 if [[ "${1:-}" == "status" ]]; then
+  status_call_count=0
+  if [[ -n "${FAKE_BD_STATUS_COUNTER_FILE:-}" && -f "${FAKE_BD_STATUS_COUNTER_FILE}" ]]; then
+    status_call_count="$(<"${FAKE_BD_STATUS_COUNTER_FILE}")"
+  fi
+  status_call_count=$((status_call_count + 1))
+  if [[ -n "${FAKE_BD_STATUS_COUNTER_FILE:-}" ]]; then
+    printf '%s\n' "${status_call_count}" > "${FAKE_BD_STATUS_COUNTER_FILE}"
+  fi
+  if [[ -n "${FAKE_BD_STATUS_FAIL_COUNT:-}" && "${status_call_count}" -le "${FAKE_BD_STATUS_FAIL_COUNT}" ]]; then
+    printf 'failed to get statistics: dial tcp 127.0.0.1:12345: connect: connection refused\n' >&2
+    exit 1
+  fi
   if [[ -n "${FAKE_BD_STATUS_SLEEP_SECONDS:-}" ]]; then
     sleep "${FAKE_BD_STATUS_SLEEP_SECONDS}"
   fi
@@ -438,14 +450,16 @@ test_phase_a_create_rebuilds_unhealthy_named_runtime() {
     test_pass
 }
 
-test_phase_a_create_accepts_info_probe_when_status_probe_is_noisy() {
-    test_start "worktree_phase_a_create_accepts_info_probe_when_status_probe_is_noisy"
+test_phase_a_create_waits_for_runtime_status_after_bootstrap() {
+    test_start "worktree_phase_a_create_waits_for_runtime_status_after_bootstrap"
 
-    local fixture_root repo_dir fake_bin target_path output
+    local fixture_root repo_dir fake_bin target_path output call_log status_counter status_attempts
     fixture_root="$(mktemp -d /tmp/worktree-phase-a-unit.XXXXXX)"
     repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
     fake_bin="$(create_fake_bd_bin "$fixture_root")"
     target_path="${fixture_root}/moltinger-noisy-status"
+    call_log="${fixture_root}/phase-a-ready-status.calls"
+    status_counter="${fixture_root}/phase-a-ready-status.count"
 
     mkdir -p "${repo_dir}/.beads"
     printf 'issue-prefix: "molt"\n' > "${repo_dir}/.beads/config.yaml"
@@ -453,11 +467,14 @@ test_phase_a_create_accepts_info_probe_when_status_probe_is_noisy() {
     (
         cd "${repo_dir}"
         git add .beads/config.yaml .beads/issues.jsonl
-        git commit -m "fixture: tracked local foundation for noisy status probe" >/dev/null
+        git commit -m "fixture: tracked local foundation for status readiness wait" >/dev/null
     )
 
-    output="$(FAKE_BD_STATUS_RC="1" \
-        FAKE_BD_STATUS_STDERR='failed to get statistics: dial tcp 127.0.0.1:12345: connect: connection refused' \
+    output="$(WORKTREE_PHASE_A_STATUS_RETRY_COUNT="5" \
+        WORKTREE_PHASE_A_STATUS_RETRY_DELAY_SECONDS="0" \
+        FAKE_BD_CALL_LOG="${call_log}" \
+        FAKE_BD_STATUS_COUNTER_FILE="${status_counter}" \
+        FAKE_BD_STATUS_FAIL_COUNT="2" \
         FAKE_BD_INFO_STDOUT='Beads Database Information' \
         run_phase_a_create "$fake_bin" \
         --canonical-root "$repo_dir" \
@@ -466,9 +483,16 @@ test_phase_a_create_accepts_info_probe_when_status_probe_is_noisy() {
         --path "$target_path" \
         --format env)"
 
-    assert_contains "$output" 'result=created_from_base' "Phase A should trust a successful info probe even when status is noisy"
+    assert_contains "$output" 'result=created_from_base' "Phase A should wait until plain bd status becomes ready before returning success"
     if [[ ! -f "${target_path}/.beads/last-import.jsonl" && ! -f "${target_path}/.beads/last-touched" ]]; then
         test_fail "Phase A should still finish the canonical import path when status probing is noisy"
+    fi
+    status_attempts="$(<"${status_counter}")"
+    if (( status_attempts < 3 )); then
+        test_fail "Phase A should retry plain bd status until the transient connection-refused window clears"
+    fi
+    if [[ "$(grep -c '^status$' "${call_log}")" -lt 3 ]]; then
+        test_fail "Phase A should log multiple status attempts while waiting for runtime readiness"
     fi
 
     rm -rf "$fixture_root"
@@ -618,7 +642,7 @@ run_all_tests() {
     test_phase_a_create_imports_live_canonical_export
     test_phase_a_create_repairs_runtime_only_state_without_tracked_issues
     test_phase_a_create_rebuilds_unhealthy_named_runtime
-    test_phase_a_create_accepts_info_probe_when_status_probe_is_noisy
+    test_phase_a_create_waits_for_runtime_status_after_bootstrap
     test_phase_a_create_falls_back_to_status_when_info_probe_times_out
     test_phase_a_create_blocks_when_runtime_bootstrap_does_not_repair
     test_phase_a_create_blocks_when_canonical_export_fails


### PR DESCRIPTION
## Summary
- wait for plain `bd status` readiness before Phase A reports success
- canonicalize direct `bd worktree list` to the canonical root
- add RCA and regression coverage for both helper-layer defects

## Testing
- `bash -n bin/bd scripts/beads-resolve-db.sh scripts/worktree-phase-a.sh tests/unit/test_bd_dispatch.sh tests/unit/test_worktree_phase_a.sh`
- `bash tests/unit/test_worktree_phase_a.sh`
- `bash tests/unit/test_bd_dispatch.sh`
- `bash scripts/build-lessons-index.sh`
- `git diff --check`