### PR TITLE
ci: move AI workflow execution to AI IDE handoff

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-name: AI IDE Review Handoff
+name: Claude Code Review
 
 # Deterministic PR review handoff workflow.
 # GitHub Actions prepares context and operators complete the review in AI IDE.
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   review-handoff:
-    name: Review Handoff
+    name: AI Code Review
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -97,7 +97,7 @@ jobs:
           additions="0"
           deletions="0"
           files_summary="- File list unavailable"
-          checks_summary="- CI checks unavailable"
+          checks_summary="- Check the PR Checks tab for the latest CI state."
 
           pr_json="$(gh pr view "$pr_number" --json title,body,url,changedFiles,additions,deletions 2>/dev/null || true)"
           if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
@@ -120,13 +120,6 @@ jobs:
               files_summary="$api_files"
             fi
 
-            api_checks="$(
-              gh pr checks "$pr_number" --json name,state --jq '.[] | "- \(.name): \(.state)"' 2>/dev/null \
-                | sed -n '1,40p' || true
-            )"
-            if [[ -n "$api_checks" ]]; then
-              checks_summary="$api_checks"
-            fi
           fi
 
           focus_hint="General quality, correctness, maintainability, and risks."
@@ -234,13 +227,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! scripts/ci/upsert_sticky_comment.sh \
+          scripts/ci/upsert_sticky_comment.sh \
             --repo "${GITHUB_REPOSITORY}" \
             --issue-number "${{ steps.review.outputs.pr_number }}" \
             --marker "${{ steps.review.outputs.marker }}" \
-            --body-file "${{ steps.review.outputs.comment_path }}"; then
-            echo "::warning::Unable to publish/update sticky review comment."
-          fi
+            --body-file "${{ steps.review.outputs.comment_path }}"
 
       - name: Upload review artifact
         if: always()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-name: Claude Code Review
+name: AI IDE Review Handoff
 
 # Deterministic PR review handoff workflow.
 # GitHub Actions prepares context and operators complete the review in AI IDE.
@@ -30,8 +30,8 @@ permissions:
   issues: write
 
 jobs:
-  claude-review:
-    name: AI Code Review
+  review-handoff:
+    name: Review Handoff
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -85,7 +85,7 @@ jobs:
 
           report_path="reports/pr-${pr_number}-review.md"
           comment_path=".tmp/pr-${pr_number}-review-comment.md"
-          marker="zai-review:pr-${pr_number}"
+          marker="ai-ide-review:pr-${pr_number}"
           run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           status="ready"
@@ -246,7 +246,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: zai-review-pr-${{ steps.pr-context.outputs.number }}
+          name: ai-ide-review-pr-${{ steps.pr-context.outputs.number }}
           path: ${{ steps.review.outputs.report_path }}
           retention-days: 90
           if-no-files-found: warn

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,13 +1,14 @@
-name: Claude Interactive Assistant
+name: AI IDE Assistant Handoff
 
-# Interactive assistant workflow powered by Z.ai Coding Plan.
-# Triggered by @claude or @zai mentions in issues/PR comments/reviews.
+# Deterministic assistant handoff workflow.
+# GitHub Actions collects context and posts a sticky handoff comment.
+# Any AI response must be completed manually in AI IDE.
 
 on:
   workflow_dispatch:
     inputs:
       target_number:
-        description: "Issue/PR number for assistant response"
+        description: "Issue/PR number for assistant handoff"
         required: true
         type: number
       target_kind:
@@ -19,9 +20,9 @@ on:
           - pr
           - issue
       message:
-        description: "Assistant request (include @zai or @claude)"
+        description: "Assistant request (prefer @ai-ide; legacy @claude/@zai still trigger handoff)"
         required: true
-        default: "@zai Please summarize risks in this change."
+        default: "@ai-ide Please summarize review risks for this change."
         type: string
 
   issue_comment:
@@ -40,27 +41,36 @@ permissions:
   actions: read
 
 jobs:
