### PR TITLE
ci: fix deploy runtime validation shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1321,49 +1321,13 @@ jobs:
 
             # Test 7: Runtime Moltis TOML syntax
             echo "Test 7: Runtime Moltis TOML syntax..."
-            python3 - "$RUNTIME_CONFIG_DIR/moltis.toml" <<'PY'
-            import pathlib
-            import sys
-            import tomllib
-
-            config_path = pathlib.Path(sys.argv[1])
-            with config_path.open("rb") as handle:
-                tomllib.load(handle)
-
-            print(f"Runtime TOML OK: {config_path}")
-            PY
+            python3 -c 'import pathlib, sys, tomllib; config_path = pathlib.Path(sys.argv[1]); tomllib.load(config_path.open("rb")); print(f"Runtime TOML OK: {config_path}")' \
+              "$RUNTIME_CONFIG_DIR/moltis.toml"
 
             # Test 8: Runtime Ollama and failover contract
             echo "Test 8: Runtime Ollama and failover contract..."
-            python3 - "$RUNTIME_CONFIG_DIR/moltis.toml" <<'PY'
-            import pathlib
-            import sys
-            import tomllib
-
-            config_path = pathlib.Path(sys.argv[1])
-            with config_path.open("rb") as handle:
-                config = tomllib.load(handle)
-
-            providers = config.get("providers", {})
-            ollama = providers.get("ollama")
-            if not isinstance(ollama, dict):
-                raise SystemExit("Missing [providers.ollama] in runtime config")
-            if not ollama.get("enabled", False):
-                raise SystemExit("Runtime config has [providers.ollama] but it is not enabled")
-            if not ollama.get("base_url"):
-                raise SystemExit("Runtime config is missing providers.ollama.base_url")
-
-            failover = config.get("failover")
-            if not isinstance(failover, dict):
-                raise SystemExit("Missing [failover] in runtime config")
-            if not failover.get("enabled", False):
-                raise SystemExit("Runtime config has failover disabled")
-            fallback_models = failover.get("fallback_models", [])
-            if not any(str(model).startswith("ollama::") for model in fallback_models):
-                raise SystemExit("Failover contract must include an ollama:: fallback model")
-
-            print("Runtime failover contract OK")
-            PY
+            python3 -c 'import pathlib, sys, tomllib; config = tomllib.load(pathlib.Path(sys.argv[1]).open("rb")); providers = config.get("providers", {}); ollama = providers.get("ollama"); failover = config.get("failover"); fallback_models = failover.get("fallback_models", []) if isinstance(failover, dict) else []; checks = [(isinstance(ollama, dict), "Missing [providers.ollama] in runtime config"), (isinstance(ollama, dict) and ollama.get("enabled", False), "Runtime config has [providers.ollama] but it is not enabled"), (isinstance(ollama, dict) and bool(ollama.get("base_url")), "Runtime config is missing providers.ollama.base_url"), (isinstance(failover, dict), "Missing [failover] in runtime config"), (isinstance(failover, dict) and failover.get("enabled", False), "Runtime config has failover disabled"), (any(str(model).startswith("ollama::") for model in fallback_models), "Failover contract must include an ollama:: fallback model")]; failed = next((message for ok, message in checks if not ok), None); print("Runtime failover contract OK") if failed is None else sys.exit(failed)' \
+              "$RUNTIME_CONFIG_DIR/moltis.toml"
 
             # Test 9: Ollama fallback container status
             echo "Test 9: Ollama fallback container status..."

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -272,7 +272,7 @@ test_deploy_workflow_runs_non_llm_runtime_validation() {
     if ! grep -Fq 'Test 7: Runtime Moltis TOML syntax' "$DEPLOY_WORKFLOW" || \
        ! grep -Fq 'Test 8: Runtime Ollama and failover contract' "$DEPLOY_WORKFLOW" || \
        ! grep -Fq 'Test 9: Ollama fallback container status' "$DEPLOY_WORKFLOW" || \
-       ! grep -Fq 'tomllib.load(handle)' "$DEPLOY_WORKFLOW" || \
+       ! grep -Fq "python3 -c 'import pathlib, sys, tomllib;" "$DEPLOY_WORKFLOW" || \
        ! grep -Fq 'ollama-fallback container is not running' "$DEPLOY_WORKFLOW" || \
        ! grep -Fq 'Direct provider and LLM validation is disabled in GitHub Actions.' "$DEPLOY_WORKFLOW" || \
        grep -Fq 'scripts/test-moltis-api.sh' "$DEPLOY_WORKFLOW" || \


### PR DESCRIPTION
## Summary
- replace nested Python heredocs in post-deploy validation with shell-safe inline checks
- keep deploy verification non-LLM and remote-shell compatible
- align deploy guard expectations with the shell-safe validation form

## Verification
- bash tests/unit/test_deploy_workflow_guards.sh
