### PR TITLE
fix(worktree): harden governance helper reconciliation

### DIFF
--- a/bin/bd
+++ b/bin/bd
@@ -30,7 +30,7 @@ case "${BEADS_RESOLVE_DECISION}" in
   pass_through_non_repo|pass_through_root_readonly|pass_through_root_cleanup_admin|pass_through_global|allow_explicit_troubleshooting)
     exec "${SYSTEM_BD}" "$@"
     ;;
-  block_deprecated_sync|block_legacy_redirect|block_missing_foundation|block_pilot_legacy_command|block_root_fallback|block_root_mutation|block_unresolved_ownership)
+  block_deprecated_sync|block_legacy_redirect|block_missing_foundation|block_pilot_legacy_command|block_repo_worktree_create|block_root_fallback|block_root_mutation|block_unresolved_ownership)
     printf '%s\n' "${BEADS_RESOLVE_MESSAGE}" >&2
     if [[ -n "${BEADS_RESOLVE_RECOVERY_HINT}" ]]; then
       printf 'Recovery: %s\n' "${BEADS_RESOLVE_RECOVERY_HINT}" >&2

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-15
-**Total Lessons**: 81
+**Total Lessons**: 82
 
 ---
 
@@ -55,7 +55,8 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (25 lessons)
+#### P2 (26 lessons)
+- [Worktree governance left raw create and cleanup reconciliation gaps](../docs/rca/2026-04-15-worktree-governance-left-raw-create-and-cleanup-reconciliation-gaps.md)
 - [Worktree cleanup helper treated derived branch-only path as a path/branch conflict](../docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md)
 - [Worktree cleanup helper blocked merged behind-only branch on stale upstream unpushed-guard](../docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md)
 - [Telegram skill-detail remained non-terminal and repo skills lacked a shared Telegram-safe summary contract](../docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md)