-  claude-assistant:
-    name: Claude Assistant
+  ai-ide-assistant:
+    name: Assistant Handoff
     if: |
       (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@zai'))) ||
-      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@zai'))) ||
-      (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '@claude') || contains(github.event.review.body, '@zai'))) ||
+      (github.event_name == 'issue_comment' && (
+        contains(github.event.comment.body, '@ai-ide') ||
+        contains(github.event.comment.body, '@claude') ||
+        contains(github.event.comment.body, '@zai')
+      )) ||
+      (github.event_name == 'pull_request_review_comment' && (
+        contains(github.event.comment.body, '@ai-ide') ||
+        contains(github.event.comment.body, '@claude') ||
+        contains(github.event.comment.body, '@zai')
+      )) ||
+      (github.event_name == 'pull_request_review' && (
+        contains(github.event.review.body, '@ai-ide') ||
+        contains(github.event.review.body, '@claude') ||
+        contains(github.event.review.body, '@zai')
+      )) ||
       (github.event_name == 'issues' && (
+        contains(github.event.issue.body, '@ai-ide') ||
         contains(github.event.issue.body, '@claude') ||
         contains(github.event.issue.body, '@zai') ||
+        contains(github.event.issue.title, '@ai-ide') ||
         contains(github.event.issue.title, '@claude') ||
         contains(github.event.issue.title, '@zai')
       ))
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      GLM_API_BASE: https://api.z.ai/api/coding/paas/v4
-      GLM_MODEL: glm-5
-      AI_ASSISTANT_MAX_CONTEXT_CHARS: "35000"
-      AI_REVIEW_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER }}
 
     steps:
       - name: Checkout repository
@@ -72,214 +82,220 @@ jobs:
         run: |
           command -v gh >/dev/null 2>&1 || (echo "::error::gh CLI is required" && exit 1)
           command -v jq >/dev/null 2>&1 || (echo "::error::jq is required" && exit 1)
-          command -v curl >/dev/null 2>&1 || (echo "::error::curl is required" && exit 1)
 
-      - name: Build assistant reply (Z.ai)
-        id: assistant
+      - name: Build AI IDE handoff
+        id: handoff
         env:
           GH_TOKEN: ${{ github.token }}
-          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
         run: |
           set -euo pipefail
 
-          mkdir -p .tmp
+          mkdir -p reports .tmp
 
           event_name="${GITHUB_EVENT_NAME}"
-          provider="${AI_REVIEW_PROVIDER:-zai}"
           event_path="${GITHUB_EVENT_PATH}"
 
           issue_number=""
           request_text=""
           request_author="unknown"
-          is_pr="false"
-          status="fallback"
-          reason=""
+          target_kind="issue"
+          marker=""
+          report_path=""
+          comment_path=""
+          status="ready"
+          reason="Context collected successfully."
 
           case "$event_name" in
             workflow_dispatch)
               issue_number="${{ inputs.target_number }}"
               request_text="${{ inputs.message }}"
               request_author="${GITHUB_ACTOR}"
-              if [[ "${{ inputs.target_kind }}" == "pr" ]]; then
-                is_pr="true"
-              fi
+              target_kind="${{ inputs.target_kind }}"
               ;;
             issue_comment)
               issue_number="$(jq -r '.issue.number // empty' "$event_path")"
               request_text="$(jq -r '.comment.body // ""' "$event_path")"
               request_author="$(jq -r '.comment.user.login // "unknown"' "$event_path")"
               if jq -e '.issue.pull_request != null' "$event_path" >/dev/null 2>&1; then
-                is_pr="true"
+                target_kind="pr"
               fi
               ;;
             pull_request_review_comment)
               issue_number="$(jq -r '.pull_request.number // empty' "$event_path")"
               request_text="$(jq -r '.comment.body // ""' "$event_path")"
               request_author="$(jq -r '.comment.user.login // "unknown"' "$event_path")"
-              is_pr="true"
+              target_kind="pr"
               ;;
             pull_request_review)
               issue_number="$(jq -r '.pull_request.number // empty' "$event_path")"
               request_text="$(jq -r '.review.body // ""' "$event_path")"
               request_author="$(jq -r '.review.user.login // "unknown"' "$event_path")"
-              is_pr="true"
+              target_kind="pr"
               ;;
             issues)
               issue_number="$(jq -r '.issue.number // empty' "$event_path")"
-              issue_title="$(jq -r '.issue.title // ""' "$event_path")"
-              issue_body="$(jq -r '.issue.body // ""' "$event_path")"
-              request_text="${issue_title}\n\n${issue_body}"
+              request_title="$(jq -r '.issue.title // ""' "$event_path")"
+              request_body="$(jq -r '.issue.body // ""' "$event_path")"
+              request_text="${request_title}\n\n${request_body}"
               request_author="$(jq -r '.issue.user.login // "unknown"' "$event_path")"
+              target_kind="issue"
               ;;
             *)
+              status="degraded"
               reason="Unsupported event: ${event_name}"
               ;;
           esac
 
-          marker="zai-assistant:thread-${issue_number:-unknown}"
-          prompt_path=".tmp/assistant-${issue_number:-unknown}-prompt.md"
-          output_path=".tmp/assistant-${issue_number:-unknown}-output.md"
-          raw_response_path=".tmp/assistant-${issue_number:-unknown}-raw-response.json"
-          comment_path=".tmp/assistant-${issue_number:-unknown}-comment.md"
-          context_path=".tmp/assistant-${issue_number:-unknown}-context.md"
+          marker="ai-ide-assistant:thread-${issue_number:-unknown}"
+          report_path="reports/thread-${issue_number:-unknown}-ai-ide-handoff.md"
+          comment_path=".tmp/thread-${issue_number:-unknown}-ai-ide-comment.md"
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          title="(unavailable)"
+          body="(unavailable)"
+          url=""
+          files_summary="- File list unavailable"
+          checks_summary="- CI checks unavailable"
 
           if [[ -z "$issue_number" ]]; then
+            status="degraded"
             reason="Unable to determine issue/PR number from event payload."
-          elif [[ "$provider" == "off" ]]; then
-            reason="AI provider disabled by AI_REVIEW_PROVIDER=off."
-          elif [[ -z "${GLM_API_KEY:-}" ]]; then
-            reason="Missing GLM_API_KEY secret."
-          elif ! printf '%s' "$request_text" | grep -Eiq '@(claude|zai)\b'; then
-            reason="Mention not detected in message text."
-          else
-            if [[ "$is_pr" == "true" ]]; then
-              pr_json="$(gh pr view "$issue_number" --json title,body,url,changedFiles,additions,deletions 2>/dev/null || true)"
-              if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
-                reason="Failed to fetch PR context via gh pr view."
-              else
-                gh pr diff "$issue_number" > "$context_path" 2>/dev/null || true
-                max_chars="${AI_ASSISTANT_MAX_CONTEXT_CHARS:-35000}"
-                context_size="$(wc -c < "$context_path" | tr -d ' ' || echo 0)"
-                if [[ "$context_size" -gt "$max_chars" ]]; then
-                  head -c "$max_chars" "$context_path" > "${context_path}.trimmed"
-                  printf '\n\n[context diff truncated to %s chars]\n' "$max_chars" >> "${context_path}.trimmed"
-                  mv "${context_path}.trimmed" "$context_path"
-                fi
+          fi
 
-                {
-                  echo "Repository: ${GITHUB_REPOSITORY}"
-                  echo "Event: ${event_name}"
-                  echo "Requester: ${request_author}"
-                  echo "PR Number: ${issue_number}"
-                  echo "PR URL: $(echo "$pr_json" | jq -r '.url // ""')"
-                  echo "PR Title: $(echo "$pr_json" | jq -r '.title // "(no title)"')"
-                  echo "PR Description:"
-                  echo "$(echo "$pr_json" | jq -r '.body // "(no description)"')"
-                  echo ""
-                  echo "User request:"
-                  echo "$request_text"
-                  echo ""
-                  echo "Recent PR diff (possibly truncated):"
-                  cat "$context_path"
-                  echo ""
-                  echo "Instructions:"
-                  echo "- Answer the user's request directly."
-                  echo "- Be concise and actionable."
-                  echo "- Use file:line references when possible."
-                  echo "- Do not claim actions you did not perform."
-                } > "$prompt_path"
-              fi
+          if [[ "$status" == "ready" && "$target_kind" == "pr" ]]; then
+            pr_json="$(gh pr view "$issue_number" --json title,body,url,changedFiles,additions,deletions 2>/dev/null || true)"
+            if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+              status="degraded"
+              reason="Failed to fetch PR context via gh pr view."
             else
-              issue_json="$(gh issue view "$issue_number" --json title,body,url 2>/dev/null || true)"
-              if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
-                reason="Failed to fetch issue context via gh issue view."
-              else
-                {
-                  echo "Repository: ${GITHUB_REPOSITORY}"
-                  echo "Event: ${event_name}"
-                  echo "Requester: ${request_author}"
-                  echo "Issue Number: ${issue_number}"
-                  echo "Issue URL: $(echo "$issue_json" | jq -r '.url // ""')"
-                  echo "Issue Title: $(echo "$issue_json" | jq -r '.title // "(no title)"')"
-                  echo "Issue Body:"
-                  echo "$(echo "$issue_json" | jq -r '.body // "(no description)"')"
-                  echo ""
-                  echo "User request:"
-                  echo "$request_text"
-                  echo ""
-                  echo "Instructions:"
-                  echo "- Answer the user's request directly."
-                  echo "- Be concise and actionable."
-                  echo "- If data is missing, state exactly what is missing."
-                } > "$prompt_path"
+              title="$(echo "$pr_json" | jq -r '.title // "(no title)"')"
+              body="$(echo "$pr_json" | jq -r '.body // "(no description)"')"
+              url="$(echo "$pr_json" | jq -r '.url // ""')"
+              api_files="$(
+                gh api "repos/${GITHUB_REPOSITORY}/pulls/${issue_number}/files?per_page=100" --paginate \
+                  --jq '.[] | "- \(.filename) (+\(.additions // 0)/-\(.deletions // 0))"' 2>/dev/null \
+                  | sed -n '1,40p' || true
+              )"
+              if [[ -n "$api_files" ]]; then
+                files_summary="$api_files"
+              fi
+
+              api_checks="$(
+                gh pr checks "$issue_number" --json name,state --jq '.[] | "- \(.name): \(.state)"' 2>/dev/null \
+                  | sed -n '1,40p' || true
+              )"
+              if [[ -n "$api_checks" ]]; then
+                checks_summary="$api_checks"
               fi
             fi