@@ -153,8 +154,9 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (27 lessons)
+#### process (28 lessons)
 - [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
+- [Worktree governance left raw create and cleanup reconciliation gaps](../docs/rca/2026-04-15-worktree-governance-left-raw-create-and-cleanup-reconciliation-gaps.md)
 - [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram chat probe skill pointed to a missing wrapper entrypoint](../docs/rca/2026-04-14-telegram-chat-probe-skill-pointed-to-missing-wrapper-entrypoint.md)
 - [Skill execution drifted into workaround behavior and task reports lacked a shared simple contract](../docs/rca/2026-04-09-skill-execution-and-reporting-contract-drift.md)
@@ -206,15 +208,15 @@
 
 ### Popular Tags
 
-- `rca` (29 lessons)
+- `rca` (30 lessons)
 - `moltis` (26 lessons)
 - `telegram` (20 lessons)
 - `deploy` (19 lessons)
 - `github-actions` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
+- `beads` (12 lessons)
 - `skills` (11 lessons)
-- `beads` (11 lessons)
 - `process` (9 lessons)
 
 
@@ -224,7 +226,7 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 81 |
+| Total Lessons | 82 |
 | Critical (P0/P1) | 40 |
 | Categories | 8 |
 | Unique Tags | 161 |

--- a/docs/rca/2026-04-15-worktree-governance-left-raw-create-and-cleanup-reconciliation-gaps.md
+++ b/docs/rca/2026-04-15-worktree-governance-left-raw-create-and-cleanup-reconciliation-gaps.md
@@ -1,0 +1,126 @@
+---
+title: "Worktree governance left raw create and cleanup reconciliation gaps"
+date: 2026-04-15
+severity: P2
+category: process
+tags: [worktree, branches, cleanup, beads, governance, rca]
+root_cause: "Repo-owned worktree governance still allowed unmanaged raw `bd worktree create`, did not audit branch-only drift, treated cleanup close/reporting as secondary instead of first-class governance reconciliation, and left the shipped compatibility wrapper out of sync with resolver decisions."
+---
+
+# RCA: Worktree governance left raw create and cleanup reconciliation gaps
+
+**Дата:** 2026-04-15  
+**Статус:** Resolved in source  
+**Влияние:** non-topology worktree/branch hygiene could drift back into unmanaged state even after prior hardening, leaving stale lane ownership and incomplete cleanup reconciliation  
+**Контекст:** beads `moltinger-crq6`, follow-up non-topology worktree/branch governance repair
+
+## Ошибка
+
+Во время завершающего cleanup non-topology lane-ов всплыло сразу несколько связанных дефектов в repo-owned governance stack:
+
+1. raw `bd worktree create moltinger-crq6` из canonical repo создал nested worktree внутри repo root и Beads redirect/shared ownership вместо managed local-runtime lane;
+2. `scripts/beads-worktree-audit.sh` видел linked worktree drift, но не видел branch-only local drift;
+3. `scripts/worktree-ready.sh cleanup --branch ... --delete-branch --close-issue` сперва ложноположительно блокировался на synthetic path conflict, а после source fix ещё и не отражал successful close step в cleanup report;
+4. deprecated compatibility wrapper `scripts/bd-local.sh` не сопровождал новые resolver decision states (`block_repo_worktree_create`, canonical-root pass-through paths) и падал в `unsupported resolution state ...` вместо корректного fail-closed/pass-through поведения.
+
+Итог: инструменты, которые должны были закрыть governance cycle, сами оставляли дыры в ownership и operator evidence.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+- `docs/LESSONS-LEARNED.md`
+- `rg -n "worktree governance|raw bd worktree create|cleanup helper|branch-only drift" docs/rca docs/LESSONS-LEARNED.md -S`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+**Релевантные прошлые RCA/уроки:**
+1. `docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md`
+   - уже требовал не доверять contextual proxy-state при worktree governance.
+2. `docs/rca/2026-04-15-worktree-cleanup-helper-blocked-merged-behind-only-branch-on-stale-upstream-guard.md`
+   - уже показал, что cleanup helper нельзя считать корректным без explicit regression coverage по live hygiene path.
+3. `docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md`
+   - уже зафиксировал один branch-only cleanup defect, но не покрывал close/reporting path и raw create entrypoint.
+
+**Что могло быть упущено без этой сверки:**
+- можно было бы снова “дочистить руками” branch/worktree topology и не исправить управляющие helper-ы;
+- можно было бы считать cleanup успешным, хотя Beads issue-close/report contract оставался частично broken.
+
+**Что в текущем инциденте действительно новое:**
+- raw `bd worktree create` сам по себе оказался запрещённым entrypoint для этого репозитория;
+- branch-only drift нужно аудировать не только по worktree, но и по branch без worktree;
+- cleanup governance считается незавершённым, если helper не умеет завершить issue reconciliation и отразить это в operator-facing report.
+
+## Evidence
+
+Подтверждённые факты:
+
+1. Live вызов `bd worktree create moltinger-crq6` создал nested worktree внутри `/Users/rl/coding/moltinger/moltinger-main/moltinger-crq6` с redirected/shared Beads ownership.
+2. `git worktree list --porcelain` и `bd worktree list` после cleanup показали, что реальных non-topology worktree уже почти не осталось, но governance stack всё ещё позволял unsafe raw create.
+3. `git branch --format='%(refname:short)'` показал branch-only local drift (`feat/remote-uat-hardening-v2`) без связанного worktree; до фикса audit helper этого не подсвечивал.
+4. Repro для `run_worktree_cleanup ... --close-issue` до фикса:
+   - возвращал `cleanup_blocked` из-за synthetic path conflict, хотя user передал только `--branch`;
+   - после устранения conflict helper успешно выполнял `bd --db <repo>/.beads/beads.db close ...`, но human cleanup report не печатал `Close: closed`.
+5. Review replay через compatibility path показал, что `scripts/bd-local.sh` не обрабатывает `block_repo_worktree_create`, `pass_through_canonical_root_readonly` и `pass_through_root_cleanup_admin`, хотя resolver уже выдаёт эти states.
+6. После source fixes:
+   - `bash tests/unit/test_bd_dispatch.sh` → `30/30 PASS`
+   - `bash tests/unit/test_beads_worktree_audit.sh` → `9/9 PASS`
+   - `bash tests/unit/test_worktree_ready.sh` → `60/60 PASS`
+   - `bash tests/unit/test_bd_local.sh` → green with explicit coverage for raw create block and canonical-root pass-through compatibility
+
+## Анализ 5 Почему (with Evidence)
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему governance cleanup оставлял незавершённые хвосты? | Потому что repo-owned helper-ы покрывали linked worktree happy-path, но не весь lifecycle governance. | live cleanup cycle, failing unit regressions |
+| 2 | Почему lifecycle был неполным? | Потому что raw create entrypoint, branch-only drift и issue-close reconciliation рассматривались как второстепенные. | raw `bd worktree create` repro, pre-fix audit output, missing `Close: closed` |
+| 3 | Почему raw create был опасным именно здесь? | Потому что этот репозиторий использует managed worktree model, а plain `bd worktree create` materialized redirect/shared ownership, несовместимую с repo contract. | nested `/moltinger-main/moltinger-crq6`, redirected Beads state |
+| 4 | Почему audit, cleanup и compatibility wrapper не поймали это как source-level defect раньше? | Потому что тесты были сосредоточены на linked worktree paths и основном dispatch path, но не покрывали branch-only governance drift, close/report path и deprecated wrapper compatibility surface. | pre-fix coverage in `test_beads_worktree_audit.sh`, `test_worktree_ready.sh`, `test_bd_local.sh` |
+| 5 | Почему это дошло до operator-visible confusion? | Потому что governance helper-ы не fail-closed на unsafe entrypoint, не доводили cleanup contract до полного operator-facing reconciliation и оставляли shipped compatibility wrapper вне синхронизации с resolver. | raw create repro, blocked cleanup, missing close signal in report, `unsupported resolution state` in `bd-local.sh` |
+
+## Корневая причина
+
+Repo-owned worktree governance stack всё ещё мыслил cleanup как набор разрозненных shell-операций, а не как единый lifecycle contract.
+
+Из-за этого:
+- unsafe raw create entrypoint оставался доступен;
+- branch-only branch drift выпадал из аудита;
+- cleanup считался “почти завершённым” даже без issue-close reconciliation и явного operator-facing evidence;
+- shipped compatibility entrypoint не считался обязательной частью того же governance contract.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| □ Actionable? | yes | все fixes находятся в repo-owned shell helpers/tests |
+| □ Systemic? | yes | defect span-ил dispatch, audit и cleanup/report layers |
+| □ Preventable? | yes | через explicit entrypoint guard, wider audit scope и reconciliation regressions |
+
+## Принятые меры
+
+1. **Немедленное исправление**
+   - `bin/bd` + `scripts/beads-resolve-db.sh`: raw `bd worktree create` fail-closed blocked в этом репозитории с явной managed-worktree guidance.
+   - `scripts/beads-worktree-audit.sh`: добавлен branch-only drift audit для local branches без worktree.
+   - `scripts/worktree-ready.sh`: cleanup close path доведён до explicit `bd --db ... close ...`, branch-only synthetic conflict corrected, cleanup report теперь печатает `Issue` и `Close`.
+2. **Предотвращение**
+   - добавлены regressions:
+     - raw `bd worktree create` must block;
+     - audit warns for branch-only merged local branch;
+     - cleanup with attached branch-only worktree must not false-conflict;
+     - cleanup `--close-issue` must close the issue and report it;
+     - `bd-local` must mirror raw-create block and canonical-root readonly/admin pass-through states.
+3. **Документация**
+   - этот RCA зафиксирован;
+   - lessons index будет пересобран после landing.
+
+## Связанные обновления
+
+- [x] Тесты добавлены
+- [x] Индекс уроков будет пересобран
+- [ ] Новый rule file не понадобился
+
+## Уроки
+
+1. В репозитории с managed worktree model raw lower-level create entrypoint должен быть либо доказанно совместим, либо fail-closed заблокирован.
+2. Worktree governance audit должен видеть не только worktree, но и branch-only drift.
+3. Cleanup не считается завершённым, пока helper не завершил issue reconciliation и не показал это в отчёте.
+4. Operator-facing report — часть safety contract, а не косметика после успешной shell-логики.
+5. Deprecated compatibility wrapper тоже остаётся owning layer: если resolver расширился, wrapper обязан быть синхронизирован и покрыт тестом.

--- a/scripts/bd-local.sh
+++ b/scripts/bd-local.sh
@@ -59,14 +59,14 @@ case "${BEADS_RESOLVE_DECISION}" in
     system_bd="$(resolve_system_bd)" || fail "could not locate a bd binary to execute the resolved local runtime" 1
     exec "${system_bd}" --db "${BEADS_RESOLVE_DB_PATH}" "$@"
     ;;
-  pass_through_non_repo|pass_through_root_readonly|pass_through_global|allow_explicit_troubleshooting)
+  pass_through_non_repo|pass_through_root_readonly|pass_through_global|allow_explicit_troubleshooting|pass_through_canonical_root_readonly|pass_through_root_cleanup_admin)
     if [[ -x "${repo_bd_path}" ]]; then
       exec "${repo_bd_path}" "$@"
     fi
     system_bd="$(resolve_system_bd)" || fail "could not locate a bd binary to execute the command" 1
     exec "${system_bd}" "$@"
     ;;
-  block_deprecated_sync|block_legacy_redirect|block_missing_foundation|block_pilot_legacy_command|block_root_fallback|block_root_mutation|block_unresolved_ownership)
+  block_deprecated_sync|block_legacy_redirect|block_missing_foundation|block_pilot_legacy_command|block_repo_worktree_create|block_root_fallback|block_root_mutation|block_unresolved_ownership)
     printf '%s\n' "${BEADS_RESOLVE_MESSAGE}" >&2
     if [[ -n "${BEADS_RESOLVE_RECOVERY_HINT}" ]]; then
       printf 'Recovery: %s\n' "${BEADS_RESOLVE_RECOVERY_HINT}" >&2

--- a/scripts/beads-resolve-db.sh
+++ b/scripts/beads-resolve-db.sh
@@ -500,6 +500,17 @@ beads_resolve_is_worktree_list_command() {
   [[ "${command}" == "worktree" && "${subcommand}" == "list" ]]
 }
 