-
-            if [[ -z "$reason" ]]; then
-              if ZAI_RAW_RESPONSE_FILE="$raw_response_path" scripts/ci/zai_chat_completion.sh \
-                --prompt-file "$prompt_path" \
-                --output-file "$output_path" \
-                --system-prompt "You are the repository assistant. Reply in the same language as the user request. Keep it concise and concrete." \
-                --model "${GLM_MODEL:-glm-5}" \
-                --api-base "${GLM_API_BASE:-https://api.z.ai/api/coding/paas/v4}" \
-                --max-tokens 900 \
-                --temperature 0.3 \
-                --timeout-seconds 90 \
-                --retry-count 1; then
-                status="success"
-                reason="OK"
-              else
-                rc="$?"
-                reason="z.ai request failed (exit code ${rc})."
-              fi
+          elif [[ "$status" == "ready" ]]; then
+            issue_json="$(gh issue view "$issue_number" --json title,body,url 2>/dev/null || true)"
+            if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
+              status="degraded"
+              reason="Failed to fetch issue context via gh issue view."
+            else
+              title="$(echo "$issue_json" | jq -r '.title // "(no title)"')"
+              body="$(echo "$issue_json" | jq -r '.body // "(no description)"')"
+              url="$(echo "$issue_json" | jq -r '.url // ""')"
             fi
           fi
 
-          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          if [[ "$status" == "success" ]]; then
-            reply_body="$(cat "$output_path")"
-            status_line="✅ Completed (z.ai)"
+          if [[ "$status" == "ready" ]]; then
+            status_line="✅ Ready for AI IDE"
           else
-            reply_body="Assistant is currently unavailable in active mode. Fallback reason: ${reason}"
-            status_line="⚠️ Fallback"
+            status_line="⚠️ Degraded context (${reason})"
           fi
 
           {
+            echo "# AI IDE Assistant Handoff"
+            echo ""
+            echo "**Status**: ${status_line}"
+            echo "**Target**: ${target_kind^^} #${issue_number:-unknown}"
+            echo "**Requested by**: ${request_author}"
+            echo "**Prepared**: $(date -u +'%Y-%m-%d %H:%M UTC')"
+            echo ""
+            echo "## Workflow mode"
+            echo "- GitHub Actions no longer invokes any LLM for assistant replies."
+            echo "- This workflow only prepares deterministic context for manual work in AI IDE."
+            echo ""
+            echo "## Requested message"
+            echo "${request_text:-"(no request text)"}"
+            echo ""
+            echo "## Target details"
+            if [[ -n "$url" ]]; then
+              echo "- URL: ${url}"
+            fi
+            echo "- Title: ${title}"
+            echo ""
+            echo "## Description"
+            echo "${body}"
+            echo ""
+            if [[ "$target_kind" == "pr" ]]; then
+              echo "## Changed files"
+              echo "${files_summary}"
+              echo ""
+              echo "## Current CI checks"
+              echo "${checks_summary}"
+              echo ""
+            fi
+            echo "## AI IDE handoff"
+            echo "1. Open ${target_kind^^} #${issue_number:-unknown} in your AI IDE."
+            echo "2. Use this artifact and current CI status as the response baseline."
+            echo "3. Publish the final response manually from the IDE or as a human-authored GitHub comment."
+          } > "$report_path"
+
+          {
             echo "<!-- ${marker} -->"
-            echo "### Z.ai Assistant"
+            echo "### AI IDE Assistant Handoff"
             echo ""
-            echo "${reply_body}"
+            echo "**Status**: ${status_line}"
+            echo "**Target**: ${target_kind^^} #${issue_number:-unknown}"
+            echo "**Workflow mode**: Deterministic context only"
             echo ""
-            echo "---"
-            echo "Status: ${status_line}"
-            echo "Triggered by @${request_author} via \`${event_name}\`."
+            echo "GitHub Actions no longer runs any LLM for assistant replies."
+            echo "Continue the request manually in AI IDE."
+            echo ""
+            echo "Legacy `@claude` / `@zai` mentions now produce handoff context only."
+            echo ""
             echo "[View workflow run](${run_url})"
           } > "$comment_path"
 
           {
-            echo "## Interactive Assistant"
-            echo "- Event: ${event_name}"
-            echo "- Target: #${issue_number:-unknown}"
+            echo "## AI IDE Assistant Handoff"
+            echo "- Target: ${target_kind^^} #${issue_number:-unknown}"
             echo "- Status: ${status_line}"
-            echo "- Provider: ${provider:-zai}"
+            echo "- Requested by: ${request_author}"
+            echo "- Workflow mode: Deterministic context only"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "issue_number=${issue_number}" >> "$GITHUB_OUTPUT"
-          echo "status=${status}" >> "$GITHUB_OUTPUT"
-          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
-          echo "marker=${marker}" >> "$GITHUB_OUTPUT"
-          echo "comment_path=${comment_path}" >> "$GITHUB_OUTPUT"
+          {
+            echo "issue_number=${issue_number}"
+            echo "status=${status}"
+            echo "reason=${reason}"
+            echo "marker=${marker}"
+            echo "report_path=${report_path}"
+            echo "comment_path=${comment_path}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upsert sticky thread comment
-        if: steps.assistant.outputs.issue_number != ''
+        if: steps.handoff.outputs.issue_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if ! scripts/ci/upsert_sticky_comment.sh \
             --repo "${GITHUB_REPOSITORY}" \
-            --issue-number "${{ steps.assistant.outputs.issue_number }}" \
-            --marker "${{ steps.assistant.outputs.marker }}" \
-            --body-file "${{ steps.assistant.outputs.comment_path }}"; then
-            echo "::warning::Unable to publish/update sticky assistant comment."
+            --issue-number "${{ steps.handoff.outputs.issue_number }}" \
+            --marker "${{ steps.handoff.outputs.marker }}" \
+            --body-file "${{ steps.handoff.outputs.comment_path }}"; then
+            echo "::warning::Unable to publish/update sticky assistant handoff comment."
           fi
+
+      - name: Upload handoff artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-ide-assistant-thread-${{ steps.handoff.outputs.issue_number || 'unknown' }}
+          path: ${{ steps.handoff.outputs.report_path }}
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  actions: read
 
 jobs:
   ai-ide-assistant:
@@ -87,6 +86,9 @@ jobs:
         id: handoff
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_MESSAGE: ${{ inputs.message }}
+          INPUT_TARGET_KIND: ${{ inputs.target_kind }}
+          INPUT_TARGET_NUMBER: ${{ inputs.target_number }}
         run: |
           set -euo pipefail
 
@@ -107,10 +109,10 @@ jobs:
 
           case "$event_name" in
             workflow_dispatch)
-              issue_number="${{ inputs.target_number }}"
-              request_text="${{ inputs.message }}"
+              issue_number="${INPUT_TARGET_NUMBER}"
+              request_text="$(printf '%s' "${INPUT_MESSAGE}")"
               request_author="${GITHUB_ACTOR}"
-              target_kind="${{ inputs.target_kind }}"
+              target_kind="${INPUT_TARGET_KIND}"
               ;;
             issue_comment)
               issue_number="$(jq -r '.issue.number // empty' "$event_path")"
@@ -136,7 +138,7 @@ jobs:
               issue_number="$(jq -r '.issue.number // empty' "$event_path")"
               request_title="$(jq -r '.issue.title // ""' "$event_path")"
               request_body="$(jq -r '.issue.body // ""' "$event_path")"
-              request_text="${request_title}\n\n${request_body}"
+              request_text="$(printf '%s\n\n%s' "$request_title" "$request_body")"
               request_author="$(jq -r '.issue.user.login // "unknown"' "$event_path")"
               target_kind="issue"
               ;;
@@ -155,7 +157,7 @@ jobs:
           body="(unavailable)"
           url=""
           files_summary="- File list unavailable"
-          checks_summary="- CI checks unavailable"
+          checks_summary="- Check the PR Checks tab for the latest CI state."
 
           if [[ -z "$issue_number" ]]; then
             status="degraded"
@@ -180,13 +182,6 @@ jobs:
                 files_summary="$api_files"
               fi
 