+beads_resolve_is_worktree_create_command() {
+  local command=""
+  local subcommand=""
+
+  beads_resolve_extract_command "$@"
+  command="${BEADS_RESOLVE_COMMAND}"
+  subcommand="${BEADS_RESOLVE_SUBCOMMAND}"
+
+  [[ "${command}" == "worktree" && "${subcommand}" == "create" ]]
+}
+
 beads_resolve_extract_worktree_remove_target() {
   local -a args=("$@")
   local index=0
@@ -670,6 +681,16 @@ beads_resolve_dispatch() {
       28 \
       "bd: 'sync' is retired in this repository's Beads workflow." \
       "Use bd status for local inspection, and use bd dolt push / bd dolt pull only when this worktree is configured with a Dolt remote."
+    return 0
+  fi
+
+  if beads_resolve_is_worktree_create_command "$@"; then
+    beads_resolve_set_decision \
+      "block_repo_worktree_create" \
+      "repo_local" \
+      29 \
+      "bd: raw 'bd worktree create' is disabled in this repository because it creates redirect-based shared Beads ownership." \
+      "Use scripts/worktree-ready.sh plan/create or scripts/worktree-phase-a.sh create-from-base from the canonical root instead."
     return 0
   fi
 

--- a/scripts/beads-worktree-audit.sh
+++ b/scripts/beads-worktree-audit.sh
@@ -44,6 +44,7 @@ report_action_count=0
 
 declare -a REPORT_LINES=()
 declare -a NEXT_STEPS=()
+declare -a LINKED_BRANCHES=()
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -91,6 +92,19 @@ add_report_line() {
 
 add_next_step() {
   NEXT_STEPS+=("$1")
+}
+
+default_branch_name() {
+  local default_branch=""
+
+  default_branch="$(git -C "${report_repo_root}" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  default_branch="${default_branch#origin/}"
+  if [[ -n "${default_branch}" ]]; then
+    printf '%s\n' "${default_branch}"
+    return 0
+  fi
+
+  printf 'main\n'
 }
 
 classify_worktree_state() {
@@ -171,6 +185,23 @@ collect_worktrees() {
   '
 }
 
+collect_worktree_branches() {
+  local repo_root="$1"
+  local line=""
+  local current_branch=""
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    case "${line}" in
+      branch\ refs/heads/*)
+        current_branch="${line#branch refs/heads/}"
+        if [[ -n "${current_branch}" ]]; then
+          printf '%s\n' "${current_branch}"
+        fi
+        ;;
+    esac
+  done < <(git -C "${repo_root}" worktree list --porcelain)
+}
+
 audit_worktree() {
   local worktree_path="$1"
   local issues_path="${worktree_path}/.beads/issues.jsonl"
@@ -247,7 +278,46 @@ audit_worktree() {
       ;;
   esac
 
-  add_report_line "${severity}|${state}|${action}|${worktree_path}"
+  add_report_line "worktree|${severity}|${state}|${action}|${worktree_path}"
+}
+
+branch_has_linked_worktree() {
+  local branch_name="$1"
+  local linked_branch=""
+
+  for linked_branch in "${LINKED_BRANCHES[@]+"${LINKED_BRANCHES[@]}"}"; do
+    if [[ "${linked_branch}" == "${branch_name}" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+audit_branch_only_local() {
+  local branch_name="$1"
+  local default_branch="$2"
+  local state="branch_only_active"
+  local action="review_branch_owner"
+
+  if [[ -z "${branch_name}" || "${branch_name}" == "${default_branch}" || "${branch_name}" == "chore/topology-registry-publish" ]]; then
+    return 0
+  fi
+
+  if branch_has_linked_worktree "${branch_name}"; then
+    return 0
+  fi
+
+  if git -C "${report_repo_root}" merge-base --is-ancestor "refs/heads/${branch_name}" "refs/heads/${default_branch}" >/dev/null 2>&1; then
+    state="branch_only_merged"
+    action="delete_local_branch_if_stale"
+    add_next_step "git -C $(printf '%q' "${report_repo_root}") branch -d $(printf '%q' "${branch_name}")"
+  else
+    add_next_step "git -C $(printf '%q' "${report_repo_root}") log --oneline --decorate -n 20 $(printf '%q' "${branch_name}") --"
+  fi
+
+  ((report_warning_count += 1))
+  add_report_line "branch|warn|${state}|${action}|${branch_name}"
 }
 
 render_human() {
@@ -260,8 +330,12 @@ render_human() {
     printf 'Actions: %s\n' "${report_action_count}"
     printf '\n'
     for line in "${REPORT_LINES[@]}"; do
-      IFS='|' read -r severity state action path <<< "${line}"
-      printf '[%s] state=%s action=%s path=%s\n' "${severity}" "${state}" "${action}" "${path}"
+      IFS='|' read -r scope severity state action subject <<< "${line}"
+      if [[ "${scope}" == "branch" ]]; then
+        printf '[%s] scope=branch state=%s action=%s branch=%s\n' "${severity}" "${state}" "${action}" "${subject}"
+      else
+        printf '[%s] state=%s action=%s path=%s\n' "${severity}" "${state}" "${action}" "${subject}"
+      fi
     done
     if [[ "${#NEXT_STEPS[@]}" -gt 0 ]]; then
       printf '\nNext Steps:\n'
@@ -316,6 +390,11 @@ main() {
   fi
 
   report_mode="canonical_root"
+  LINKED_BRANCHES=()
+  while IFS= read -r linked_branch; do
+    [[ -n "${linked_branch}" ]] || continue
+    LINKED_BRANCHES+=("${linked_branch}")
+  done < <(collect_worktree_branches "${repo_root}")
 
   while IFS= read -r worktree_path; do
     [[ -n "${worktree_path}" ]] || continue
@@ -324,6 +403,11 @@ main() {
     fi
     audit_worktree "${worktree_path}"
   done < <(collect_worktrees "${repo_root}")
+
+  while IFS= read -r branch_name; do
+    [[ -n "${branch_name}" ]] || continue
+    audit_branch_only_local "${branch_name}" "$(default_branch_name)"
+  done < <(git -C "${repo_root}" for-each-ref --format='%(refname:short)' refs/heads)
 
   if [[ "${output_format}" == "env" ]]; then
     render_env

--- a/scripts/worktree-ready.sh
+++ b/scripts/worktree-ready.sh
@@ -29,6 +29,7 @@ Common Options:
   --repo <path>              Repository root override
   --handoff <profile>        Handoff profile (manual|terminal|codex)
   --delete-branch            Delete local + remote branch after cleanup when merged proof exists
+  --close-issue              Close the resolved Beads issue after successful cleanup
   --pending-summary <text>   Concrete deferred Phase B summary for handoff output
   --phase-b-seed-payload <text>
                             Structured deferred Phase B payload for rich handoff output
@@ -44,6 +45,7 @@ Examples:
   scripts/worktree-ready.sh doctor --path ../moltinger-0308-005-worktree-ready-flow
   scripts/worktree-ready.sh finish --branch feat/remote-uat-hardening
   scripts/worktree-ready.sh cleanup --branch feat/remote-uat-hardening --delete-branch
+  scripts/worktree-ready.sh cleanup --branch feat/remote-uat-hardening --delete-branch --close-issue
   scripts/worktree-ready.sh handoff --handoff codex --path ../moltinger-0308-005-worktree-ready-flow
 EOF
 }
@@ -82,6 +84,7 @@ target_path=""
 repo_root=""
 handoff_profile="manual"
 delete_branch_requested="false"
+close_issue_requested="false"
 existing_branch=""
 output_format="human"
 pending_summary=""
@@ -230,6 +233,10 @@ parse_args() {
         ;;
       --delete-branch)
         delete_branch_requested="true"
+        shift
+        ;;
+      --close-issue)
+        close_issue_requested="true"
         shift
         ;;
       --pending-summary)
@@ -1013,6 +1020,22 @@ build_finish_close_command() {
   printf 'bd close %s --reason %s || bd close --no-db %s --reason %s\n' "${quoted_issue}" "${quoted_reason}" "${quoted_issue}" "${quoted_reason}"
 }
 
+build_cleanup_close_command() {
+  local resolved_issue="${report_issue_id:-}"
+  local quoted_db=""
+  local quoted_issue=""
+  local quoted_reason=""
+
+  if [[ -z "${resolved_issue}" || "${resolved_issue}" == "n/a" ]]; then
+    return 1
+  fi
+
+  quoted_db="$(shell_quote "${resolved_repo_root}/.beads/beads.db")"
+  quoted_issue="$(shell_quote "${resolved_issue}")"
+  quoted_reason="$(shell_quote "Done")"
+  printf 'bd --db %s close %s --reason %s\n' "${quoted_db}" "${quoted_issue}" "${quoted_reason}"
+}
+
 build_finish_review_command() {
   local worktree_path="${1:-}"
 
@@ -1405,6 +1428,13 @@ cleanup_target_arguments_conflict() {
   local target_branch=""
 
   if [[ -z "${branch}" || -z "${target_path}" ]]; then
+    return 1
+  fi
+
+  # Only explicit --path + --branch requests can conflict. When cleanup
+  # derives a preview path from --branch, the discovered attached worktree is
+  # authoritative and the synthetic sibling preview must not block cleanup.
+  if [[ -z "${path_preview:-}" || "${path_preview}" != "${target_path}" ]]; then
     return 1
   fi
 
@@ -3671,14 +3701,63 @@ set_cleanup_contract() {
   report_phase="cleanup"
   report_boundary="none"
 
-  if [[ "${report_cleanup_reconcile_required}" == "true" || "${report_worktree_action}" == "blocked" || "${report_local_branch_action}" == "blocked" || "${report_remote_branch_action}" == "blocked" || "${report_local_branch_action}" == "skipped" || "${report_remote_branch_action}" == "skipped" ]]; then
+  if [[ "${report_cleanup_reconcile_required}" == "true" || "${report_worktree_action}" == "blocked" || "${report_local_branch_action}" == "blocked" || "${report_remote_branch_action}" == "blocked" || "${report_local_branch_action}" == "skipped" || "${report_remote_branch_action}" == "skipped" || "${report_close_action}" == "blocked" ]]; then
     report_status="cleanup_blocked"
     report_final_state="cleanup_blocked"
+    if [[ "${close_issue_requested}" == "true" && "${report_close_action}" == "skip" ]]; then
+      report_close_action="blocked"
+    fi
     return 0
   fi
 
   report_status="cleanup_complete"
   report_final_state="cleanup_complete"
+}
+
+execute_cleanup_close_action() {
+  local resolved_issue="${report_issue_id:-}"
+  local close_output=""
+  local compact_output=""
+  local rc=0
+  local bd_command=""
+
+  if [[ "${close_issue_requested}" != "true" ]]; then
+    return 0
+  fi
+
+  if ! report_close_command="$(build_cleanup_close_command)"; then
+    report_close_action="skip"
+    add_warning "Issue: n/a; skip bd close for cleanup."
+    return 0
+  fi
+
+  bd_command="$(resolve_system_bd_command_for_path "${resolved_repo_root}" 2>/dev/null || true)"
+  if [[ -z "${bd_command}" ]]; then
+    report_close_action="blocked"
+    add_warning "Could not resolve a system bd command for cleanup close."
+    add_next_step "${report_close_command}"
+    return 1
+  fi
+
+  set +e
+  close_output="$("${bd_command}" --db "${resolved_repo_root}/.beads/beads.db" close "${resolved_issue}" --reason "Done" 2>&1)"
+  rc=$?
+  set -e
+
+  if [[ "${rc}" -eq 0 ]]; then
+    report_close_action="closed"
+    report_close_command=""
+    return 0
+  fi
+
+  compact_output="$(printf '%s' "${close_output}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  report_close_action="blocked"
+  add_warning "bd close failed for ${resolved_issue} after successful cleanup."
+  if [[ -n "${compact_output}" ]]; then
+    add_warning "${compact_output}"
+  fi
+  add_next_step "${report_close_command}"
+  return 1
 }
 
 add_warning() {
@@ -4032,12 +4111,17 @@ render_cleanup_report() {
     render_env_kv "worktree" "${report_worktree_path:-n/a}"
     render_env_kv "preview" "${report_path_preview:-n/a}"
     render_env_kv "branch" "${report_branch_name:-n/a}"
+    render_env_kv "issue" "${report_issue_id:-n/a}"
     render_env_kv "status" "${report_status}"
     render_env_kv "topology_state" "${report_topology_state}"
     render_env_kv "worktree_action" "${report_worktree_action}"
     render_env_kv "local_branch_action" "${report_local_branch_action}"
     render_env_kv "remote_branch_action" "${report_remote_branch_action}"
     render_env_kv "merge_check" "${report_merge_check}"
+    render_env_kv "close_action" "${report_close_action}"
+    if [[ -n "${report_close_command}" ]]; then
+      render_env_kv "close_command" "${report_close_command}"
+    fi
     if [[ -n "${report_default_branch_name}" ]]; then
       render_env_kv "default_branch" "${report_default_branch_name}"
     fi
@@ -4052,6 +4136,7 @@ render_cleanup_report() {
   printf 'Worktree: %s\n' "${report_worktree_path:-n/a}"
   printf 'Preview: %s\n' "${report_path_preview:-n/a}"
   printf 'Branch: %s\n' "${report_branch_name:-n/a}"
+  printf 'Issue: %s\n' "${report_issue_id:-n/a}"
   printf 'Status: %s\n' "${report_status}"
   printf 'Phase: %s\n' "${report_phase}"
   printf 'Boundary: %s\n' "${report_boundary}"
@@ -4061,6 +4146,7 @@ render_cleanup_report() {
   printf 'Local Branch Action: %s\n' "${report_local_branch_action}"
   printf 'Remote Branch Action: %s\n' "${report_remote_branch_action}"
   printf 'Merge Check: %s\n' "${report_merge_check}"
+  printf 'Close: %s\n' "${report_close_command:-${report_close_action}}"
   if [[ -n "${report_default_branch_name}" ]]; then
     printf 'Default Branch: %s\n' "${report_default_branch_name}"
   fi
@@ -4412,10 +4498,14 @@ render_cleanup_contract_report() {
   prepare_report_target
   if [[ "${resolved_repo_root}" != "${resolved_canonical_root}" ]]; then
     local delete_flag=""
+    local close_flag=""
     local cleanup_args="--branch <branch>"
 
     if [[ "${delete_branch_requested}" == "true" ]]; then
       delete_flag=" --delete-branch"
+    fi
+    if [[ "${close_issue_requested}" == "true" ]]; then
+      close_flag=" --close-issue"
     fi
     if [[ -n "${branch}" ]]; then
       cleanup_args="--branch $(shell_quote "${branch}")"
@@ -4428,13 +4518,16 @@ render_cleanup_contract_report() {
     report_status="cleanup_blocked"
     report_final_state="cleanup_blocked"
     report_worktree_action="blocked"
-    report_repair_command="cd $(shell_quote "${resolved_canonical_root}") && scripts/worktree-ready.sh cleanup ${cleanup_args}${delete_flag}"
+    if [[ "${close_issue_requested}" == "true" ]]; then
+      report_close_action="blocked"
+    fi
+    report_repair_command="cd $(shell_quote "${resolved_canonical_root}") && scripts/worktree-ready.sh cleanup ${cleanup_args}${delete_flag}${close_flag}"
     add_warning "Cleanup must run from the canonical root worktree."
     add_next_step "cd $(shell_quote "${resolved_canonical_root}")"
     if [[ -n "${branch}" ]]; then
-      add_next_step "scripts/worktree-ready.sh cleanup --branch $(shell_quote "${branch}")${delete_flag}"
+      add_next_step "scripts/worktree-ready.sh cleanup --branch $(shell_quote "${branch}")${delete_flag}${close_flag}"
     elif [[ -n "${target_path}" ]]; then
-      add_next_step "scripts/worktree-ready.sh cleanup --path $(shell_quote "${target_path}")${delete_flag}"
+      add_next_step "scripts/worktree-ready.sh cleanup --path $(shell_quote "${target_path}")${delete_flag}${close_flag}"
     fi
     render_cleanup_report
     set_command_exit_code_from_cleanup
@@ -4447,6 +4540,9 @@ render_cleanup_contract_report() {
     report_status="cleanup_blocked"
     report_final_state="cleanup_blocked"
     report_worktree_action="blocked"
+    if [[ "${close_issue_requested}" == "true" ]]; then
+      report_close_action="blocked"
+    fi
     add_warning "Cleanup arguments conflict: --path $(shell_quote "${target_path}") resolves to branch '${discovered_branch_name:-unknown}', not requested branch '${branch}'."
     add_next_step "Retry cleanup with --path $(shell_quote "${target_path}") only"
     if [[ -n "${discovered_branch_name}" ]]; then
@@ -4462,6 +4558,12 @@ render_cleanup_contract_report() {
     execute_cleanup_branch_actions || true
   fi
   set_cleanup_contract
+  if [[ "${report_status}" == "cleanup_complete" ]]; then
+    execute_cleanup_close_action || true
+    set_cleanup_contract
+  elif [[ "${close_issue_requested}" == "true" ]]; then
+    report_close_action="blocked"
+  fi
   render_cleanup_report
   set_command_exit_code_from_cleanup
 }

--- a/tests/unit/test_bd_dispatch.sh
+++ b/tests/unit/test_bd_dispatch.sh
@@ -459,6 +459,31 @@ test_canonical_root_plain_bd_allows_worktree_remove_for_linked_worktree() {
     test_pass
 }
 
+test_plain_bd_blocks_raw_worktree_create_in_repo() {
+    test_start "plain_bd_blocks_raw_worktree_create_in_repo"
+
+    local fixture_root repo_dir fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/bd-dispatch-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    seed_repo_local_bd_tools "${repo_dir}"
+    seed_local_beads_foundation "${repo_dir}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    output="$(
+        set +e
+        run_plain_bd "${repo_dir}" "${fake_bin}" worktree create nested-lane 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "29" "${rc}" "Repo-local plain bd must fail closed on raw worktree create"
+    assert_contains "${output}" "raw 'bd worktree create' is disabled" "Blocked raw create should explain the redirect-based ownership problem"
+    assert_contains "${output}" "scripts/worktree-phase-a.sh create-from-base" "Blocked raw create should point to the managed Phase A helper"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
 test_dedicated_worktree_plain_bd_canonicalizes_worktree_list_to_root() {
     test_start "dedicated_worktree_plain_bd_canonicalizes_worktree_list_to_root"
 
@@ -1102,6 +1127,7 @@ run_all_tests() {
     test_canonical_root_plain_bd_blocks_mutation_by_default
     test_canonical_root_plain_bd_allows_explicit_root_db_override
     test_canonical_root_plain_bd_allows_worktree_remove_for_linked_worktree
+    test_plain_bd_blocks_raw_worktree_create_in_repo
     test_dedicated_worktree_plain_bd_canonicalizes_worktree_list_to_root
     test_canonical_root_plain_bd_blocks_worktree_remove_for_non_linked_target
     test_plain_bd_blocks_legacy_redirect

--- a/tests/unit/test_bd_local.sh
+++ b/tests/unit/test_bd_local.sh
@@ -193,6 +193,79 @@ test_bd_local_blocks_deprecated_sync_with_modern_guidance() {
     test_pass
 }
 
+test_bd_local_blocks_raw_worktree_create_with_managed_guidance() {
+    test_start "bd_local_blocks_raw_worktree_create_with_managed_guidance"
+
+    local fixture_root repo_dir worktree_path output rc
+    fixture_root="$(mktemp -d /tmp/bd-local-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    worktree_path="${fixture_root}/moltinger-runtime-only-create"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/runtime-only-create" "main"
+
+    install_fake_bd "${worktree_path}"
+    seed_post_migration_runtime_state "${worktree_path}"
+
+    output="$(
+        set +e
+        run_wrapper "${worktree_path}" worktree create nested-lane 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "29" "${rc}" "bd-local must fail closed on raw worktree create in this repository"
+    assert_contains "${output}" "raw 'bd worktree create' is disabled" "bd-local must surface the managed-worktree restriction"
+    assert_contains "${output}" "scripts/worktree-ready.sh plan/create" "bd-local must redirect operators to the repo-owned worktree entrypoint"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_bd_local_passes_through_canonical_root_worktree_list() {
+    test_start "bd_local_passes_through_canonical_root_worktree_list"
+
+    local fixture_root repo_dir output
+    fixture_root="$(mktemp -d /tmp/bd-local-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+
+    install_fake_bd "${repo_dir}"
+
+    output="$(
+        run_wrapper "${repo_dir}" worktree list
+    )"
+
+    assert_contains "${output}" "ARGS=worktree list" "bd-local must pass canonical-root worktree list through unchanged"
+    if [[ "${output}" == *"BEADS_DB=${repo_dir}/.beads/beads.db"* ]]; then
+        test_fail "bd-local must not pin BEADS_DB for canonical-root readonly worktree list"
+    fi
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_bd_local_allows_canonical_root_cleanup_admin_worktree_remove() {
+    test_start "bd_local_allows_canonical_root_cleanup_admin_worktree_remove"
+
+    local fixture_root repo_dir worktree_path output
+    fixture_root="$(mktemp -d /tmp/bd-local-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    worktree_path="${fixture_root}/moltinger-cleanup-target"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/cleanup-target" "main"
+
+    install_fake_bd "${repo_dir}"
+
+    output="$(
+        run_wrapper "${repo_dir}" worktree remove "${worktree_path}"
+    )"
+
+    assert_contains "${output}" "ARGS=worktree remove ${worktree_path}" "bd-local must allow canonical-root cleanup-admin worktree remove"
+    if [[ "${output}" == *"BEADS_DB=${repo_dir}/.beads/beads.db"* ]]; then
+        test_fail "bd-local must not pin BEADS_DB for canonical-root cleanup-admin remove"
+    fi
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
 test_bd_local_blocks_broken_runtime_only_state_with_bootstrap_guidance() {
     test_start "bd_local_blocks_broken_runtime_only_state_with_bootstrap_guidance"
 
@@ -244,6 +317,9 @@ run_all_tests() {
     test_bd_local_blocks_missing_foundation_files
     test_bd_local_allows_readonly_post_migration_runtime_without_issues_jsonl
     test_bd_local_blocks_deprecated_sync_with_modern_guidance
+    test_bd_local_blocks_raw_worktree_create_with_managed_guidance
+    test_bd_local_passes_through_canonical_root_worktree_list
+    test_bd_local_allows_canonical_root_cleanup_admin_worktree_remove
     test_bd_local_blocks_broken_runtime_only_state_with_bootstrap_guidance
     generate_report
 }

--- a/tests/unit/test_beads_worktree_audit.sh
+++ b/tests/unit/test_beads_worktree_audit.sh
@@ -306,6 +306,109 @@ test_audit_warns_for_runtime_bootstrap_required_runtime_only_sibling() {
     test_pass
 }
 
+test_audit_warns_for_branch_only_merged_local_branch() {
+    test_start "audit_warns_for_branch_only_merged_local_branch"
+
+    local fixture_root repo_dir fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/beads-worktree-audit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "${fixture_root}" "moltinger")"
+    seed_beads_audit_tools "${repo_dir}"
+    seed_local_beads_foundation "${repo_dir}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    (
+        cd "${repo_dir}"
+        git checkout -b feat/branch-only-cleanup >/dev/null
+        printf 'branch-only\n' > cleanup.txt
+        git add cleanup.txt
+        git commit -m "fixture: branch-only cleanup commit" >/dev/null
+        git checkout main >/dev/null
+        git merge --no-ff feat/branch-only-cleanup -m "fixture: merge branch-only cleanup" >/dev/null
+    )
+
+    output="$(
+        set +e
+        run_audit "${repo_dir}" "${fake_bin}" 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "${rc}" "Branch-only drift should surface as a warning, not fail closed canonical audit"
+    assert_contains "${output}" "Warnings: 1" "Audit should count branch-only drift as a warning"
+    assert_contains "${output}" "scope=branch state=branch_only_merged" "Audit should classify merged branch-only drift explicitly"
+    assert_contains "${output}" "branch=feat/branch-only-cleanup" "Audit should identify the stale local branch by name"
+    assert_contains "${output}" "git -C " "Audit should emit a concrete local branch deletion next step"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_audit_warns_for_branch_only_active_local_branch() {
+    test_start "audit_warns_for_branch_only_active_local_branch"
+
+    local fixture_root repo_dir fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/beads-worktree-audit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "${fixture_root}" "moltinger")"
+    seed_beads_audit_tools "${repo_dir}"
+    seed_local_beads_foundation "${repo_dir}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    (
+        cd "${repo_dir}"
+        git checkout -b feat/branch-only-active >/dev/null
+        printf 'branch-only-active\n' > cleanup.txt
+        git add cleanup.txt
+        git commit -m "fixture: branch-only active commit" >/dev/null
+        git checkout main >/dev/null
+    )
+
+    output="$(
+        set +e
+        run_audit "${repo_dir}" "${fake_bin}" 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "${rc}" "Active branch-only drift should remain a warning, not fail closed canonical audit"
+    assert_contains "${output}" "Warnings: 1" "Audit should count active branch-only drift as a warning"
+    assert_contains "${output}" "scope=branch state=branch_only_active" "Audit should classify unmerged branch-only drift explicitly"
+    assert_contains "${output}" "action=review_branch_owner" "Audit should ask for review instead of deletion on unmerged branch-only drift"
+    assert_contains "${output}" "branch=feat/branch-only-active" "Audit should identify the active local branch by name"
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
+test_audit_skips_branch_only_warning_for_linked_branch() {
+    test_start "audit_skips_branch_only_warning_for_linked_branch"
+
+    local fixture_root repo_dir worktree_path fake_bin output rc
+    fixture_root="$(mktemp -d /tmp/beads-worktree-audit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "${fixture_root}" "moltinger")"
+    seed_beads_audit_tools "${repo_dir}"
+    seed_local_beads_foundation "${repo_dir}"
+    worktree_path="${fixture_root}/moltinger-linked-branch"
+    git_topology_fixture_add_worktree_branch_from "${repo_dir}" "${worktree_path}" "feat/linked-branch" "main"
+    seed_post_migration_runtime_foundation "${worktree_path}"
+    fake_bin="$(create_fake_system_bd_bin "${fixture_root}")"
+
+    output="$(
+        set +e
+        run_audit "${repo_dir}" "${fake_bin}" 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "${output}" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "${rc}" "Canonical audit should stay clean for a branch that already has a linked worktree"
+    assert_contains "${output}" "Warnings: 0" "Audit should not create synthetic branch-only warnings for linked branches"
+    if printf '%s' "${output}" | grep -Fq 'scope=branch state='; then
+        test_fail "Audit must not emit branch-only warnings for branches that already have linked worktrees"
+    fi
+
+    rm -rf "${fixture_root}"
+    test_pass
+}
+
 run_test_beads_worktree_audit() {
     start_timer
     test_audit_blocks_canonical_root_when_legacy_redirect_exists
@@ -314,6 +417,9 @@ run_test_beads_worktree_audit() {
     test_audit_skips_enforcement_in_non_canonical_worktree
     test_audit_treats_post_migration_runtime_only_sibling_as_ok
     test_audit_warns_for_runtime_bootstrap_required_runtime_only_sibling
+    test_audit_warns_for_branch_only_merged_local_branch
+    test_audit_warns_for_branch_only_active_local_branch
+    test_audit_skips_branch_only_warning_for_linked_branch
     generate_report
 }
 

--- a/tests/unit/test_worktree_ready.sh
+++ b/tests/unit/test_worktree_ready.sh
@@ -19,7 +19,51 @@ create_fake_bd_bin() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${1:-}" == "worktree" && "${2:-}" == "list" && "${3:-}" == "--json" ]]; then
+db_path=""
+args=()
+seen_command=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db)
+      if [[ "${seen_command}" == "1" ]]; then
+        args+=("$1")
+        shift
+        continue
+      fi
+      db_path="${2:-}"
+      shift 2
+      ;;
+    --db=*)
+      if [[ "${seen_command}" == "1" ]]; then
+        args+=("$1")
+        shift
+        continue
+      fi
+      db_path="${1#--db=}"
+      shift
+      ;;
+    --no-db|--quiet|--verbose)
+      if [[ "${seen_command}" == "1" ]]; then
+        args+=("$1")
+      fi
+      shift
+      ;;
+    --json)
+      if [[ "${seen_command}" == "1" ]]; then
+        args+=("$1")
+      fi
+      shift
+      ;;
+    *)
+      args+=("$1")
+      seen_command=1
+      shift
+      ;;
+  esac
+done
+
+if [[ "${args[0]:-}" == "worktree" && "${args[1]:-}" == "list" && "${args[2]:-}" == "--json" ]]; then
   payload="${BD_WORKTREE_LIST_JSON:-[]}"
   if [[ "${BD_WORKTREE_LIST_FILTER_MISSING:-0}" == "1" ]]; then
     filtered_lines=()
@@ -42,11 +86,11 @@ if [[ "${1:-}" == "worktree" && "${2:-}" == "list" && "${3:-}" == "--json" ]]; t
 fi
 
 if [[ -n "${BD_CALL_LOG:-}" ]]; then
-  printf '%s\n' "${1:-}" >> "${BD_CALL_LOG}"
+  printf '%s\n' "${args[0]:-}" >> "${BD_CALL_LOG}"
 fi
 
-if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
-  target_path="${3:-}"
+if [[ "${args[0]:-}" == "worktree" && "${args[1]:-}" == "remove" ]]; then
+  target_path="${args[2]:-}"
   if [[ "${BD_WORKTREE_REMOVE_CANONICALIZE:-0}" == "1" && -d "${target_path}" ]]; then
     target_path="$(cd "${target_path}" && pwd -P)"
   fi
@@ -62,21 +106,21 @@ if [[ "${1:-}" == "worktree" && "${2:-}" == "remove" ]]; then
   exit "${BD_WORKTREE_REMOVE_RC:-0}"
 fi
 
-if [[ "${1:-}" == "list" && "${2:-}" == "--all" && "${3:-}" == "--json" ]]; then
+if [[ "${args[0]:-}" == "list" && "${args[1]:-}" == "--all" && "${args[2]:-}" == "--json" ]]; then
   printf '%s\n' "${BD_LIST_ALL_JSON:-[]}"
   exit 0
 fi
 
-if [[ "${1:-}" == "show" && "${3:-}" == "--json" ]]; then
+if [[ "${args[0]:-}" == "show" && "${args[2]:-}" == "--json" ]]; then
   if [[ -n "${BD_SHOW_JSON_MAP:-}" ]]; then
-    printf '%s\n' "${BD_SHOW_JSON_MAP}" | jq -c --arg issue "${2:-}" '.[$issue] // empty'
+    printf '%s\n' "${BD_SHOW_JSON_MAP}" | jq -c --arg issue "${args[1]:-}" '.[$issue] // empty'
     exit 0
   fi
   printf '%s\n' "${BD_SHOW_JSON:-[]}"
   exit 0
 fi
 
-if [[ "${1:-}" == "status" ]]; then
+if [[ "${args[0]:-}" == "status" ]]; then
   if [[ -n "${BD_STATUS_SLEEP_SECONDS:-}" ]]; then
     sleep "${BD_STATUS_SLEEP_SECONDS}"
   fi
@@ -89,7 +133,7 @@ if [[ "${1:-}" == "status" ]]; then
   exit "${BD_STATUS_RC:-0}"
 fi
 
-if [[ "${1:-}" == "info" ]]; then
+if [[ "${args[0]:-}" == "info" ]]; then
   if [[ -n "${BD_INFO_SLEEP_SECONDS:-}" ]]; then
     sleep "${BD_INFO_SLEEP_SECONDS}"
   fi
@@ -102,12 +146,25 @@ if [[ "${1:-}" == "info" ]]; then
   exit "${BD_INFO_RC:-0}"
 fi
 
-if [[ "${1:-}" == "doctor" && "${2:-}" == "--json" ]]; then
+if [[ "${args[0]:-}" == "doctor" && "${args[1]:-}" == "--json" ]]; then
   if [[ -n "${BD_DOCTOR_SLEEP_SECONDS:-}" ]]; then
     sleep "${BD_DOCTOR_SLEEP_SECONDS}"
   fi
   printf '%s\n' "${BD_DOCTOR_STDOUT:-{\"checks\":[],\"overall_ok\":true}}"
   exit "${BD_DOCTOR_RC:-0}"
+fi
+
+if [[ "${args[0]:-}" == "close" ]]; then
+  if [[ -n "${BD_CLOSE_LOG:-}" ]]; then
+    printf 'DB=%s ARGS=%s\n' "${db_path}" "${args[*]}" >> "${BD_CLOSE_LOG}"
+  fi
+  if [[ -n "${BD_CLOSE_STDOUT:-}" ]]; then
+    printf '%s\n' "${BD_CLOSE_STDOUT}"
+  fi
+  if [[ -n "${BD_CLOSE_STDERR:-}" ]]; then
+    printf '%s\n' "${BD_CLOSE_STDERR}" >&2
+  fi
+  exit "${BD_CLOSE_RC:-0}"
 fi
 
 printf 'unsupported fake bd invocation\n' >&2
@@ -1818,6 +1875,145 @@ test_cleanup_delete_branch_uses_git_ancestor_proof() {
     test_pass
 }
 
+test_cleanup_close_issue_closes_resolved_issue_after_success() {
+    test_start "worktree_ready_cleanup_close_issue_closes_resolved_issue_after_success"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json close_log
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-crq6-cleanup"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/moltinger-crq6-cleanup" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    close_log="${fixture_root}/bd-close.log"
+    mkdir -p "${repo_dir}/.beads"
+    : > "${repo_dir}/.beads/beads.db"
+    cat > "${repo_dir}/.beads/issues.jsonl" <<'EOF'
+{"id":"moltinger-crq6","title":"cleanup governance drift","status":"in_progress","issue_type":"bug","priority":1}
+EOF
+    (
+        cd "$repo_dir"
+        git push -u origin feat/moltinger-crq6-cleanup >/dev/null
+        git merge --no-ff feat/moltinger-crq6-cleanup -m "fixture: merge crq6 cleanup branch" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{"name":"crq6-cleanup","path":"%s","branch":"feat/moltinger-crq6-cleanup","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_CLOSE_LOG="${close_log}" \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/moltinger-crq6-cleanup --delete-branch --close-issue 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should be able to close the resolved issue after successful branch/worktree cleanup"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should remain complete when issue close succeeds"
+    assert_contains "$output" 'Close: closed' "Cleanup should report the issue as closed after a successful close step"
+    if [[ ! -f "${close_log}" ]]; then
+        test_fail "Cleanup close flow should record a bd close invocation"
+    fi
+    assert_file_contains "${close_log}" 'DB='"${repo_dir}/.beads/beads.db"' ARGS=close moltinger-crq6 --reason Done' "Cleanup close should use an explicit canonical-root DB override"
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_without_close_issue_does_not_invoke_bd_close() {
+    test_start "worktree_ready_cleanup_without_close_issue_does_not_invoke_bd_close"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json close_log
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-cleanup-no-close"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/moltinger-cleanup-no-close" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    close_log="${fixture_root}/bd-close.log"
+    mkdir -p "${repo_dir}/.beads"
+    : > "${repo_dir}/.beads/beads.db"
+    cat > "${repo_dir}/.beads/issues.jsonl" <<'EOF'
+{"id":"moltinger-cleanup","title":"cleanup governance drift","status":"in_progress","issue_type":"bug","priority":1}
+EOF
+    (
+        cd "$repo_dir"
+        git push -u origin feat/moltinger-cleanup-no-close >/dev/null
+        git merge --no-ff feat/moltinger-cleanup-no-close -m "fixture: merge cleanup without close flag" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{"name":"cleanup-no-close","path":"%s","branch":"feat/moltinger-cleanup-no-close","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_CLOSE_LOG="${close_log}" \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/moltinger-cleanup-no-close --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Cleanup should still succeed when --close-issue is not requested"
+    assert_contains "$output" 'Close: skip' "Cleanup report should keep close action skipped when the flag is absent"
+    if [[ -f "${close_log}" ]]; then
+        test_fail "Cleanup must not invoke bd close when --close-issue was not requested"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_close_issue_does_not_run_when_cleanup_is_blocked() {
+    test_start "worktree_ready_cleanup_close_issue_does_not_run_when_cleanup_is_blocked"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json close_log
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-cleanup-blocked"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/moltinger-cleanup-blocked" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    close_log="${fixture_root}/bd-close.log"
+    mkdir -p "${repo_dir}/.beads"
+    : > "${repo_dir}/.beads/beads.db"
+    cat > "${repo_dir}/.beads/issues.jsonl" <<'EOF'
+{"id":"moltinger-cleanup-blocked","title":"cleanup governance drift","status":"in_progress","issue_type":"bug","priority":1}
+EOF
+    (
+        cd "$existing_path"
+        printf 'unmerged\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: unmerged cleanup branch" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/moltinger-cleanup-blocked >/dev/null
+    )
+    bd_json="$(printf '[{"name":"cleanup-blocked","path":"%s","branch":"feat/moltinger-cleanup-blocked","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        BD_CLOSE_LOG="${close_log}" \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/moltinger-cleanup-blocked --delete-branch --close-issue 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "23" "$rc" "Cleanup must stay blocked when merge proof is missing even if --close-issue was requested"
+    assert_contains "$output" 'Status: cleanup_blocked' "Cleanup should report the blocked state before any close step"
+    assert_contains "$output" 'Close: blocked' "Cleanup report should show that issue close stayed blocked with the overall cleanup"
+    if [[ -f "${close_log}" ]]; then
+        test_fail "Cleanup must not invoke bd close before the cleanup contract succeeds"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
 test_cleanup_delete_branch_without_existing_worktree_does_not_false_conflict() {
     test_start "worktree_ready_cleanup_delete_branch_without_existing_worktree_does_not_false_conflict"
 
@@ -1897,6 +2093,56 @@ test_cleanup_branch_only_without_existing_worktree_preserves_branch_without_dele
     fi
     if ! git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/cleanup-branch-only; then
         test_fail "Cleanup should preserve the local branch when --delete-branch is not requested"
+    fi
+
+    rm -rf "$fixture_root"
+    test_pass
+}
+
+test_cleanup_branch_only_with_existing_worktree_does_not_false_conflict() {
+    test_start "worktree_ready_cleanup_branch_only_with_existing_worktree_does_not_false_conflict"
+
+    local fixture_root repo_dir fake_bin existing_path output rc bd_json
+    fixture_root="$(mktemp -d /tmp/worktree-ready-unit.XXXXXX)"
+    repo_dir="$(git_topology_fixture_create_named_repo "$fixture_root" "moltinger")"
+    repo_dir="$(cd "$repo_dir" && pwd -P)"
+    fake_bin="$(create_fake_bd_bin "$fixture_root")"
+    existing_path="${fixture_root}/moltinger-attached-cleanup-target"
+    git_topology_fixture_add_worktree_branch_from "$repo_dir" "$existing_path" "feat/attached-cleanup-target" "main"
+    existing_path="$(cd "$existing_path" && pwd -P)"
+    (
+        cd "$existing_path"
+        printf 'feature\n' > feature.txt
+        git add feature.txt
+        git commit -m "fixture: attached cleanup target commit" >/dev/null
+    )
+    (
+        cd "$repo_dir"
+        git push -u origin feat/attached-cleanup-target >/dev/null
+        git merge --no-ff feat/attached-cleanup-target -m "fixture: merge attached cleanup target" >/dev/null
+        git push origin main >/dev/null
+    )
+    bd_json="$(printf '[{"name":"attached-cleanup-target","path":"%s","branch":"feat/attached-cleanup-target","beads_state":"local"}]\n' "${existing_path}")"
+
+    output="$(
+        set +e
+        BD_WORKTREE_LIST_JSON="${bd_json}" \
+        run_worktree_cleanup "$repo_dir" "$fake_bin" --branch feat/attached-cleanup-target --delete-branch 2>&1
+        printf '\n__RC__=%s\n' "$?"
+    )"
+    rc="$(printf '%s\n' "$output" | awk -F= '/__RC__/ {print $2}' | tail -1)"
+
+    assert_eq "0" "$rc" "Branch-only cleanup should accept the discovered attached worktree instead of tripping a synthetic path conflict"
+    assert_contains "$output" 'Status: cleanup_complete' "Cleanup should complete when the requested branch already has an attached managed worktree"
+    assert_contains "$output" 'Worktree Action: removed' "Cleanup should remove the attached worktree for the requested branch"
+    if printf '%s' "$output" | grep -Fq 'Cleanup arguments conflict'; then
+        test_fail "Branch-only cleanup with an attached worktree must not report a false path/branch conflict"
+    fi
+    if [[ -d "$existing_path" ]]; then
+        test_fail "Cleanup should remove the discovered attached worktree for branch-only cleanup"
+    fi
+    if git -C "$repo_dir" show-ref --verify --quiet refs/heads/feat/attached-cleanup-target; then
+        test_fail "Cleanup should remove the local branch after attached branch-only cleanup"
     fi
 
     rm -rf "$fixture_root"
@@ -2752,8 +2998,12 @@ run_all_tests() {
     test_cleanup_removes_linked_worktree_without_branch_delete
     test_cleanup_prunes_stale_missing_worktree_entry
     test_cleanup_delete_branch_uses_git_ancestor_proof
+    test_cleanup_close_issue_closes_resolved_issue_after_success
+    test_cleanup_without_close_issue_does_not_invoke_bd_close
+    test_cleanup_close_issue_does_not_run_when_cleanup_is_blocked
     test_cleanup_delete_branch_without_existing_worktree_does_not_false_conflict
     test_cleanup_branch_only_without_existing_worktree_preserves_branch_without_delete_flag
+    test_cleanup_branch_only_with_existing_worktree_does_not_false_conflict
     test_cleanup_uses_git_remove_fallback_for_false_unpushed_guard
     test_cleanup_does_not_bypass_false_unpushed_guard_without_merge_proof
     test_cleanup_does_not_bypass_false_unpushed_guard_for_dirty_worktree


### PR DESCRIPTION
## Что сделано
- fail-closed blocked raw \ in repo-owned dispatch surfaces
- extended worktree audit to catch branch-only local drift
- completed cleanup reconciliation with explicit issue-close/report handling
- synchronized deprecated \ wrapper with new resolver decisions and added regression coverage
- recorded RCA and rebuilt lessons index

## Проверки
- bash tests/unit/test_bd_local.sh
- bash tests/unit/test_bd_dispatch.sh
- bash tests/unit/test_beads_worktree_audit.sh
- bash tests/unit/test_worktree_ready.sh
- bash tests/static/test_beads_worktree_ownership.sh
- bash scripts/build-lessons-index.sh