-              api_checks="$(
-                gh pr checks "$issue_number" --json name,state --jq '.[] | "- \(.name): \(.state)"' 2>/dev/null \
-                  | sed -n '1,40p' || true
-              )"
-              if [[ -n "$api_checks" ]]; then
-                checks_summary="$api_checks"
-              fi
             fi
           elif [[ "$status" == "ready" ]]; then
             issue_json="$(gh issue view "$issue_number" --json title,body,url 2>/dev/null || true)"
@@ -255,7 +250,7 @@ jobs:
             echo "GitHub Actions no longer runs any LLM for assistant replies."
             echo "Continue the request manually in AI IDE."
             echo ""
-            echo "Legacy `@claude` / `@zai` mentions now produce handoff context only."
+            echo "Legacy @claude / @zai mentions now produce handoff context only."
             echo ""
             echo "[View workflow run](${run_url})"
           } > "$comment_path"
@@ -283,13 +278,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! scripts/ci/upsert_sticky_comment.sh \
+          scripts/ci/upsert_sticky_comment.sh \
             --repo "${GITHUB_REPOSITORY}" \
             --issue-number "${{ steps.handoff.outputs.issue_number }}" \
             --marker "${{ steps.handoff.outputs.marker }}" \
-            --body-file "${{ steps.handoff.outputs.comment_path }}"; then
-            echo "::warning::Unable to publish/update sticky assistant handoff comment."
-          fi
+            --body-file "${{ steps.handoff.outputs.comment_path }}"
 
       - name: Upload handoff artifact
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1319,15 +1319,70 @@ jobs:
             test -f "$RUNTIME_CONFIG_DIR/moltis.toml"
             echo "Runtime config OK: $RUNTIME_CONFIG_DIR"
 
-            # Test 7: Provider auth status evidence
-            echo "Test 7: Provider auth status..."
+            # Test 7: Runtime Moltis TOML syntax
+            echo "Test 7: Runtime Moltis TOML syntax..."
+            python3 - "$RUNTIME_CONFIG_DIR/moltis.toml" <<'PY'
+            import pathlib
+            import sys
+            import tomllib
+
+            config_path = pathlib.Path(sys.argv[1])
+            with config_path.open("rb") as handle:
+                tomllib.load(handle)
+
+            print(f"Runtime TOML OK: {config_path}")
+            PY
+
+            # Test 8: Runtime Ollama and failover contract
+            echo "Test 8: Runtime Ollama and failover contract..."
+            python3 - "$RUNTIME_CONFIG_DIR/moltis.toml" <<'PY'
+            import pathlib
+            import sys
+            import tomllib
+
+            config_path = pathlib.Path(sys.argv[1])
+            with config_path.open("rb") as handle:
+                config = tomllib.load(handle)
+
+            providers = config.get("providers", {})
+            ollama = providers.get("ollama")
+            if not isinstance(ollama, dict):
+                raise SystemExit("Missing [providers.ollama] in runtime config")
+            if not ollama.get("enabled", False):
+                raise SystemExit("Runtime config has [providers.ollama] but it is not enabled")
+            if not ollama.get("base_url"):
+                raise SystemExit("Runtime config is missing providers.ollama.base_url")
+
+            failover = config.get("failover")
+            if not isinstance(failover, dict):
+                raise SystemExit("Missing [failover] in runtime config")
+            if not failover.get("enabled", False):
+                raise SystemExit("Runtime config has failover disabled")
+            fallback_models = failover.get("fallback_models", [])
+            if not any(str(model).startswith("ollama::") for model in fallback_models):
+                raise SystemExit("Failover contract must include an ollama:: fallback model")
+
+            print("Runtime failover contract OK")
+            PY
+
+            # Test 9: Ollama fallback container status
+            echo "Test 9: Ollama fallback container status..."
+            OLLAMA_STATE=$(docker inspect --format '{{.State.Status}}' ollama-fallback 2>/dev/null || true)
+            if [ "$OLLAMA_STATE" != "running" ]; then
+              echo "::error::ollama-fallback container is not running (state: ${OLLAMA_STATE:-missing})"
+              exit 1
+            fi
+            echo "Ollama fallback container OK (state: $OLLAMA_STATE)"
+
+            # Test 10: Provider auth status evidence
+            echo "Test 10: Provider auth status..."
             AUTH_STATUS=$(docker exec moltis moltis auth status 2>&1 || true)
             echo "$AUTH_STATUS"
             if printf '%s' "$AUTH_STATUS" | grep -q 'No authenticated providers.'; then
               echo "::warning::No authenticated providers are currently loaded in live Moltis"
             fi
 
-            echo "All smoke tests passed!"
+            echo "All smoke and configuration validation checks passed!"
           EOF
           echo "::endgroup::"
 
@@ -1398,7 +1453,7 @@ jobs:
 
           echo "## Verification Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All smoke tests passed successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "All smoke and configuration validation checks passed successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Container Info" >> $GITHUB_STEP_SUMMARY
           echo "- **Image**: \`${{ steps.info.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1327,17 +1327,6 @@ jobs:
               echo "::warning::No authenticated providers are currently loaded in live Moltis"
             fi
 
-            # Test 8: Real OpenAI Codex chat canary
-            echo "Test 8: Real OpenAI Codex chat canary..."
-            MOLTIS_ACTIVE_ROOT="${{ env.DEPLOY_ACTIVE_PATH }}" \
-            MOLTIS_URL="http://localhost:13131" \
-            TEST_TIMEOUT="25" \
-            EXPECTED_PROVIDER="openai-codex" \
-            EXPECTED_MODEL="openai-codex::gpt-5.4" \
-            EXPECTED_REPLY_TEXT="OK" \
-            bash "${{ env.DEPLOY_ACTIVE_PATH }}/scripts/test-moltis-api.sh" \
-              "Reply with exactly OK and nothing else."
-
             echo "All smoke tests passed!"
           EOF
           echo "::endgroup::"
@@ -1376,95 +1365,13 @@ jobs:
           fi
           echo "::endgroup::"
 
-      # ===========================================
-      # LLM Failover Validation (T024-T026)
-      # ===========================================
-      - name: Validate TOML syntax
+      - name: Record AI IDE follow-up
         run: |
-          echo "::group::TOML syntax validation"
-          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << 'EOF'
-            set -e
-            cd ${{ env.DEPLOY_PATH }}
-
-            # Install Python TOML validator if not present
-            if ! python3 -c "import toml" 2>/dev/null; then
-              pip3 install toml 2>/dev/null || apt-get install -y python3-toml 2>/dev/null || true
-            fi
-
-            # Validate moltis.toml syntax
-            if python3 -c "import toml; toml.load('config/moltis.toml')" 2>/dev/null; then
-              echo "::notice::moltis.toml syntax is valid"
-            else
-              echo "::warning::TOML validation failed - checking with basic parser"
-              # Fallback: basic syntax check
-              if grep -E '^\s*\[.*\]\s*$' config/moltis.toml > /dev/null; then
-                echo "Basic TOML structure looks OK"
-              fi
-            fi
-          EOF
-          echo "::endgroup::"
-
-      - name: Validate Ollama configuration
-        run: |
-          echo "::group::Ollama configuration validation"
-          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << 'EOF'
-            set -e
-            cd ${{ env.DEPLOY_PATH }}
-
-            # Check if Ollama is configured in docker-compose.prod.yml
-            if grep -q 'ollama:' docker-compose.prod.yml; then
-              echo "Ollama service found in docker-compose.prod.yml"
-
-              # Check if Ollama container is running
-              if docker ps --filter "name=ollama" --filter "status=running" | grep -q ollama; then
-                echo "::notice::Ollama container is running"
-
-                # Check Ollama health
-                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:11434/api/tags 2>/dev/null || echo "000")
-                if [ "$HTTP_CODE" = "200" ]; then
-                  echo "::notice::Ollama API is responding (HTTP 200)"
-                else
-                  echo "::warning::Ollama API returned HTTP $HTTP_CODE (may be starting)"
-                fi
-              else
-                echo "::warning::Ollama container is not running (may be intentional)"
-              fi
-            else
-              echo "::notice::Ollama service not configured in docker-compose.prod.yml"
-            fi
-          EOF
-          echo "::endgroup::"
-
-      - name: Validate failover configuration
-        run: |
-          echo "::group::Failover configuration validation"
-          ssh ${{ env.SSH_USER }}@${{ env.SSH_HOST }} << 'EOF'
-            set -e
-            cd ${{ env.DEPLOY_PATH }}
-
-            # Check failover is enabled in moltis.toml
-            if grep -A5 '^\[failover\]' config/moltis.toml | grep -q 'enabled.*=.*true'; then
-              echo "::notice::Failover is enabled in moltis.toml"
-
-              # Check fallback models are configured
-              if grep -A10 '^\[failover\]' config/moltis.toml | grep -q 'fallback_models'; then
-                echo "::notice::Fallback models are configured"
-              else
-                echo "::warning::No fallback_models configured in failover section"
-              fi
-            else
-              echo "::notice::Failover is not enabled (optional feature)"
-            fi
-
-            # Check circuit breaker state file
-            if [ -f /tmp/moltis-llm-state.json ]; then
-              echo "::notice::Circuit breaker state file exists"
-              cat /tmp/moltis-llm-state.json | head -c 200
-            else
-              echo "::notice::Circuit breaker state file not found (will be created on first check)"
-            fi
-          EOF
-          echo "::endgroup::"
+          {
+            echo "## AI IDE follow-up"
+            echo "- Direct provider and LLM validation is disabled in GitHub Actions."
+            echo "- If AI behavior must be checked after deploy, perform that verification manually in AI IDE against the live environment."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Get deployment info
         id: info

--- a/scripts/ci/upsert_sticky_comment.sh
+++ b/scripts/ci/upsert_sticky_comment.sh
@@ -87,8 +87,8 @@ trap cleanup EXIT
 jq -n --rawfile body "$BODY_FILE" '{body: $body}' > "$body_json"
 
 existing_id="$(
-    gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments?per_page=100" --paginate \
-        --jq ".[] | select((.body // \"\") | contains(\"$MARKER\")) | .id" 2>/dev/null \
+    gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments?per_page=100" --paginate 2>/dev/null \
+        | jq -r --arg marker "$MARKER" '.[] | select((.body // "") | contains($marker)) | .id' \
         | tail -n 1 || true
 )"
 

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -261,20 +261,24 @@ test_deploy_script_verifies_live_moltis_runtime_contract() {
     test_pass
 }
 
-test_deploy_workflow_runs_real_openai_codex_chat_canary() {
-    test_start "Deploy workflow should run a real OpenAI Codex chat canary after rollout"
+test_deploy_workflow_runs_non_llm_runtime_validation() {
+    test_start "Deploy workflow should validate runtime config without calling an LLM"
 
     if [[ ! -f "$DEPLOY_WORKFLOW" ]]; then
         test_skip "Missing workflow file: $DEPLOY_WORKFLOW"
         return
     fi
 
-    if ! grep -Fq 'Test 8: Real OpenAI Codex chat canary' "$DEPLOY_WORKFLOW" || \
-       ! grep -Fq 'scripts/test-moltis-api.sh' "$DEPLOY_WORKFLOW" || \
-       ! grep -Fq 'EXPECTED_PROVIDER="openai-codex"' "$DEPLOY_WORKFLOW" || \
-       ! grep -Fq 'EXPECTED_MODEL="openai-codex::gpt-5.4"' "$DEPLOY_WORKFLOW" || \
-       ! grep -Fq 'EXPECTED_REPLY_TEXT="OK"' "$DEPLOY_WORKFLOW"; then
-        test_fail "deploy.yml must prove the live OpenAI Codex chat path with scripts/test-moltis-api.sh against openai-codex::gpt-5.4"
+    if ! grep -Fq 'Test 7: Runtime Moltis TOML syntax' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'Test 8: Runtime Ollama and failover contract' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'Test 9: Ollama fallback container status' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'tomllib.load(handle)' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'ollama-fallback container is not running' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq 'Direct provider and LLM validation is disabled in GitHub Actions.' "$DEPLOY_WORKFLOW" || \
+       grep -Fq 'scripts/test-moltis-api.sh' "$DEPLOY_WORKFLOW" || \
+       grep -Fq 'EXPECTED_PROVIDER="openai-codex"' "$DEPLOY_WORKFLOW" || \
+       grep -Fq 'EXPECTED_MODEL="openai-codex::gpt-5.4"' "$DEPLOY_WORKFLOW"; then
+        test_fail "deploy.yml must validate runtime TOML, Ollama, and failover contracts without calling a live LLM from GitHub Actions"
         return
     fi
 
@@ -1790,7 +1794,7 @@ run_all_tests() {
     test_moltis_env_workflows_use_shared_render_script
     test_tracked_deploy_workflows_use_shared_script_entrypoint
     test_deploy_script_verifies_live_moltis_runtime_contract
-    test_deploy_workflow_runs_real_openai_codex_chat_canary
+    test_deploy_workflow_runs_non_llm_runtime_validation
     test_deploy_script_exports_live_docker_socket_gid_for_browser_sandbox
     test_deploy_script_prepares_tracked_browser_sandbox_image
     test_deploy_script_force_recreates_moltis_runtime_on_rollout


### PR DESCRIPTION
## Summary
- replace active review and assistant workflows with deterministic AI IDE handoff flows
- remove direct LLM execution from deployment workflow validation
- keep GitHub Actions focused on context collection and standard deploy checks

## Validation
- parsed updated workflow YAML with Python
- re-scanned workflows for direct Claude/OpenAI execution paths