### PR TITLE
fix: remove Z.ai path and harden malformed tool fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -957,6 +957,7 @@ jobs:
       - name: Generate .env from Secrets
         env:
           MOLTIS_PASSWORD: ${{ secrets.MOLTIS_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}

--- a/.github/workflows/uat-gate.yml
+++ b/.github/workflows/uat-gate.yml
@@ -349,6 +349,7 @@ jobs:
       - name: Generate .env from Secrets
         env:
           MOLTIS_PASSWORD: ${{ secrets.MOLTIS_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}

--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -317,7 +317,7 @@ receivers:
           *Description:* {{ .Annotations.description }}
 
           *Immediate Actions:*
-          1. Check GLM (Z.ai) API status
+          1. Check official GLM (BigModel) API status
           2. Check Ollama container: `docker logs ollama-fallback`
           3. Verify OLLAMA_API_KEY is valid
           4. Check network connectivity

--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -216,7 +216,8 @@ timezone = "Europe/Moscow"
 offered = [
     "openai-codex",  # Primary: ChatGPT subscription OAuth
     "ollama",        # Fallback 1: Ollama cloud Gemini
-    "openai",        # Fallback 2: GLM-5 via Z.ai Coding Plan
+    "anthropic",     # Fallback 2: Claude Sonnet
+    "openai",        # Fallback 3: GLM-5.1 via official BigModel Coding Plan
 ] # Providers shown in onboarding/picker UI ([] = show all)
 # All available providers:
 #   "anthropic", "openai", "gemini", "groq", "xai", "deepseek",
@@ -226,7 +227,7 @@ offered = [
 
 # ── Anthropic (Claude) ────────────────────────────────────────
 [providers.anthropic]
-enabled = false                     # Set to true and add API key to enable
+enabled = true                      # Enabled as fallback; requires ANTHROPIC_API_KEY in runtime env
 api_key = "${ANTHROPIC_API_KEY}"    # Or set ANTHROPIC_API_KEY env var
 model = "claude-sonnet-4-20250514"  # Default model
 base_url = "https://api.anthropic.com"
@@ -240,30 +241,16 @@ alias = "openai-codex"
 models = ["gpt-5.4"]
 tool_mode = "auto"
 
-# ── OpenAI / GLM-5 via Z.ai Coding Plan ───────────────────────────────────────
-# Using Z.ai Coding Plan (Pro subscription) through OpenAI-compatible API
-# Docs: https://docs.z.ai/api-reference/introduction
-# Coding Plan endpoint: https://api.z.ai/api/coding/paas/v4
+# ── OpenAI-compatible GLM-5.1 via BigModel Coding Plan ────────────────────────
+# Official BigModel Coding Plan OpenAI-compatible endpoint:
+# https://docs.bigmodel.cn/cn/coding-plan/tool/opencode
 [providers.openai]
 enabled = true
-api_key = "${GLM_API_KEY}"                          # Use GLM_API_KEY from .env
-model = "glm-5"                                     # Default model
-base_url = "https://api.z.ai/api/coding/paas/v4"    # Coding Plan endpoint
-alias = "zai"
-models = ["glm-5"]                                  # Keep GLM-5 as third step in chain
-
-# ── Telegram-safe Z.ai lane ───────────────────────────────────────────────────
-# Keep the user-facing Telegram bot on a guarded provider surface. Dedicated
-# skill tools stay available for Telegram skill-authoring turns, while the
-# repo-managed hook blocks browser/search/filesystem drift and telemetry leaks.
-[providers.custom-zai-telegram-safe]
-enabled = true
-api_key = "${GLM_API_KEY}"
-model = "glm-5"
-base_url = "https://api.z.ai/api/coding/paas/v4"
-alias = "zai-telegram-safe"
-models = ["glm-5"]
-tool_mode = "auto"
+api_key = "${GLM_API_KEY}"                               # Official BigModel API key
+model = "glm-5.1"                                       # Default fallback model
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+alias = "glm"
+models = ["glm-5.1"]
 
 # ── GLM (Zhipu AI) - DISABLED (invalid provider name) ────────────────────────
 # This section is NOT a valid Moltis provider! Use [providers.openai] instead.
@@ -326,16 +313,18 @@ message_queue_mode = "followup"   # How to handle messages during an active agen
                                   #   "collect"  - Buffer messages, concatenate as single message
 # priority_models = ["claude-opus-4-5", "gpt-5.4", "gemini-3-flash"]  # Optional: models to pin first in selectors
 # allowed_models = ["opus", "gpt 5.4", "gemini-3"]  # Optional: only show models matching these patterns (local-llm/ollama are always included)
-# Preferred chain: GPT-5.4 (OAuth) -> Ollama Gemini 3 Flash Preview -> GLM-5
+# Preferred chain: GPT-5.4 (OAuth) -> Ollama Gemini 3 Flash Preview -> Claude -> GLM-5.1
 allowed_models = [
-    "openai-codex::gpt-5.4",                 # Primary
-    "ollama::gemini-3-flash-preview:cloud",  # Fallback 1
-    "zai::glm-5"                             # Fallback 2
+    "openai-codex::gpt-5.4",                    # Primary
+    "ollama::gemini-3-flash-preview:cloud",     # Fallback 1
+    "anthropic::claude-sonnet-4-20250514",      # Fallback 2
+    "glm::glm-5.1"                              # Fallback 3
 ]
 priority_models = [
     "openai-codex::gpt-5.4",
     "ollama::gemini-3-flash-preview:cloud",
-    "zai::glm-5",
+    "anthropic::claude-sonnet-4-20250514",
+    "glm::glm-5.1",
 ]
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -656,12 +645,13 @@ timezone = "local"                # Timezone: "local" or IANA name like "Europe/
 
 [failover]
 enabled = true                    # Enable automatic failover
-# Fallback chain: GPT-5.4 → Ollama Gemini → GLM-5
+# Fallback chain: GPT-5.4 → Ollama Gemini → Claude → GLM-5.1
 fallback_models = [
     "ollama::gemini-3-flash-preview:cloud",  # Primary fallback: Ollama sidecar
-    "zai::glm-5"                             # Secondary fallback: GLM-5 via Z.ai
+    "anthropic::claude-sonnet-4-20250514",   # Secondary fallback: Claude
+    "glm::glm-5.1"                           # Final fallback: official BigModel GLM-5.1
 ]
-# Chain: gpt-5.4 → ollama-gemini → glm-5
+# Chain: gpt-5.4 → ollama-gemini → claude-sonnet-4 → glm-5.1
 
 # ══════════════════════════════════════════════════════════════════════════════
 # VOICE

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -69,7 +69,7 @@ services:
       TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-}
       # Tavily API for MCP server
       TAVILY_API_KEY: ${TAVILY_API_KEY}
-      # GLM-5 API key for Z.ai Coding Plan (OpenAI-compatible)
+      # GLM-5.1 API key for official BigModel Coding Plan (OpenAI-compatible)
       GLM_API_KEY: ${GLM_API_KEY}
       # Ollama Cloud API key for cloud-backed fallback chat models
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       TELEGRAM_ALLOWED_USERS: ${TELEGRAM_ALLOWED_USERS:-}
       # Tavily API for MCP server
       TAVILY_API_KEY_FILE: /run/secrets/tavily_api_key
-      # GLM-5 API key for Z.ai Coding Plan (OpenAI-compatible)
+      # GLM-5.1 API key for official BigModel Coding Plan (OpenAI-compatible)
       GLM_API_KEY_FILE: /run/secrets/glm_api_key
 
     # Docker secrets for secure credential management

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -303,7 +303,8 @@ docker logs moltis --tail 100
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `MOLTIS_PASSWORD` | Yes | Authentication password |
-| `GLM_API_KEY` | Yes | GLM-5 last-fallback API key |
+| `ANTHROPIC_API_KEY` | No | Claude fallback API key |
+| `GLM_API_KEY` | Yes | Official BigModel GLM-5.1 last-fallback API key |
 | `OLLAMA_API_KEY` | No | Ollama Cloud key for `gemini-3-flash-preview:cloud` fallback |
 | `MOLTIS_DOMAIN` | No | Domain for Traefik |
 | `MOLTIS_RUNTIME_CONFIG_DIR` | No | Writable live Moltis config path on server (default `/opt/moltinger-state/config-runtime`) |

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -139,7 +139,8 @@ make logs LOGS_OPTS=-f
 | TELEGRAM_BOT_TOKEN | ✅ | Bot token |
 | TELEGRAM_ALLOWED_USERS | ✅ | Allowed user IDs |
 | OLLAMA_API_KEY | ✅/optional | Ollama Cloud first fallback |
-| GLM_API_KEY | ✅ | GLM-5 last fallback + interactive assistant workflow |
+| ANTHROPIC_API_KEY | ✅/optional | Claude fallback |
+| GLM_API_KEY | ✅ | Official BigModel GLM-5.1 last fallback + interactive assistant workflow |
 | SSH_PRIVATE_KEY | ✅ | Deploy |
 
 Runtime-only auth state:
@@ -150,7 +151,7 @@ Runtime-only auth state:
 - re-auth only on expiry, revocation, corruption, or explicit rotation
 
 Workflow variable:
-- `AI_REVIEW_PROVIDER` (`zai` by default, `off` to disable the interactive assistant AI path)
+- Legacy compatibility kill-switch: `AI_REVIEW_PROVIDER=off`
 - PR review in GitHub Actions is deterministic-only; final review is completed manually in AI IDE
 
 ---

--- a/docs/SECRETS-MANAGEMENT.md
+++ b/docs/SECRETS-MANAGEMENT.md
@@ -21,6 +21,7 @@
 │                   GitHub Repository                      │
 │  ┌───────────────────────────────────────────────────┐  │
 │  │              GitHub Secrets                        │  │
+│  │  • ANTHROPIC_API_KEY                              │  │
 │  │  • GLM_API_KEY                                    │  │
 │  │  • BRAVE_API_KEY                                  │  │
 │  │  • ELEVENLABS_API_KEY                             │  │
@@ -59,6 +60,7 @@ gh secret set SECRET_NAME --repo owner/repo
 
 # Use in GitHub Actions
 env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
 ```
 
@@ -68,8 +70,8 @@ env:
 # .github/workflows/deploy.yml
 - name: Create .env file
   run: |
-    echo "GLM_API_KEY=${{ secrets.GLM_API_KEY }}" > .env
-    echo "BRAVE_API_KEY=${{ secrets.BRAVE_API_KEY }}" >> .env
+    echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" > .env
+    echo "GLM_API_KEY=${{ secrets.GLM_API_KEY }}" >> .env
     scp .env $SSH_USER@$SSH_HOST:$DEPLOY_PATH/.env
 ```
 
@@ -126,6 +128,7 @@ gh workflow run deploy.yml
 
 | Secret | Purpose | Where Used |
 |--------|---------|------------|
+| `ANTHROPIC_API_KEY` | Claude fallback | Moltis config + runtime fallback chain |
 | `GLM_API_KEY` | GLM/Zhipu AI LLM (Last fallback) | Moltis config + interactive assistant workflow |
 | `OLLAMA_API_KEY` | Ollama Cloud first fallback | Docker secrets |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot auth | Moltis config |
@@ -160,10 +163,11 @@ Rules:
 
 ### AI Workflow Secrets
 
-- `.github/workflows/claude.yml` uses `GLM_API_KEY` for Z.ai Coding Plan requests in the interactive assistant path.
+- Interactive assistant and deploy surfaces use `GLM_API_KEY` only against the official BigModel Coding Plan endpoint (`open.bigmodel.cn`), not Z.ai.
 - `.github/workflows/claude-code-review.yml` no longer invokes an AI provider in GitHub Actions; it prepares a deterministic handoff for manual review in AI IDE.
-- `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are not required for current CI workflows.
-- Optional kill-switch: repository variable `AI_REVIEW_PROVIDER=off` disables the interactive assistant AI calls while keeping fallback behavior non-blocking.
+- `CLAUDE_CODE_OAUTH_TOKEN` is not required for current CI workflows.
+- `ANTHROPIC_API_KEY` is required when the Claude fallback lane must be active in runtime/deploy paths.
+- Legacy compatibility kill-switch: repository variable `AI_REVIEW_PROVIDER=off` may stay set, but the current review workflow is already deterministic-only and does not invoke an AI provider in GitHub Actions.
 - Rollback artifacts for legacy Anthropic workflows are stored in:
   - `.github/workflows/claude.legacy.yml.disabled`
   - `.github/workflows/claude-code-review.legacy.yml.disabled`
@@ -190,15 +194,25 @@ The Ollama fallback system requires the following secret:
 gh secret set OLLAMA_API_KEY --repo RussianLioN/moltinger
 ```
 
+### Claude Fallback Secret
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `ANTHROPIC_API_KEY` | Optional but recommended | Claude Sonnet fallback lane |
+
+**When ANTHROPIC_API_KEY is needed:**
+- When Claude must participate in the tracked fallback chain
+- When deploy/runtime should expose `anthropic::claude-sonnet-4-20250514`
+
 ### GLM Last-Fallback Secret
 
 | Secret | Required | Purpose |
 |--------|----------|---------|
-| `GLM_API_KEY` | Required for full three-step chain | Final fallback to `glm-5` via Z.ai |
+| `GLM_API_KEY` | Required for full fallback chain | Final fallback to `glm-5.1` via official BigModel |
 
 **When GLM_API_KEY is needed:**
-- When both GPT-5.4 and Ollama `gemini-3-flash-preview:cloud` are unavailable
-- For AI workflow jobs that still use Z.ai Coding Plan outside the Moltis primary runtime path
+- When Codex, Ollama, and Claude are unavailable
+- For AI workflow jobs that still use the official BigModel Coding Plan path outside the Moltis primary runtime path
 
 ### Runtime Config Persistence
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -111,7 +111,7 @@ An incident is not closed until all of the following are true:
 ### Failover Chain
 
 ```text
-OpenAI Codex (`gpt-5.4`) -> Ollama Gemini -> GLM-5 (Z.ai)
+OpenAI Codex (`gpt-5.4`) -> Ollama Gemini -> Claude Sonnet -> GLM-5.1 (official BigModel)
 ```
 
 ### Circuit States

--- a/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
+++ b/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
@@ -407,7 +407,7 @@ Fix:
 - use writable runtime config mounted at `/home/moltis/.config/moltis`
 - prepare it from static `./config` before restart
 
-### Symptom: Moltis UI still shows `glm-5` after a successful GPT-5.4 rollout
+### Symptom: Moltis UI still shows `glm-5.1` after a successful GPT-5.4 rollout
 
 Likely cause:
 

--- a/docs/rca/2026-04-17-zai-removal-left-non-telegram-tool-guard-and-live-config-drift.md
+++ b/docs/rca/2026-04-17-zai-removal-left-non-telegram-tool-guard-and-live-config-drift.md
@@ -1,0 +1,88 @@
+# RCA: Z.ai Removal Left Non-Telegram Tool Guard Gap And Live Config Drift
+
+**Date**: 2026-04-17
+**Severity**: P1
+**Category**: telegram, ui, configuration, deploy
+**Status**: fixed in code, deploy pending merge
+
+## Incident
+
+Two user-visible symptoms were reported at the same time:
+
+1. Web UI showed raw tool-error cards such as `missing 'query' parameter` and `missing 'command' parameter`.
+2. Telegram bot still reported `model 'zai::glm-5-turbo' not found. available: []`.
+
+## Lessons Pre-Check
+
+Reviewed relevant prior lessons before changing code:
+
+- `docs/rca/2026-03-20-telegram-uat-false-pass-on-model-not-found.md`
+- `docs/rca/2026-04-02-telegram-skill-detail-fell-back-to-tool-error-leak.md`
+- `docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md`
+- `docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md`
+
+Those incidents already established two important patterns:
+
+- Telegram and UI-safe lanes must fail closed before raw tool/runtime errors become user-visible.
+- Provider-chain migrations are not complete until the live tracked runtime config is reconciled, not just repo-local code.
+
+## 5 Whys
+
+### Symptom A: Web UI leaked raw tool cards
+
+1. Why did the UI show raw tool cards?
+   Because malformed tool calls like `memory_search` without `query` and `exec` without `command` reached user-visible execution paths.
+2. Why did malformed tool calls reach execution paths?
+   Because `scripts/telegram-safe-llm-guard.sh` only had strict fail-closed suppression for Telegram-safe paths and generic telemetry/planning cases, not an explicit non-Telegram malformed-known-tool branch.
+3. Why was there no explicit malformed-known-tool branch outside Telegram?
+   Because earlier hardening work focused on Telegram-safe regressions and did not promote “missing required arguments” into a shared contract for all user-facing lanes.
+4. Why was that shared contract missing?
+   Because the owning hook evolved by incident-specific patches instead of one unified malformed-tool taxonomy.
+5. Why did incident-specific patches accumulate?
+   Because the migration effort treated raw tool leakage as a Telegram-only problem instead of a general user-surface problem.
+
+### Symptom B: Telegram still referenced `zai::glm-5-turbo`
+
+1. Why did Telegram still reference `zai::glm-5-turbo`?
+   Because the live tracked runtime config still advertised `alias = "zai"`, `custom-zai-telegram-safe`, and fallback lists containing `zai::glm-5`.
+2. Why was the live tracked runtime config still old?
+   Because the provider-removal work had been implemented in the branch but not yet deployed into the running `/server/config/moltis.toml`.
+3. Why was deploy drift able to persist?
+   Because code-level migration and live-config reconciliation were not validated together as one acceptance boundary.
+4. Why was acceptance split across boundaries?
+   Because source-of-truth updates, runtime normalization, and live deploy verification were tracked as loosely coupled changes instead of one provider-governance contract.
+5. Why was provider-governance incomplete?
+   Because Z.ai removal was initially approached as config editing rather than a full “repo source + runtime normalization + live tracked config” migration.
+
+## Root Cause
+
+The same migration class was left incomplete in two different owning layers:
+
+- `scripts/telegram-safe-llm-guard.sh` lacked a fail-closed branch for malformed known-tool calls outside Telegram-safe mode.
+- Live tracked Moltis config on the server still carried legacy Z.ai aliases and fallback entries because deploy reconciliation had not yet happened.
+
+## Fix
+
+1. Added malformed-known-tool detection and fail-closed handling in `scripts/telegram-safe-llm-guard.sh` for non-Telegram user-visible lanes.
+2. Added regression coverage for:
+   - non-Telegram `AfterLLMCall` malformed tool-call suppression
+   - non-Telegram `BeforeToolCall` malformed known-tool rewrite to no-op
+3. Removed remaining active-spec drift still describing Z.ai in deployment research/tasks artifacts.
+4. Kept runtime/provider normalization and attestation aligned to the official BigModel `glm::glm-5.1` fallback contract.
+
+## Validation
+
+Validation is complete when all of the following hold:
+
+- component tests pass for `telegram-safe-llm-guard`
+- repo source-of-truth contains no active `api.z.ai` or `zai::` references outside intentional compatibility/history paths
+- live `/server/config/moltis.toml` no longer contains `alias = "zai"`, `custom-zai-telegram-safe`, or `zai::glm-*`
+
+## Preventive Actions
+
+1. Treat provider removal as a three-layer migration:
+   - repo source config
+   - runtime normalization / attestation
+   - live tracked deploy config
+2. Treat malformed tool calls as a shared user-surface contract, not a Telegram-only safety concern.
+3. Keep authoritative probes and deploy verification coupled whenever provider aliases or fallback chains change.

--- a/docs/telegram-e2e-on-demand.md
+++ b/docs/telegram-e2e-on-demand.md
@@ -144,7 +144,7 @@ Authoritative `Telegram Web` probe больше не принимает перв
 - ранняя промежуточная реплика вроде `Проверяю снова...` больше не считается достаточным pass;
 - если следом приходит `Timed out: Agent run timed out after <N>s`, authoritative verdict должен стать `failed`, а не `passed`.
 - если сообщение `/status` не показывает текущую pinned Telegram-safe модель
-  `custom-zai-telegram-safe::glm-5`, verdict тоже должен стать `failed`.
+  `openai-codex::gpt-5.4`, verdict тоже должен стать `failed`.
 
 ## Failure Codes
 

--- a/scripts/ci/glm_chat_completion.sh
+++ b/scripts/ci/glm_chat_completion.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Shared Z.ai (GLM) chat completion helper for GitHub Actions workflows.
+# Shared GLM (official BigModel) chat completion helper for GitHub Actions workflows.
 
 set -euo pipefail
 
 usage() {
     cat <<'USAGE'
 Usage:
-  zai_chat_completion.sh \
+  glm_chat_completion.sh \
     --prompt-file <path> \
     --output-file <path> \
     [--system-prompt <text>] \
@@ -18,15 +18,15 @@ Usage:
     [--retry-count <int>]
 
 Environment:
-  GLM_API_KEY               Required API key for https://api.z.ai
-  GLM_MODEL                 Default: glm-5
-  GLM_API_BASE              Default: https://api.z.ai/api/coding/paas/v4
+  GLM_API_KEY               Required API key for official BigModel Coding Plan
+  GLM_MODEL                 Default: glm-5.1
+  GLM_API_BASE              Default: https://open.bigmodel.cn/api/coding/paas/v4
   GLM_MAX_TOKENS            Default: 1800
   GLM_TEMPERATURE           Default: 0.2
   GLM_TIMEOUT_SECONDS       Default: 90
   GLM_RETRY_COUNT           Default: 1
   GLM_SYSTEM_PROMPT         Optional fallback system prompt
-  ZAI_RAW_RESPONSE_FILE     Optional file path to persist raw JSON response
+  GLM_RAW_RESPONSE_FILE     Optional file path to persist raw JSON response
 USAGE
 }
 
@@ -41,8 +41,8 @@ require_command() {
 PROMPT_FILE=""
 OUTPUT_FILE=""
 SYSTEM_PROMPT="${GLM_SYSTEM_PROMPT:-You are a precise software engineering assistant. Return valid Markdown only.}"
-MODEL="${GLM_MODEL:-glm-5}"
-API_BASE="${GLM_API_BASE:-https://api.z.ai/api/coding/paas/v4}"
+MODEL="${GLM_MODEL:-glm-5.1}"
+API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
 MAX_TOKENS="${GLM_MAX_TOKENS:-1800}"
 TEMPERATURE="${GLM_TEMPERATURE:-0.2}"
 TIMEOUT_SECONDS="${GLM_TIMEOUT_SECONDS:-90}"
@@ -110,7 +110,7 @@ if [[ ! -f "$PROMPT_FILE" ]]; then
 fi
 
 if [[ -z "${GLM_API_KEY:-}" ]]; then
-    echo "ERROR: GLM_API_KEY is required for Z.ai requests." >&2
+    echo "ERROR: GLM_API_KEY is required for official BigModel GLM requests." >&2
     exit 3
 fi
 
@@ -154,10 +154,10 @@ http_code="$(curl -sS \
 
 if [[ "$http_code" != "200" ]]; then
     error_message="$(jq -r '.error.message // .message // "Unknown API error"' "$response_file" 2>/dev/null || true)"
-    if [[ -n "${ZAI_RAW_RESPONSE_FILE:-}" ]]; then
-        cp "$response_file" "$ZAI_RAW_RESPONSE_FILE" || true
+    if [[ -n "${GLM_RAW_RESPONSE_FILE:-}" ]]; then
+        cp "$response_file" "$GLM_RAW_RESPONSE_FILE" || true
     fi
-    echo "ERROR: Z.ai request failed (HTTP ${http_code}): ${error_message}" >&2
+    echo "ERROR: GLM request failed (HTTP ${http_code}): ${error_message}" >&2
     exit 5
 fi
 
@@ -172,15 +172,15 @@ content="$(jq -r '
 ' "$response_file" 2>/dev/null || true)"
 
 if [[ -z "$content" ]]; then
-    if [[ -n "${ZAI_RAW_RESPONSE_FILE:-}" ]]; then
-        cp "$response_file" "$ZAI_RAW_RESPONSE_FILE" || true
+    if [[ -n "${GLM_RAW_RESPONSE_FILE:-}" ]]; then
+        cp "$response_file" "$GLM_RAW_RESPONSE_FILE" || true
     fi
-    echo "ERROR: Z.ai response did not contain choices[0].message.content" >&2
+    echo "ERROR: GLM response did not contain choices[0].message.content" >&2
     exit 6
 fi
 
 printf '%s\n' "$content" > "$OUTPUT_FILE"
 
-if [[ -n "${ZAI_RAW_RESPONSE_FILE:-}" ]]; then
-    cp "$response_file" "$ZAI_RAW_RESPONSE_FILE" || true
+if [[ -n "${GLM_RAW_RESPONSE_FILE:-}" ]]; then
+    cp "$response_file" "$GLM_RAW_RESPONSE_FILE" || true
 fi

--- a/scripts/glm-rate-monitor.sh
+++ b/scripts/glm-rate-monitor.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # ==============================================================================
-# Z.AI Rate Limit Monitor
+# GLM Rate Limit Monitor
 # ==============================================================================
-# Мониторинг rate limits для Z.ai Coding Plan API
+# Мониторинг rate limits для официального BigModel Coding Plan API
 # Использование:
-#   ./scripts/zai-rate-monitor.sh           # Однократная проверка
-#   ./scripts/zai-rate-monitor.sh --watch   # Постоянный мониторинг
-#   ./scripts/zai-rate-monitor.sh --json    # JSON вывод для CI/CD
+#   ./scripts/glm-rate-monitor.sh           # Однократная проверка
+#   ./scripts/glm-rate-monitor.sh --watch   # Постоянный мониторинг
+#   ./scripts/glm-rate-monitor.sh --json    # JSON вывод для CI/CD
 #
 # Требования:
 #   - GLM_API_KEY в переменных окружения или ~/.config/moltis/.env
@@ -15,9 +15,9 @@
 set -euo pipefail
 
 # Конфигурация
-API_BASE="https://api.z.ai/api/coding/paas/v4"
-MODEL="glm-5"
-CACHE_FILE="/tmp/zai-rate-limit-cache.json"
+API_BASE="https://open.bigmodel.cn/api/coding/paas/v4"
+MODEL="glm-5.1"
+CACHE_FILE="/tmp/glm-rate-limit-cache.json"
 CACHE_TTL=30  # секунд
 
 # Цвета
@@ -167,7 +167,7 @@ print_human() {
     local status=$(echo "$data" | grep "^status:" | cut -d: -f2-)
 
     echo -e "${CYAN}═══════════════════════════════════════════════════════════${NC}"
-    echo -e "${CYAN}  Z.AI Rate Limit Monitor${NC}"
+    echo -e "${CYAN}  GLM Rate Limit Monitor${NC}"
     echo -e "${CYAN}═══════════════════════════════════════════════════════════${NC}"
     echo ""
 

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -198,15 +198,15 @@ check_http_health() {
 # LLM PROVIDER HEALTH CHECKS (Circuit Breaker Support)
 # ========================================================================
 
-# Production chain defaults: OpenAI Codex OAuth -> Ollama -> Z.ai.
+# Production chain defaults: OpenAI Codex OAuth -> Ollama -> Claude -> GLM.
 PRIMARY_PROVIDER="${PRIMARY_PROVIDER:-openai-codex}"
 FALLBACK_PROVIDER="${FALLBACK_PROVIDER:-ollama}"
 MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
 
-# GLM API configuration
-GLM_API_HOST="${GLM_API_HOST:-https://api.z.ai}"
+# GLM API configuration (official BigModel Coding Plan endpoint)
+GLM_API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
 GLM_API_KEY="${GLM_API_KEY:-}"
-GLM_MODEL="${GLM_MODEL:-glm-5}"
+GLM_MODEL="${GLM_MODEL:-glm-5.1}"
 GLM_HEALTH_TIMEOUT="${GLM_HEALTH_TIMEOUT:-10}"
 
 # Ollama API configuration
@@ -238,10 +238,10 @@ check_openai_codex_health() {
     return 1
 }
 
-# Check GLM (Z.ai) API health
+# Check official GLM (BigModel) API health
 check_glm_health() {
     local timeout="${1:-$GLM_HEALTH_TIMEOUT}"
-    local url="${GLM_API_HOST}/v1/models"
+    local url="${GLM_API_BASE%/}/models"
     local response_code
 
     # If no API key, skip check
@@ -336,7 +336,7 @@ check_primary_provider_health() {
         openai-codex)
             check_openai_codex_health "$@"
             ;;
-        glm|zai)
+        glm)
             check_glm_health "$@"
             ;;
         ollama)
@@ -354,7 +354,7 @@ check_fallback_provider_health() {
         ollama)
             check_ollama_health "$@"
             ;;
-        glm|zai)
+        glm)
             check_glm_health "$@"
             ;;
         openai-codex)

--- a/scripts/manifest.json
+++ b/scripts/manifest.json
@@ -1288,18 +1288,18 @@
         "RESET_CHAT_CONTEXT_BEFORE_SEND"
       ]
     },
-    "zai-rate-monitor.sh": {
+    "glm-rate-monitor.sh": {
       "version": "1.0.0",
-      "description": "Monitor Z.ai Coding Plan API rate limits and output JSON for CI",
+      "description": "Monitor official BigModel Coding Plan API rate limits and output JSON for CI",
       "entrypoint": true,
       "requires": [
         "curl",
         "jq"
       ],
       "provides": [
-        "zai-rate-monitor",
-        "zai-rate-watch",
-        "zai-rate-json"
+        "glm-rate-monitor",
+        "glm-rate-watch",
+        "glm-rate-json"
       ]
     },
     "telegram-webhook-rollout.sh": {

--- a/scripts/moltis-runtime-attestation.sh
+++ b/scripts/moltis-runtime-attestation.sh
@@ -205,6 +205,21 @@ oauth_tokens_have_refresh_token() {
         "$oauth_tokens_file" >/dev/null 2>&1
 }
 
+provider_keys_legacy_aliases() {
+    local runtime_config_dir="$1"
+    local provider_keys_file="$runtime_config_dir/provider_keys.json"
+
+    [[ -f "$provider_keys_file" ]] || return 1
+
+    jq -r '
+        [
+          (if has("zai") then "zai" else empty end),
+          (if has("zai-telegram-safe") then "zai-telegram-safe" else empty end),
+          (if has("custom-zai-telegram-safe") then "custom-zai-telegram-safe" else empty end)
+        ] | .[]
+    ' "$provider_keys_file" 2>/dev/null
+}
+
 provider_keys_first_model_for_provider() {
     local runtime_config_dir="$1"
     local provider="$2"
@@ -374,6 +389,7 @@ emit_failure_json() {
         --arg auth_canary_succeeded "${AUTH_CANARY_SUCCEEDED:-}" \
         --arg expected_auth_model "${EXPECTED_AUTH_MODEL:-}" \
         --arg auth_provider_model_preference "${AUTH_PROVIDER_MODEL_PREFERENCE:-}" \
+        --arg legacy_runtime_provider_aliases "${LEGACY_RUNTIME_PROVIDER_ALIASES:-}" \
         '{
           status: $status,
           target: $target,
@@ -391,6 +407,11 @@ emit_failure_json() {
             expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
             expected_auth_model: (if $expected_auth_model == "" then null else $expected_auth_model end),
             auth_provider_model_preference: (if $auth_provider_model_preference == "" then null else $auth_provider_model_preference end),
+            legacy_runtime_provider_aliases: (
+              if $legacy_runtime_provider_aliases == "" then []
+              else ($legacy_runtime_provider_aliases | split("\n") | map(select(length > 0)))
+              end
+            ),
             auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
             auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
             auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end),
@@ -506,6 +527,7 @@ TRACKED_RUNTIME_TOML=""
 RUNTIME_RUNTIME_TOML=""
 EXPECTED_AUTH_MODEL=""
 AUTH_PROVIDER_MODEL_PREFERENCE=""
+LEGACY_RUNTIME_PROVIDER_ALIASES=""
 
 if [[ ! -L "$ACTIVE_PATH" ]]; then
     fail_with "ACTIVE_ROOT_NOT_SYMLINK" "Active deploy root is not a symlink: $ACTIVE_PATH"
@@ -627,6 +649,11 @@ if [[ ! -f "$TRACKED_RUNTIME_TOML" || ! -f "$RUNTIME_RUNTIME_TOML" ]]; then
 fi
 if ! cmp -s "$TRACKED_RUNTIME_TOML" "$RUNTIME_RUNTIME_TOML"; then
     fail_with "RUNTIME_CONFIG_FILE_MISMATCH" "Runtime moltis.toml diverges from tracked config/moltis.toml"
+fi
+
+LEGACY_RUNTIME_PROVIDER_ALIASES="$(provider_keys_legacy_aliases "$EXPECTED_RUNTIME_CONFIG" || true)"
+if [[ -n "$LEGACY_RUNTIME_PROVIDER_ALIASES" ]]; then
+    fail_with "LEGACY_RUNTIME_PROVIDER_ALIAS_PRESENT" "Runtime provider_keys.json still exposes removed legacy provider aliases: $(printf '%s' "$LEGACY_RUNTIME_PROVIDER_ALIASES" | paste -sd ', ' -)"
 fi
 
 if [[ -n "$EXPECTED_AUTH_PROVIDER" ]]; then
@@ -830,6 +857,7 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
         --arg auth_canary_succeeded "$AUTH_CANARY_SUCCEEDED" \
         --arg expected_auth_model "$EXPECTED_AUTH_MODEL" \
         --arg auth_provider_model_preference "$AUTH_PROVIDER_MODEL_PREFERENCE" \
+        --arg legacy_runtime_provider_aliases "$LEGACY_RUNTIME_PROVIDER_ALIASES" \
         '{
           status: $status,
           target: $target,
@@ -877,6 +905,11 @@ if [[ "$OUTPUT_JSON" == "true" ]]; then
             expected_auth_provider: (if $expected_auth_provider == "" then null else $expected_auth_provider end),
             expected_auth_model: (if $expected_auth_model == "" then null else $expected_auth_model end),
             auth_provider_model_preference: (if $auth_provider_model_preference == "" then null else $auth_provider_model_preference end),
+            legacy_runtime_provider_aliases: (
+              if $legacy_runtime_provider_aliases == "" then []
+              else ($legacy_runtime_provider_aliases | split("\n") | map(select(length > 0)))
+              end
+            ),
             auth_status_raw: (if $auth_status_raw == "" then null else $auth_status_raw end),
             auth_status_post_canary: (if $auth_status_post_canary == "" then null else $auth_status_post_canary end),
             auth_status_valid: (if $auth_status_valid == "" then null else ($auth_status_valid == "true") end),
@@ -928,5 +961,6 @@ auth_status_valid=${AUTH_STATUS_VALID:-skipped}
 auth_validation_path=${AUTH_VALIDATION_PATH:-skipped}
 auth_canary_attempted=${AUTH_CANARY_ATTEMPTED:-false}
 auth_canary_succeeded=${AUTH_CANARY_SUCCEEDED:-false}
+legacy_runtime_provider_aliases=${LEGACY_RUNTIME_PROVIDER_ALIASES:-none}
 EOF
 fi

--- a/scripts/moltis-search-memory-diagnostics.sh
+++ b/scripts/moltis-search-memory-diagnostics.sh
@@ -122,7 +122,7 @@ if log_path:
         lambda line: "memory_search" in line and ("tool execution failed" in line or "all embedding providers failed" in line)
     )
     runtime["memory"]["openai_embeddings_400"] = count_lines(
-        lambda line: "https://api.z.ai/api/coding/paas/v4/embeddings" in line or "openai: HTTP status client error (400 Bad Request)" in line
+        lambda line: "https://open.bigmodel.cn/api/coding/paas/v4/embeddings" in line or "https://api.z.ai/api/coding/paas/v4/embeddings" in line or "openai: HTTP status client error (400 Bad Request)" in line
     )
     runtime["memory"]["groq_embeddings_401"] = count_lines(
         lambda line: "https://api.groq.com/openai/v1/embeddings" in line or "groq: HTTP status client error (401 Unauthorized)" in line

--- a/scripts/prepare-moltis-runtime-config.sh
+++ b/scripts/prepare-moltis-runtime-config.sh
@@ -95,6 +95,60 @@ normalize_openai_codex_model_preferences() {
     log "normalized runtime-managed openai-codex preferences to keep $tracked_model primary"
 }
 
+normalize_glm_provider_preferences() {
+    local tracked_model provider_alias provider_keys_file tmp_file
+
+    tracked_model="$(read_toml_key "$STATIC_CONFIG_DIR/moltis.toml" "[providers.openai]" "model" || true)"
+    provider_alias="$(read_toml_key "$STATIC_CONFIG_DIR/moltis.toml" "[providers.openai]" "alias" || true)"
+    provider_keys_file="$RUNTIME_CONFIG_DIR/provider_keys.json"
+
+    [[ -n "$tracked_model" && -n "$provider_alias" ]] || return 0
+    [[ -f "$provider_keys_file" ]] || return 0
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log "jq is unavailable, skipping GLM runtime preference normalization"
+        return 0
+    fi
+
+    tmp_file="$provider_keys_file.tmp.$$"
+    if ! jq \
+        --arg provider_alias "$provider_alias" \
+        --arg tracked_model "$tracked_model" \
+        '
+        . as $root
+        | ($root[$provider_alias] // $root["zai"] // {}) as $preferred_entry
+        | ($root["zai"] // {}) as $legacy_zai
+        | ($root["zai-telegram-safe"] // {}) as $legacy_safe_alias
+        | ($root["custom-zai-telegram-safe"] // {}) as $legacy_custom_safe
+        | .[$provider_alias] = (
+            (if ($preferred_entry | type) == "object" then $preferred_entry else {} end)
+            | .models = (
+                [$tracked_model] +
+                (
+                    (
+                        (
+                            (($preferred_entry.models // []) | if type == "array" then . else [] end) +
+                            (($legacy_zai.models // []) | if type == "array" then . else [] end) +
+                            (($legacy_safe_alias.models // []) | if type == "array" then . else [] end) +
+                            (($legacy_custom_safe.models // []) | if type == "array" then . else [] end)
+                        )
+                        | map(select(. != $tracked_model))
+                    )
+                    | unique
+                )
+            )
+        )
+        | del(.["zai"], .["zai-telegram-safe"], .["custom-zai-telegram-safe"])
+        ' "$provider_keys_file" >"$tmp_file"; then
+        rm -f "$tmp_file"
+        echo "Failed to normalize GLM provider preferences in $provider_keys_file" >&2
+        exit 1
+    fi
+
+    mv "$tmp_file" "$provider_keys_file"
+    log "normalized runtime-managed $provider_alias preferences and removed legacy runtime GLM aliases"
+}
+
 main() {
     if [[ ! -d "$STATIC_CONFIG_DIR" ]]; then
         echo "Static config directory not found: $STATIC_CONFIG_DIR" >&2
@@ -132,6 +186,7 @@ main() {
     done
 
     normalize_openai_codex_model_preferences
+    normalize_glm_provider_preferences
 
     if [[ -f "$RUNTIME_CONFIG_DIR/provider_keys.json" ]]; then
         chmod 600 "$RUNTIME_CONFIG_DIR/provider_keys.json" 2>/dev/null || true

--- a/scripts/rate-check.sh
+++ b/scripts/rate-check.sh
@@ -55,7 +55,7 @@ get_429_count() {
                 ((count++)) || true
             fi
         fi
-    # Z.ai rate limit patterns: HTTP 429 OR code:"1302" (Z.ai specific)
+    # GLM provider rate limit patterns: HTTP 429 OR code:"1302" (legacy GLM-specific)
     done < <(grep -hE '(429.*Rate limit|"code":"1302")' $recent_files 2>/dev/null | tail -50)
 
     echo "$count"

--- a/scripts/render-moltis-env.sh
+++ b/scripts/render-moltis-env.sh
@@ -60,6 +60,7 @@ if [[ -z "$OUTPUT_PATH" ]]; then
 fi
 
 assert_single_line "MOLTIS_PASSWORD" "${MOLTIS_PASSWORD:-}"
+assert_single_line "ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY:-}"
 assert_single_line "GLM_API_KEY" "${GLM_API_KEY:-}"
 assert_single_line "OLLAMA_API_KEY" "${OLLAMA_API_KEY:-}"
 assert_single_line "TAVILY_API_KEY" "${TAVILY_API_KEY:-}"
@@ -79,7 +80,10 @@ cat > "$OUTPUT_PATH" <<EOF
 # Authentication
 MOLTIS_PASSWORD=${MOLTIS_PASSWORD:-}
 
-# LLM Provider - GLM (Zhipu AI)
+# LLM Provider - Claude (Anthropic)
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+
+# LLM Provider - GLM (Zhipu AI / BigModel)
 GLM_API_KEY=${GLM_API_KEY:-}
 
 # LLM Fallback - Ollama Cloud (optional, for cloud models)

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -2980,6 +2980,38 @@ emit_modified_payload_preserve_tool_calls() {
         )"
 }
 
+tool_call_has_missing_required_arguments() {
+    local tool_name="${1:-}"
+    local arguments_json="${2:-}"
+
+    [[ -n "$tool_name" ]] || return 1
+    [[ -n "$arguments_json" ]] || arguments_json='{}'
+
+    case "$tool_name" in
+        memory_search)
+            ! jq -e '
+                (. // {}) as $args
+                | (($args.query? // "") | tostring | gsub("\\s+"; "") | length) > 0
+            ' >/dev/null 2>&1 <<<"$arguments_json"
+            ;;
+        exec)
+            ! jq -e '
+                (. // {}) as $args
+                | (($args.command? // "") | tostring | gsub("\\s+"; "") | length) > 0
+            ' >/dev/null 2>&1 <<<"$arguments_json"
+            ;;
+        cron)
+            ! jq -e '
+                (. // {}) as $args
+                | (($args.action? // "") | tostring | gsub("\\s+"; "") | length) > 0
+            ' >/dev/null 2>&1 <<<"$arguments_json"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 extract_tool_call_names() {
     local tool_calls_json="${1:-}"
 
@@ -3098,6 +3130,23 @@ tool_calls_only_tavily_allowlisted() {
     $saw_name
 }
 
+tool_calls_include_missing_required_arguments() {
+    local tool_calls_json="${1:-}"
+
+    [[ -n "$tool_calls_json" && "$tool_calls_json" != "[]" ]] || return 1
+
+    jq -e '
+        any(.[]?;
+            (.arguments // {}) as $args
+            | (
+                (.name == "memory_search" and ((($args.query? // "") | tostring | gsub("\\s+"; "") | length) == 0))
+                or (.name == "exec" and ((($args.command? // "") | tostring | gsub("\\s+"; "") | length) == 0))
+                or (.name == "cron" and ((($args.action? // "") | tostring | gsub("\\s+"; "") | length) == 0))
+            )
+        )
+    ' >/dev/null 2>&1 <<<"$tool_calls_json"
+}
+
 emit_modified_payload() {
     local text="$1"
     local include_tool_calls="${2:-false}"
@@ -3200,6 +3249,7 @@ if [[ -z "$tool_name" ]]; then
     tool_name="$(extract_first_string tool_name || true)"
 fi
 command_arg="$(extract_first_string command || true)"
+tool_arguments_json="$(extract_json_object arguments || true)"
 messages_json="$(extract_json_array messages || true)"
 latest_user_message="$(extract_last_message_content_by_role "${messages_json:-}" user || true)"
 latest_assistant_message="$(extract_last_message_content_by_role "${messages_json:-}" assistant || true)"
@@ -3256,11 +3306,11 @@ write_audit_line "invoke event=${event:-<none>} provider=${provider:-<none>} mod
 
 is_telegram_safe_lane=false
 case "${model:-}" in
-    custom-zai-telegram-safe::*|openai-codex::*)
+    openai-codex::*)
         is_telegram_safe_lane=true
         ;;
 esac
-if [[ "${provider:-}" == "custom-zai-telegram-safe" || "${provider:-}" == "zai-telegram-safe" || "${provider:-}" == "openai-codex" ]]; then
+if [[ "${provider:-}" == "openai-codex" ]]; then
     is_telegram_safe_lane=true
 fi
 if [[ "${account_id:-}" == "moltis-bot" || "${channel_account:-}" == "moltis-bot" ]]; then
@@ -3285,6 +3335,7 @@ if [[ -n "${tool_calls_json:-}" && "$tool_calls_json" != "[]" ]]; then
 fi
 tool_calls_allowlisted_only=false
 tool_calls_have_disallowed=false
+tool_calls_have_missing_required_arguments=false
 if [[ "$tool_calls_present" == true ]]; then
     if tool_calls_only_allowlisted "$tool_calls_json"; then
         tool_calls_allowlisted_only=true
@@ -3292,6 +3343,14 @@ if [[ "$tool_calls_present" == true ]]; then
     if tool_calls_include_disallowed "$tool_calls_json"; then
         tool_calls_have_disallowed=true
     fi
+    if tool_calls_include_missing_required_arguments "$tool_calls_json"; then
+        tool_calls_have_missing_required_arguments=true
+    fi
+fi
+
+current_tool_missing_required_arguments=false
+if [[ "$event" == "BeforeToolCall" ]] && tool_call_has_missing_required_arguments "$tool_name" "${tool_arguments_json:-}"; then
+    current_tool_missing_required_arguments=true
 fi
 
 # Keep delivery-time stripping strict, but allow broader AfterLLM fail-closed
@@ -3330,7 +3389,7 @@ fi
 
 looks_like_observed_status_reply=false
 if [[ ( "$event" == "AfterLLMCall" || "$event" == "MessageSending" ) && -z "$status_query_text_flat" ]] && \
-   printf '%s' "${response_text_flat:-$payload_flat}" | grep -Eiq '(^|[^[:alnum:]_])/?status([^[:alnum:]_]|$)|статус( системы)?|активность:|канал: telegram|провайдер:|режим: safe-text|модель: (custom-zai-telegram-safe::glm-5|openai-codex::gpt-5\.4)'; then
+   printf '%s' "${response_text_flat:-$payload_flat}" | grep -Eiq '(^|[^[:alnum:]_])/?status([^[:alnum:]_]|$)|статус( системы)?|активность:|канал: telegram|провайдер:|режим: safe-text|модель: openai-codex::gpt-5\.4'; then
     looks_like_observed_status_reply=true
 fi
 
@@ -3552,6 +3611,12 @@ if [[ ( "$event" == "AfterLLMCall" || "$event" == "MessageSending" ) && "$tool_c
     has_skill_visibility_generic_mismatch=true
 fi
 
+non_telegram_after_llm_fail_closed=false
+if [[ "$event" == "AfterLLMCall" && "$is_telegram_safe_lane" != true ]] && \
+   [[ "$tool_calls_have_missing_required_arguments" == true || "$has_delivery_internal_telemetry" == true || "$has_after_llm_tool_intent" == true || "$has_user_visible_internal_planning" == true || "$has_skill_path_false_negative" == true || "$has_skill_visibility_generic_mismatch" == true ]]; then
+    non_telegram_after_llm_fail_closed=true
+fi
+
 if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
     diagnostic_preview_source="text"
     diagnostic_preview_value="$response_text_flat"
@@ -3589,6 +3654,19 @@ if [[ "$event" == "MessageSending" ]]; then
         exit 0
     fi
 elif [[ "$is_telegram_safe_lane" != true ]]; then
+    if [[ "$event" == "AfterLLMCall" && "$non_telegram_after_llm_fail_closed" == true ]]; then
+        :
+    elif [[ "$event" == "BeforeToolCall" && "$current_tool_missing_required_arguments" == true ]]; then
+        :
+    else
+        exit 0
+    fi
+fi
+
+if [[ "$event" == "BeforeToolCall" && "$current_tool_missing_required_arguments" == true ]]; then
+    synthetic_command="true"
+    write_audit_line "emit_modify event=$event reason=malformed_tool_call_suppress tool=${tool_name:-missing} telegram_safe=$is_telegram_safe_lane"
+    emit_before_tool_modified_payload "exec" "{\"command\":\"$synthetic_command\"}"
     exit 0
 fi
 
@@ -4065,12 +4143,15 @@ if [[ "$event" == "AfterLLMCall" && "$tool_calls_allowlisted_only" == true && ( 
     exit 0
 fi
 
-if [[ "$tool_calls_have_disallowed" == true || "$has_delivery_internal_telemetry" == true || "$has_after_llm_tool_intent" == true || "$has_user_visible_internal_planning" == true || "$has_skill_path_false_negative" == true ]]; then
+if [[ "$tool_calls_have_disallowed" == true || "$tool_calls_have_missing_required_arguments" == true || "$has_delivery_internal_telemetry" == true || "$has_after_llm_tool_intent" == true || "$has_user_visible_internal_planning" == true || "$has_skill_path_false_negative" == true ]]; then
     fallback_text='В Telegram-safe режиме я не запускаю инструменты и не показываю внутренние логи. Для browser/search/process workflow продолжим в web UI или операторской сессии.'
+    if [[ "$tool_calls_have_missing_required_arguments" == true && "$is_telegram_safe_lane" != true ]]; then
+        fallback_text='Внутренний tool-path сформировал некорректный вызов, поэтому я не показываю сырые tool-ошибки. Повтори запрос, и я отвечу без внутренней диагностики.'
+    fi
     if [[ "$has_skill_path_false_negative" == true ]]; then
         fallback_text='Я не использую sandbox filesystem как доказательство отсутствия навыков. Для работы с навыками продолжу через runtime skill-tools без проверки директорий.'
     fi
-    write_audit_line "emit_modify event=$event reason=fallback tool_calls_present=$tool_calls_present disallowed_tools=$tool_calls_have_disallowed delivery_telemetry=$has_delivery_internal_telemetry after_llm_intent=$has_after_llm_tool_intent planning=$has_user_visible_internal_planning false_negative=$has_skill_path_false_negative"
+    write_audit_line "emit_modify event=$event reason=fallback tool_calls_present=$tool_calls_present disallowed_tools=$tool_calls_have_disallowed missing_required_args=$tool_calls_have_missing_required_arguments delivery_telemetry=$has_delivery_internal_telemetry after_llm_intent=$has_after_llm_tool_intent planning=$has_user_visible_internal_planning false_negative=$has_skill_path_false_negative"
     if [[ "$event" == "AfterLLMCall" ]]; then
         emit_modified_payload "$fallback_text" true
     else

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -449,6 +449,243 @@ extract_json_object() {
     '
 }
 
+extract_json_object_field_from_text() {
+    local source_text="${1:-}"
+    local key="${2:-}"
+
+    [[ -n "$source_text" && -n "$key" ]] || return 1
+
+    printf '%s' "$source_text" | awk -v key="$key" '
+        BEGIN {
+            RS = ""
+            ORS = ""
+            needle = "\"" key "\""
+            state = "seek"
+            value = ""
+            depth = 0
+            in_string = 0
+            escape = 0
+        }
+        {
+            text = $0
+            n = length(text)
+            for (i = 1; i <= n; i++) {
+                c = substr(text, i, 1)
+                if (state == "seek") {
+                    if (substr(text, i, length(needle)) != needle) {
+                        continue
+                    }
+                    j = i + length(needle)
+                    while (j <= n && substr(text, j, 1) ~ /[ \t\r\n]/) {
+                        j++
+                    }
+                    if (substr(text, j, 1) != ":") {
+                        continue
+                    }
+                    j++
+                    while (j <= n && substr(text, j, 1) ~ /[ \t\r\n]/) {
+                        j++
+                    }
+                    if (substr(text, j, 1) != "{") {
+                        continue
+                    }
+                    state = "capture"
+                    depth = 0
+                    in_string = 0
+                    escape = 0
+                    i = j - 1
+                    continue
+                }
+
+                value = value c
+
+                if (escape) {
+                    escape = 0
+                    continue
+                }
+                if (c == "\\") {
+                    escape = 1
+                    continue
+                }
+                if (c == "\"") {
+                    in_string = !in_string
+                    continue
+                }
+                if (in_string) {
+                    continue
+                }
+                if (c == "{") {
+                    depth++
+                    continue
+                }
+                if (c == "}") {
+                    depth--
+                    if (depth == 0) {
+                        print value
+                        exit 0
+                    }
+                }
+            }
+        }
+        END {
+            if (value == "") {
+                exit 1
+            }
+        }
+    '
+}
+
+extract_json_objects_from_array() {
+    local array_json="${1:-}"
+    local perl_output=""
+
+    [[ -n "$array_json" && "$array_json" != "[]" ]] || return 1
+
+    if command -v perl >/dev/null 2>&1; then
+        perl_output="$(
+            printf '%s' "$array_json" | perl -e '
+                use strict;
+                use warnings;
+                use utf8;
+                binmode STDIN, ":encoding(UTF-8)";
+                binmode STDOUT, ":encoding(UTF-8)";
+
+                local $/;
+                my $text = <STDIN>;
+                exit 1 unless defined $text && length $text;
+
+                my $n = length($text);
+                my $capturing = 0;
+                my $depth = 0;
+                my $in_string = 0;
+                my $escape = 0;
+                my $value = q();
+
+                for (my $i = 0; $i < $n; $i++) {
+                    my $char = substr($text, $i, 1);
+
+                    if (!$capturing) {
+                        next unless $char eq q({);
+                        $capturing = 1;
+                        $depth = 1;
+                        $in_string = 0;
+                        $escape = 0;
+                        $value = q({);
+                        next;
+                    }
+
+                    $value .= $char;
+
+                    if ($escape) {
+                        $escape = 0;
+                        next;
+                    }
+                    if ($char eq q(\\)) {
+                        $escape = 1;
+                        next;
+                    }
+                    if ($char eq q(")) {
+                        $in_string = !$in_string;
+                        next;
+                    }
+                    next if $in_string;
+
+                    if ($char eq q({)) {
+                        $depth++;
+                        next;
+                    }
+                    if ($char eq q(})) {
+                        $depth--;
+                        if ($depth == 0) {
+                            print $value, qq(\n);
+                            $capturing = 0;
+                            $value = q();
+                        }
+                    }
+                }
+            ' 2>/dev/null
+        )" || true
+        if [[ -n "$perl_output" ]]; then
+            printf '%s\n' "$perl_output"
+            return 0
+        fi
+    fi
+
+    printf '%s' "$array_json" | awk '
+        BEGIN {
+            RS = ""
+            ORS = ""
+            value = ""
+            depth = 0
+            in_string = 0
+            escape = 0
+            capturing = 0
+        }
+        {
+            text = $0
+            n = length(text)
+            for (i = 1; i <= n; i++) {
+                c = substr(text, i, 1)
+                if (!capturing) {
+                    if (c != "{") {
+                        continue
+                    }
+                    capturing = 1
+                    depth = 1
+                    in_string = 0
+                    escape = 0
+                    value = "{"
+                    continue
+                }
+
+                value = value c
+
+                if (escape) {
+                    escape = 0
+                    continue
+                }
+                if (c == "\\") {
+                    escape = 1
+                    continue
+                }
+                if (c == "\"") {
+                    in_string = !in_string
+                    continue
+                }
+                if (in_string) {
+                    continue
+                }
+                if (c == "{") {
+                    depth++
+                    continue
+                }
+                if (c == "}") {
+                    depth--
+                    if (depth == 0) {
+                        print value "\n"
+                        capturing = 0
+                        value = ""
+                    }
+                }
+            }
+        }
+    '
+}
+
+string_has_nonwhitespace() {
+    local value="${1:-}"
+    [[ -n "$(printf '%s' "$value" | tr -d '[:space:]')" ]]
+}
+
+json_string_field_present_and_nonempty_from_text() {
+    local source_text="${1:-}"
+    local key="${2:-}"
+    local value=""
+
+    value="$(extract_json_string_field_from_text "$source_text" "$key" || true)"
+    string_has_nonwhitespace "$value"
+}
+
 json_escape() {
     printf '%s' "$1" | awk '
         BEGIN {
@@ -2989,22 +3226,13 @@ tool_call_has_missing_required_arguments() {
 
     case "$tool_name" in
         memory_search)
-            ! jq -e '
-                (. // {}) as $args
-                | (($args.query? // "") | tostring | gsub("\\s+"; "") | length) > 0
-            ' >/dev/null 2>&1 <<<"$arguments_json"
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "query"
             ;;
         exec)
-            ! jq -e '
-                (. // {}) as $args
-                | (($args.command? // "") | tostring | gsub("\\s+"; "") | length) > 0
-            ' >/dev/null 2>&1 <<<"$arguments_json"
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "command"
             ;;
         cron)
-            ! jq -e '
-                (. // {}) as $args
-                | (($args.action? // "") | tostring | gsub("\\s+"; "") | length) > 0
-            ' >/dev/null 2>&1 <<<"$arguments_json"
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "action"
             ;;
         *)
             return 1
@@ -3132,19 +3360,23 @@ tool_calls_only_tavily_allowlisted() {
 
 tool_calls_include_missing_required_arguments() {
     local tool_calls_json="${1:-}"
+    local tool_call_json=""
+    local nested_tool_name=""
+    local nested_arguments_json=""
 
     [[ -n "$tool_calls_json" && "$tool_calls_json" != "[]" ]] || return 1
 
-    jq -e '
-        any(.[]?;
-            (.arguments // {}) as $args
-            | (
-                (.name == "memory_search" and ((($args.query? // "") | tostring | gsub("\\s+"; "") | length) == 0))
-                or (.name == "exec" and ((($args.command? // "") | tostring | gsub("\\s+"; "") | length) == 0))
-                or (.name == "cron" and ((($args.action? // "") | tostring | gsub("\\s+"; "") | length) == 0))
-            )
-        )
-    ' >/dev/null 2>&1 <<<"$tool_calls_json"
+    while IFS= read -r tool_call_json; do
+        [[ -n "$tool_call_json" ]] || continue
+        nested_tool_name="$(extract_json_string_field_from_text "$tool_call_json" "name" || true)"
+        [[ -n "$nested_tool_name" ]] || continue
+        nested_arguments_json="$(extract_json_object_field_from_text "$tool_call_json" "arguments" || true)"
+        if tool_call_has_missing_required_arguments "$nested_tool_name" "${nested_arguments_json:-}"; then
+            return 0
+        fi
+    done < <(extract_json_objects_from_array "$tool_calls_json" || true)
+
+    return 1
 }
 
 emit_modified_payload() {

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -54,7 +54,7 @@ const headed = hasFlag("--headed");
 const debug = hasFlag("--debug");
 
 const ERROR_RE =
-  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'?(?:action|query|command)'?\s+parameter)/i;
+  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|no models available|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'?(?:action|query|command)'?\s+parameter)/i;
 const SENSITIVE_RE = /\b(api[_ -]?key|token|password|secret)\b/i;
 
 let stage = "login";

--- a/specs/001-fallback-llm-ollama/contracts/moltis-failover-config.md
+++ b/specs/001-fallback-llm-ollama/contracts/moltis-failover-config.md
@@ -12,31 +12,48 @@ TOML configuration schema for Moltis failover settings in `config/moltis.toml`.
 ### Provider Configuration
 
 ```toml
-# Primary provider (GLM via Z.ai)
-[providers.openai]
-enabled = true                    # MUST be true
-api_key = "${GLM_API_KEY}"        # Environment variable
-model = "glm-5"                   # Primary model
-base_url = "https://api.z.ai/api/coding/paas/v4"
-alias = "glm"                     # Short name for failover config
+# Primary provider (OpenAI Codex via ChatGPT OAuth)
+[providers.openai-codex]
+enabled = true
+model = "gpt-5.4"
+alias = "openai-codex"
+models = ["gpt-5.4"]
 
-# Fallback provider (Ollama)
+# Fallback provider 1 (Ollama sidecar)
 [providers.ollama]
-enabled = true                    # MUST be true for failover
-base_url = "http://ollama:11434"  # Docker service name
-model = "gemini-3-flash-preview:cloud"  # Cloud model
-alias = "ollama"                  # Short name
-api_key = "${OLLAMA_API_KEY}"     # Optional: for cloud models
+enabled = true
+base_url = "http://ollama:11434"
+model = "gemini-3-flash-preview:cloud"
+alias = "ollama"
+api_key = "${OLLAMA_API_KEY}"
+
+# Fallback provider 2 (Claude)
+[providers.anthropic]
+enabled = true
+api_key = "${ANTHROPIC_API_KEY}"
+model = "claude-sonnet-4-20250514"
+base_url = "https://api.anthropic.com"
+alias = "anthropic"
+
+# Final fallback provider 3 (official BigModel GLM)
+[providers.openai]
+enabled = true
+api_key = "${GLM_API_KEY}"
+model = "glm-5.1"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+alias = "glm"
+models = ["glm-5.1"]
 ```
 
 ### Failover Configuration
 
 ```toml
 [failover]
-enabled = true                                      # Enable failover
-primary_provider = "glm"                            # Primary provider alias
-fallback_models = [                                 # Ordered fallback list
-    "ollama::gemini-3-flash-preview:cloud"
+enabled = true
+fallback_models = [
+    "ollama::gemini-3-flash-preview:cloud",
+    "anthropic::claude-sonnet-4-20250514",
+    "glm::glm-5.1"
 ]
 health_check_interval = "5s"                        # Health check interval
 failure_threshold = 3                               # Failures before switch
@@ -50,9 +67,14 @@ success_threshold = 2                               # Successes to recover
 
 | Section | Field | Type | Required | Default |
 |---------|-------|------|----------|---------|
+| providers.openai-codex | enabled | bool | ✅ | false |
+| providers.openai-codex | model | string | ✅ | - |
 | providers.openai | enabled | bool | ✅ | false |
 | providers.openai | api_key | string | ✅ | - |
 | providers.openai | model | string | ✅ | - |
+| providers.anthropic | enabled | bool | ✅ | false |
+| providers.anthropic | api_key | string | ✅ | - |
+| providers.anthropic | model | string | ✅ | - |
 | providers.ollama | enabled | bool | ✅ | false |
 | providers.ollama | base_url | string | ✅ | - |
 | failover | enabled | bool | ✅ | false |
@@ -67,13 +89,19 @@ success_threshold = 2                               # Successes to recover
 
 ## Example Configurations
 
-### Minimal (GLM only, no failover)
+### Minimal (Primary Codex only, no failover)
 ```toml
-[providers.openai]
+[providers.openai-codex]
 enabled = true
-api_key = "${GLM_API_KEY}"
-model = "glm-5"
-base_url = "https://api.z.ai/api/coding/paas/v4"
+model = "gpt-5.4"
+alias = "openai-codex"
+models = ["gpt-5.4"]
+
+[providers.anthropic]
+enabled = false
+
+[providers.openai]
+enabled = false
 
 [providers.ollama]
 enabled = false
@@ -83,14 +111,28 @@ enabled = false
 fallback_models = []
 ```
 
-### Full (GLM + Ollama failover)
+### Full (Codex + ordered fallback chain)
 ```toml
+[providers.openai-codex]
+enabled = true
+model = "gpt-5.4"
+alias = "openai-codex"
+models = ["gpt-5.4"]
+
+[providers.anthropic]
+enabled = true
+api_key = "${ANTHROPIC_API_KEY}"
+model = "claude-sonnet-4-20250514"
+base_url = "https://api.anthropic.com"
+alias = "anthropic"
+
 [providers.openai]
 enabled = true
 api_key = "${GLM_API_KEY}"
-model = "glm-5"
-base_url = "https://api.z.ai/api/coding/paas/v4"
+model = "glm-5.1"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
 alias = "glm"
+models = ["glm-5.1"]
 
 [providers.ollama]
 enabled = true
@@ -101,8 +143,11 @@ api_key = "${OLLAMA_API_KEY}"
 
 [failover]
 enabled = true
-primary_provider = "glm"
-fallback_models = ["ollama::gemini-3-flash-preview:cloud"]
+fallback_models = [
+    "ollama::gemini-3-flash-preview:cloud",
+    "anthropic::claude-sonnet-4-20250514",
+    "glm::glm-5.1"
+]
 health_check_interval = "5s"
 failure_threshold = 3
 recovery_timeout = "60s"
@@ -142,7 +187,8 @@ fi
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| GLM_API_KEY | ✅ | Z.ai API key |
+| GLM_API_KEY | ✅ | Official BigModel API key for final GLM fallback |
+| ANTHROPIC_API_KEY | ⚠️ | Claude Sonnet fallback lane |
 | OLLAMA_API_KEY | ⚠️ | Ollama cloud API key (if using cloud models) |
 
 ## Secrets Files
@@ -150,4 +196,5 @@ fi
 | File | Content | Permissions |
 |------|---------|-------------|
 | secrets/glm_api_key.txt | GLM API key | 600 |
+| secrets/anthropic_api_key.txt | Anthropic API key | 600 |
 | secrets/ollama_api_key.txt | Ollama API key | 600 |

--- a/specs/001-fallback-llm-ollama/data-model.md
+++ b/specs/001-fallback-llm-ollama/data-model.md
@@ -8,9 +8,11 @@
 ```
 ┌─────────────────┐     ┌─────────────────────┐
 │  LLM Provider   │     │  Circuit Breaker    │
-│  (2 instances)  │────▶│  State              │
-│  - GLM          │     │  (1 instance)       │
-│  - Ollama       │     └─────────────────────┘
+│  (4 instances)  │────▶│  State              │
+│  - openai-codex │     │  (1 instance)       │
+│  - ollama       │     └─────────────────────┘
+│  - anthropic    │
+│  - glm          │
 └────────┬────────┘              │
          │                       │
          │                       ▼
@@ -30,11 +32,11 @@ Represents an LLM API provider (primary or fallback).
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| name | string | Provider identifier | "glm", "ollama" |
+| name | string | Provider identifier | "openai-codex", "ollama", "anthropic", "glm" |
 | type | enum | Provider type | "primary", "fallback" |
 | status | enum | Current availability | "available", "unavailable", "degraded" |
-| base_url | string | API endpoint | "https://api.z.ai", "http://localhost:11434" |
-| model | string | Model identifier | "glm-5", "gemini-3-flash-preview:cloud" |
+| base_url | string | API endpoint | "https://api.anthropic.com", "http://localhost:11434", "https://open.bigmodel.cn/api/coding/paas/v4" |
+| model | string | Model identifier | "gpt-5.4", "gemini-3-flash-preview:cloud", "claude-sonnet-4-20250514", "glm-5.1" |
 | latency_p95 | number | 95th percentile latency (ms) | 2500, 12000 |
 | error_count | number | Consecutive errors | 0, 3 |
 | last_check | timestamp | Last health check time | "2026-03-01T12:00:00Z" |
@@ -63,7 +65,7 @@ Manages failover state machine.
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
 | state | enum | Circuit breaker state | "closed", "open", "half-open" |
-| current_provider | string | Active provider | "glm", "ollama" |
+| current_provider | string | Active provider | "openai-codex", "ollama" |
 | failure_count | number | Consecutive failures | 0, 3 |
 | success_count | number | Consecutive successes (half-open) | 0, 2 |
 | last_failure | timestamp | Last failure time | "2026-03-01T12:00:00Z" |
@@ -107,7 +109,7 @@ Records provider switches for observability.
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
 | timestamp | timestamp | Event time | "2026-03-01T11:55:00Z" |
-| from_provider | string | Previous provider | "glm" |
+| from_provider | string | Previous provider | "openai-codex" |
 | to_provider | string | New provider | "ollama" |
 | reason | enum | Switch reason | "health_check_failure", "manual", "recovery" |
 | failure_count | number | Failures that triggered switch | 3 |
@@ -121,7 +123,7 @@ Records provider switches for observability.
 | Reason | Trigger | Expected Frequency |
 |--------|---------|-------------------|
 | health_check_failure | 3 consecutive failures | Rare (< 1/month) |
-| recovery | GLM restored after outage | Rare |
+| recovery | Primary provider restored after outage | Rare |
 | manual | Admin intervention | Very rare |
 
 ---
@@ -131,11 +133,24 @@ Records provider switches for observability.
 ### Moltis Provider Configuration
 
 ```toml
+[providers.openai-codex]
+enabled = true
+model = "gpt-5.4"
+alias = "openai-codex"
+models = ["gpt-5.4"]
+
+[providers.anthropic]
+enabled = true
+api_key = "${ANTHROPIC_API_KEY}"
+model = "claude-sonnet-4-20250514"
+base_url = "https://api.anthropic.com"
+alias = "anthropic"
+
 [providers.openai]
 enabled = true
 api_key = "${GLM_API_KEY}"
-model = "glm-5"
-base_url = "https://api.z.ai/api/coding/paas/v4"
+model = "glm-5.1"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
 alias = "glm"
 
 [providers.ollama]
@@ -146,10 +161,27 @@ alias = "ollama"
 # Optional: api_key for cloud models
 api_key = "${OLLAMA_API_KEY}"
 
+[chat]
+allowed_models = [
+  "openai-codex::gpt-5.4",
+  "ollama::gemini-3-flash-preview:cloud",
+  "anthropic::claude-sonnet-4-20250514",
+  "glm::glm-5.1"
+]
+priority_models = [
+  "openai-codex::gpt-5.4",
+  "ollama::gemini-3-flash-preview:cloud",
+  "anthropic::claude-sonnet-4-20250514",
+  "glm::glm-5.1"
+]
+
 [failover]
 enabled = true
-primary_provider = "glm"
-fallback_models = ["ollama::gemini-3-flash-preview:cloud"]
+fallback_models = [
+  "ollama::gemini-3-flash-preview:cloud",
+  "anthropic::claude-sonnet-4-20250514",
+  "glm::glm-5.1"
+]
 health_check_interval = "5s"
 failure_threshold = 3
 recovery_timeout = "60s"
@@ -174,17 +206,19 @@ recovery_timeout = "60s"
 
 ```
 # Provider availability (gauge)
-llm_provider_available{provider="glm"} 1
+llm_provider_available{provider="openai-codex"} 1
 llm_provider_available{provider="ollama"} 1
+llm_provider_available{provider="anthropic"} 1
+llm_provider_available{provider="glm"} 1
 
 # Failover counter
-llm_fallback_triggered_total{from="glm",to="ollama",reason="health_check_failure"} 2
+llm_fallback_triggered_total{from="openai-codex",to="ollama",reason="health_check_failure"} 2
 
 # Circuit breaker state
-moltis_circuit_state{provider="glm"} 0  # 0=closed, 1=open, 2=half-open
+moltis_circuit_state{provider="openai-codex"} 0  # 0=closed, 1=open, 2=half-open
 
 # Provider latency
-llm_request_duration_seconds{provider="glm",quantile="0.95"} 2.5
+llm_request_duration_seconds{provider="openai-codex",quantile="0.95"} 2.5
 ```
 
 ---

--- a/specs/001-fallback-llm-ollama/spec.md
+++ b/specs/001-fallback-llm-ollama/spec.md
@@ -7,27 +7,28 @@
 
 ## Overview
 
-Реализовать отказоустойчивый fallback механизм для Moltis, который автоматически переключается на Ollama с моделью Gemini-3-flash-preview при недоступности основного провайдера GLM-5 (Z.ai).
+Реализовать отказоустойчивую fallback-цепочку для Moltis: `openai-codex::gpt-5.4` как primary, затем `ollama::gemini-3-flash-preview:cloud`, затем `anthropic::claude-sonnet-4-20250514`, и финальный fallback `glm::glm-5.1` через официальный BigModel Coding Plan.
 
-**Problem**: При падении GLM API — Moltis полностью неработоспособен (КРИТИЧЕСКАЯ ПРОБЛЕМА).
+**Problem**: При отказе primary или промежуточного fallback-провайдера пользователь не должен получать raw provider/tool errors или оставаться без ответа.
 
-**Solution**: Ollama Sidecar контейнер + Circuit Breaker pattern для автоматического failover.
+**Solution**: Ollama Sidecar + ordered failover policy + circuit-breaker style health tracking для автоматического перехода по цепочке `Codex -> Ollama -> Claude -> GLM-5.1`.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Automatic Failover on GLM Outage (Priority: P1)
+### User Story 1 - Automatic Failover on Primary Outage (Priority: P1)
 
 Как пользователь Moltis, я хочу, чтобы система автоматически переключалась на резервный LLM при недоступности основного провайдера, чтобы я мог продолжать работу без прерываний.
 
-**Why this priority**: Это критическая функциональность - без неё система полностью неработоспособна при сбое GLM.
+**Why this priority**: Это критическая функциональность - без неё primary LLM outage превращается в пользовательский инцидент.
 
-**Independent Test**: Можно протестировать, симулировав недоступность GLM API и проверив, что запросы автоматически направляются в Ollama.
+**Independent Test**: Можно протестировать, симулировав недоступность `openai-codex::gpt-5.4` и проверив, что запросы переходят на Ollama, затем на Claude/GLM-5.1 при дальнейших отказах.
 
 **Acceptance Scenarios**:
 
-1. **Given** GLM API недоступен (timeout/error), **When** пользователь отправляет запрос к Moltis, **Then** запрос автоматически перенаправляется в Ollama с Gemini
-2. **Given** GLM API восстановлен после сбоя, **When** circuit breaker переходит в half-open state, **Then** система автоматически возвращается к GLM
-3. **Given** оба провайдера недоступны, **When** пользователь отправляет запрос, **Then** система возвращает понятную ошибку с информацией о статусе
+1. **Given** `openai-codex::gpt-5.4` недоступен (timeout/error), **When** пользователь отправляет запрос к Moltis, **Then** запрос автоматически перенаправляется в Ollama с Gemini
+2. **Given** primary и Ollama одновременно недоступны, **When** пользователь отправляет запрос, **Then** система последовательно переходит на Claude и затем на `glm::glm-5.1` без raw provider-resolution leakage
+3. **Given** primary восстановлен после сбоя, **When** circuit breaker переходит в half-open state, **Then** система автоматически возвращается к `openai-codex::gpt-5.4`
+4. **Given** вся цепочка недоступна, **When** пользователь отправляет запрос, **Then** система возвращает понятную ошибку с информацией о статусе без показа внутренних tool/provider errors
 
 ---
 
@@ -41,9 +42,9 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** система работает, **When** запрашиваются метрики, **Then** возвращаются `llm_provider_available{provider="glm"}` и `llm_provider_available{provider="ollama"}`
+1. **Given** система работает, **When** запрашиваются метрики, **Then** возвращаются `llm_provider_available{provider="openai-codex"}`, `llm_provider_available{provider="ollama"}`, `llm_provider_available{provider="anthropic"}` и `llm_provider_available{provider="glm"}`
 2. **Given** произошёл failover, **When** запрашивается метрика, **Then** `llm_fallback_triggered_total` увеличивается
-3. **Given** GLM недоступен > 5 минут, **When** срабатывает alert, **Then** администратор получает уведомление
+3. **Given** в цепочке остаётся только финальный GLM fallback или цепочка полностью деградировала, **When** срабатывает alert, **Then** администратор получает уведомление
 
 ---
 
@@ -65,37 +66,37 @@
 
 ### Edge Cases
 
-- Что происходит при одновременном отказе GLM и Ollama?
+- Что происходит при одновременном отказе primary, Ollama и Claude?
 - Как система обрабатывает race conditions при множественных instance?
 - Что происходит при cold start Ollama (первая загрузка модели ~30-60s)?
-- Как обрабатываются timeout при медленном ответе GLM?
+- Как обрабатываются timeout при медленном ответе финального `glm::glm-5.1`?
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: System MUST запускать Ollama как sidecar-контейнер в docker-compose.prod.yml
-- **FR-002**: System MUST автоматически переключаться на Ollama при недоступности GLM API
+- **FR-002**: System MUST автоматически переключаться на следующий configured fallback model при недоступности текущего провайдера
 - **FR-003**: System MUST реализовывать Circuit Breaker pattern с состояниями (CLOSED, OPEN, HALF-OPEN)
 - **FR-004**: System MUST проверять health обоих провайдеров с интервалом 5 секунд
-- **FR-005**: System MUST автоматически возвращаться к GLM при восстановлении (graceful recovery)
+- **FR-005**: System MUST автоматически возвращаться к `openai-codex::gpt-5.4` при восстановлении primary (graceful recovery)
 - **FR-006**: System MUST сохранять state failover в `/tmp/moltis-llm-state.json`
 - **FR-007**: System MUST экспортировать метрики для Prometheus (`llm_fallback_triggered_total`, `llm_provider_available`)
 - **FR-008**: System MUST валидировать Ollama конфигурацию в preflight job CI/CD
 - **FR-009**: System MUST выполнять smoke tests для failover в verify job CI/CD
-- **FR-010**: System MUST управлять OLLAMA_API_KEY через Docker secrets
+- **FR-010**: System MUST управлять `OLLAMA_API_KEY`, `ANTHROPIC_API_KEY` и `GLM_API_KEY` через runtime environment / secret management без hardcoded значений
 
 ### Non-Functional Requirements
 
 - **NFR-001**: Resource limits для Ollama: 4 CPUs, 8GB RAM
 - **NFR-002**: RTO (Recovery Time Objective) < 5 минут
 - **NFR-003**: SLI Availability: 99.5% (включая fallback)
-- **NFR-004**: SLI Latency: P95 < 5s для GLM, P95 < 15s для Ollama fallback
+- **NFR-004**: SLI Latency: P95 < 5s для primary `openai-codex::gpt-5.4`, P95 < 15s для fallback lanes
 - **NFR-005**: GitOps compliant: вся конфигурация в git, secrets через Docker secrets
 
 ### Key Entities
 
-- **LLM Provider**: Сущность, представляющая LLM провайдера (GLM или Ollama). Атрибуты: name, status (available/unavailable), latency, error_count
+- **LLM Provider**: Сущность, представляющая LLM провайдера в ordered chain (`openai-codex`, `ollama`, `anthropic`, `glm`). Атрибуты: name, status (available/unavailable), latency, error_count
 - **Circuit Breaker State**: Текущее состояние circuit breaker. Атрибуты: state (CLOSED/OPEN/HALF-OPEN), failure_count, last_failure_time, last_success_time
 - **Failover Event**: Событие переключения между провайдерами. Атрибуты: timestamp, from_provider, to_provider, reason
 
@@ -103,8 +104,8 @@
 
 ### Measurable Outcomes
 
-- **SC-001**: При падении GLM API, система переключается на Ollama за < 30 секунд (3 consecutive failures × 5s interval + processing time)
-- **SC-002**: При восстановлении GLM, система возвращается к primary провайдеру за < 5 минут (half-open test cycle)
+- **SC-001**: При падении `openai-codex::gpt-5.4`, система переключается на Ollama за < 30 секунд (3 consecutive failures × 5s interval + processing time)
+- **SC-002**: При последовательном отказе primary и Ollama система доходит до Claude/GLM-5.1 без raw `model ... not found` или `No models available` leakage
 - **SC-003**: Метрики failover доступны в Prometheus и корректно отображают состояние провайдеров
 - **SC-004**: CI/CD pipeline падает при некорректной конфигурации Ollama (validation работает)
 - **SC-005**: Smoke tests в verify job проходят успешно при корректной конфигурации
@@ -114,7 +115,7 @@
 - OLLAMA_API_KEY будет получен пользователем через подписку на ollama.com
 - Сервер имеет достаточно ресурсов (4+ CPUs, 8GB+ RAM) для Ollama контейнера
 - Moltis поддерживает множественные LLM providers через конфигурацию
-- GLM API имеет health endpoint или можно определить availability по response status
+- Официальный BigModel Coding Plan endpoint `https://open.bigmodel.cn/api/coding/paas/v4` остаётся допустимым финальным fallback для `glm::glm-5.1`
 
 ## Out of Scope
 
@@ -138,7 +139,7 @@
 | Ollama cold start (~60s) | High | Предзагрузка модели при старте контейнера |
 | Memory competition с Moltis | Medium | Resource limits для Ollama (8GB) |
 | Race conditions при failover | Medium | File locking для state file |
-| GLM API false positives | Low | Настройка timeout и retry logic |
+| Final GLM-5.1 false positives | Low | Настройка timeout и retry logic для official BigModel endpoint |
 
 ## References
 

--- a/specs/001-moltis-docker-deploy/plan.md
+++ b/specs/001-moltis-docker-deploy/plan.md
@@ -7,7 +7,7 @@
 
 Deploy Moltis AI assistant as a Docker container on ainetic.tech server with:
 - **Reverse Proxy**: Traefik (already deployed) with automatic TLS
-- **LLM Provider**: GLM (Zhipu AI) via OpenAI-compatible endpoint
+- **LLM Provider**: Primary `openai-codex::gpt-5.4` with ordered fallback `ollama -> anthropic -> glm::glm-5.1`
 - **Auto-updates**: Watchtower for automatic container updates
 - **Backup**: Daily cron backup with 7-day retention
 - **Authentication**: MOLTIS_PASSWORD for initial setup
@@ -109,8 +109,8 @@ moltinger/
                                       │
                                       ▼
                     ┌─────────────────────────────────────────┐
-                    │   GLM API (api.z.ai)                    │
-                    │   OpenAI-compatible endpoint            │
+                    │  Provider Chain                         │
+                    │  Codex -> Ollama -> Claude -> GLM 5.1  │
                     └─────────────────────────────────────────┘
 ```
 
@@ -127,7 +127,7 @@ Primary deployment configuration with:
 ### 2. config/moltis.toml
 
 Moltis configuration with:
-- GLM provider settings
+- ordered provider-chain settings
 - Sandbox configuration
 - Authentication settings
 - Memory system settings
@@ -154,7 +154,7 @@ Routing configuration:
 | Traefik | 3.x | Reverse proxy (existing) |
 | Moltis | latest | AI assistant |
 | Watchtower | latest | Auto-updates |
-| GLM API | v4 | LLM provider |
+| Provider chain | live | Codex primary + ordered fallbacks |
 
 ## Security Considerations
 
@@ -168,7 +168,7 @@ Routing configuration:
 
 1. **Phase 1**: Deploy basic container (no sandbox)
 2. **Phase 2**: Configure Traefik labels
-3. **Phase 3**: Setup GLM provider
+3. **Phase 3**: Setup provider chain and fallback policy
 4. **Phase 4**: Enable sandbox (Docker socket)
 5. **Phase 5**: Configure backups
 6. **Phase 6**: Enable Watchtower

--- a/specs/001-moltis-docker-deploy/research.md
+++ b/specs/001-moltis-docker-deploy/research.md
@@ -25,26 +25,44 @@ Research completed via deep documentation analysis from https://docs.moltis.org/
 
 ---
 
-### 2. LLM Provider
+### 2. LLM Provider Chain
 
-**Decision**: GLM (Zhipu AI) via OpenAI-compatible endpoint
+**Decision**: Primary `openai-codex::gpt-5.4` with ordered fallback `ollama -> anthropic -> glm::glm-5.1`
 
-**Rationale**: User's preferred provider with coding-focused models.
+**Rationale**: Moltis should keep Codex as the preferred coding model while preserving an explicit failover chain. Legacy Z.ai API-key usage is no longer acceptable outside IDE-only coding flows, so GLM remains only as the final fallback via the official BigModel endpoint.
 
-**Endpoint**: `https://api.z.ai/api/coding/paas/v4`
+**Final GLM Endpoint**: `https://open.bigmodel.cn/api/coding/paas/v4`
 
 **Configuration**:
 ```toml
-[providers.glm-coding]
+[providers.openai-codex]
 enabled = true
-base_url = "https://api.z.ai/api/coding/paas/v4"
-model = "glm-4-plus"
+
+[providers.ollama]
+enabled = true
+
+[providers.anthropic]
+enabled = true
+
+[providers.openai]
+enabled = true
+alias = "glm"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+model = "glm-5.1"
+models = ["glm-5.1"]
+
+[failover]
+fallback_models = [
+  "ollama::gemini-3-flash-preview:cloud",
+  "anthropic::claude-sonnet-4-20250514",
+  "glm::glm-5.1",
+]
 ```
 
 **Alternatives Considered**:
-- OpenAI Codex — rejected: user preference for GLM
-- GitHub Copilot — rejected: requires subscription
-- Local LLM — rejected: hardware constraints
+- Z.ai Coding API keys — rejected: provider policy no longer allows non-IDE API-key usage without account risk
+- GLM as primary provider — rejected: operational policy now reserves GLM for final fallback only
+- Local-only LLM — rejected: hardware constraints and weaker coding quality for the primary lane
 
 ---
 

--- a/specs/001-moltis-docker-deploy/spec.md
+++ b/specs/001-moltis-docker-deploy/spec.md
@@ -11,7 +11,7 @@
 ### Session 2026-02-14
 
 - Q: Какой reverse proxy использовать? → A: **Traefik** (уже развёрнут на сервере)
-- Q: Какой LLM провайдер использовать? → A: **GLM (Zhipu AI)** через OpenAI-compatible endpoint `https://api.z.ai/api/coding/paas/v4`
+- Q: Какой LLM провайдер использовать? → A: **Primary `openai-codex::gpt-5.4` + ordered fallback `ollama -> anthropic -> glm::glm-5.1`**, где GLM идёт только через официальный BigModel endpoint `https://open.bigmodel.cn/api/coding/paas/v4`
 - Q: Как обновлять контейнер Moltis? → A: **Watchtower** для автоматических обновлений
 - Q: Нужна ли стратегия backup для volumes? → A: **Cron backup** — ежедневное резервирование с rotation 7 дней
 - Q: Что НЕ входит в scope? → A: **Базовый out-of-scope** — кластеризация, multi-region, SLA guarantees
@@ -214,7 +214,7 @@
 - **Data Volume**: Персистентное хранилище для баз данных, сессий, memory files, логов (путь: /home/moltis/.moltis)
 - **Docker Socket**: Unix socket для доступа к Docker daemon, необходим для sandboxed выполнения команд
 - **Reverse Proxy**: Traefik (уже развёрнут на сервере) для TLS-терминации и маршрутизации трафика
-- **LLM Provider**: GLM (Zhipu AI) через OpenAI-compatible endpoint `https://api.z.ai/api/coding/paas/v4`
+- **LLM Provider**: primary `openai-codex::gpt-5.4` с fallback-цепочкой `ollama -> anthropic -> glm::glm-5.1`, где GLM использует официальный BigModel endpoint `https://open.bigmodel.cn/api/coding/paas/v4`
 - **Credentials**: Пароли (Argon2id хеш), passkeys (WebAuthn), API keys (SHA-256 хеш), session cookies
 
 ## Success Criteria *(mandatory)*
@@ -475,30 +475,51 @@ services:
 
 ---
 
-## LLM Provider Configuration (GLM)
+## LLM Provider Configuration (Primary Codex + Ordered Fallbacks)
 
 ### Endpoint
 
-**Base URL**: `https://api.z.ai/api/coding/paas/v4`
+**Primary**: `openai-codex::gpt-5.4`
+**Fallbacks**: `ollama::gemini-3-flash-preview:cloud` → `anthropic::claude-sonnet-4-20250514` → `glm::glm-5.1`
+**Final GLM Base URL**: `https://open.bigmodel.cn/api/coding/paas/v4`
 
 **Auth**: API Key (хранится в `provider_keys.json`)
 
 ### Configuration (moltis.toml)
 
 ```toml
-[providers]
-default = "glm-coding"
-
-[providers.glm-coding]
+[providers.openai-codex]
 enabled = true
-# OpenAI-compatible endpoint для GLM
-base_url = "https://api.z.ai/api/coding/paas/v4"
-model = "glm-4-plus"  # или другая модель из линейки
+model = "gpt-5.4"
+alias = "openai-codex"
+models = ["gpt-5.4"]
+
+[providers.ollama]
+enabled = true
+base_url = "http://ollama:11434"
+model = "gemini-3-flash-preview:cloud"
+alias = "ollama"
+api_key = "${OLLAMA_API_KEY}"
+
+[providers.anthropic]
+enabled = true
+api_key = "${ANTHROPIC_API_KEY}"
+model = "claude-sonnet-4-20250514"
+base_url = "https://api.anthropic.com"
+alias = "anthropic"
+
+[providers.openai]
+enabled = true
+api_key = "${GLM_API_KEY}"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+model = "glm-5.1"
+alias = "glm"
+models = ["glm-5.1"]
 ```
 
 ### API Key Setup
 
-API key для GLM устанавливается через Web UI при первом запуске или напрямую в `~/.config/moltis/provider_keys.json`.
+OAuth / provider keys устанавливаются через Web UI при первом запуске или напрямую в `~/.config/moltis/provider_keys.json`, но Z.ai-specific provider aliases больше не используются.
 
 ---
 

--- a/specs/001-moltis-docker-deploy/tasks.md
+++ b/specs/001-moltis-docker-deploy/tasks.md
@@ -338,23 +338,24 @@
 
 ---
 
-## Phase 14: GLM Provider Configuration
+## Phase 14: Primary Codex + Ordered Fallback Chain
 
-**Goal**: Configure GLM as LLM provider
+**Goal**: Configure the production provider chain with Codex primary and ordered fallbacks `ollama -> anthropic -> glm::glm-5.1`
 
 **Independent Test**:
 1. Open Web UI
-2. Configure GLM provider
-3. Send test message
+2. Verify `openai-codex::gpt-5.4` remains the primary model
+3. Verify fallback order is `ollama`, then `anthropic`, then official BigModel `glm::glm-5.1`
+4. Send a test message without any raw provider/tool leakage
 
 ### Implementation
 
-- [X] T052 [P] Create config/moltis.toml with GLM provider settings
-- [X] T053 Add GLM base_url: `https://api.z.ai/api/coding/paas/v4`
-- [X] T054 Add GLM_API_KEY to .env.example
-- [ ] T055 Test GLM provider in Web UI
+- [X] T052 [P] Create `config/moltis.toml` with primary Codex plus ordered fallback-chain settings
+- [X] T053 Add official BigModel GLM base_url: `https://open.bigmodel.cn/api/coding/paas/v4`
+- [X] T054 Add provider-chain secret requirements to `.env.example` and deployment docs (`OLLAMA_API_KEY`, `ANTHROPIC_API_KEY`, `GLM_API_KEY`)
+- [ ] T055 Test Web UI and Telegram entrypoints against the ordered provider chain
 
-**Checkpoint**: GLM provider working
+**Checkpoint**: Provider chain working without legacy Z.ai aliases
 
 **Artifacts**:
 - `config/moltis.toml`
@@ -394,7 +395,7 @@
 - **Phase 9-11 (US7-US9 - Docs)**: Can run in parallel after Phase 2
 - **Phase 12 (Backup)**: Depends on Phase 2
 - **Phase 13 (Watchtower)**: Depends on Phase 2
-- **Phase 14 (GLM)**: Depends on Phase 3
+- **Phase 14 (Provider Chain)**: Depends on Phase 3
 - **Phase 15 (Polish)**: Depends on all previous phases
 
 ### Critical Path (MVP)
@@ -402,7 +403,7 @@
 ```
 Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 14
           ↓
-       (MVP ready after Phase 5 + GLM)
+       (MVP ready after Phase 5 + provider chain)
 ```
 
 ### Parallel Opportunities
@@ -425,12 +426,12 @@ Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 14
 3. Complete Phase 3: Container Deployment
 4. Complete Phase 4: Traefik Configuration
 5. Complete Phase 5: Authentication
-6. Complete Phase 14: GLM Provider
+6. Complete Phase 14: Provider Chain
 7. **STOP and VALIDATE**: Full deployment working
 
 ### Incremental Delivery
 
-1. **MVP**: Container + Traefik + Auth + GLM → Basic working AI assistant
+1. **MVP**: Container + Traefik + Auth + primary/fallback provider chain → Basic working AI assistant
 2. **Add**: Sandbox + Persistence → Full functionality
 3. **Add**: Backup + Watchtower → Operations
 4. **Add**: Health + Telemetry → Observability
@@ -501,7 +502,7 @@ Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 14
 
 - [ ] S001 Clone repository on server: `git clone https://github.com/RussianLioN/moltinger.git /opt/moltinger`
 - [ ] S002 Setup environment: `cp .env.example .env && nano .env`
-- [ ] S003 Add secrets to .env (MOLTIS_PASSWORD, GLM_API_KEY)
+- [ ] S003 Add secrets to `.env` (`MOLTIS_PASSWORD`, `OLLAMA_API_KEY`, `ANTHROPIC_API_KEY`, `GLM_API_KEY`)
 - [ ] S004 Run `make setup` to create networks and secrets
 - [ ] S005 Run `make deploy` for initial deployment
 - [ ] S006 Verify health: `curl https://ainetic.tech/health`

--- a/tests/component/test_moltis_runtime_attestation.sh
+++ b/tests/component/test_moltis_runtime_attestation.sh
@@ -192,6 +192,8 @@ create_workspace_fixture() {
     git -C "$workspace_root" init -q
     git -C "$workspace_root" config user.name "Codex Test"
     git -C "$workspace_root" config user.email "codex@example.com"
+    git -C "$workspace_root" config core.hooksPath /dev/null
+    git -C "$workspace_root" config commit.gpgsign false
     printf 'runtime\n' >"$workspace_root/runtime.txt"
     cat >"$workspace_root/config/moltis.toml" <<EOF
 [memory]
@@ -329,6 +331,48 @@ EOF
        [[ "$(jq -r '.details.auth_status_valid' "$output_json")" != "true" ]] || \
        [[ "$(jq -r '.details.auth_validation_path' "$output_json")" != "status" ]]; then
         test_fail "Runtime attestation success output does not reflect the expected provenance details"
+        rm -rf "$fixture_root"
+        return
+    fi
+    test_pass
+
+    cat >"$runtime_config_dir/provider_keys.json" <<'EOF'
+{
+  "openai-codex": {
+    "models": ["gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark"]
+  },
+  "zai": {
+    "models": ["glm-5.1"]
+  },
+  "custom-zai-telegram-safe": {
+    "models": ["glm-5"]
+  }
+}
+EOF
+
+    test_start "component_runtime_attestation_fails_when_legacy_runtime_provider_aliases_survive"
+    set +e
+    PATH="$fake_bin:$PATH" \
+        FAKE_DOCKER_MOUNTS_FILE="$mounts_file" \
+        FAKE_MOLTIS_VERSION="0.10.18" \
+        FAKE_DOCKER_STATE="healthy" \
+        FAKE_DOCKER_WORKDIR="/server" \
+        FAKE_CURL_HTTP_CODE="200" \
+        FAKE_LIVE_GIT_SHA="$live_sha" \
+        MOLTIS_RUNTIME_CONFIG_DIR_ALLOWLIST="$runtime_config_dir" \
+        bash "$ATTESTATION_SCRIPT" \
+            --json \
+            --deploy-path "$workspace_root" \
+            --active-path "$active_root" \
+            --expected-auth-provider "openai-codex" >"$output_json" 2>"$fixture_root/stderr-legacy-runtime-provider-aliases.log"
+    exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]] || \
+       [[ "$(jq -r '.status' "$output_json")" != "failure" ]] || \
+       ! jq -e '.errors[] | select(.code == "LEGACY_RUNTIME_PROVIDER_ALIAS_PRESENT")' "$output_json" >/dev/null 2>&1 || \
+       [[ "$(jq -r '.details.legacy_runtime_provider_aliases | join(",")' "$output_json")" != "zai,custom-zai-telegram-safe" ]]; then
+        test_fail "Runtime attestation must fail when provider_keys.json still exposes removed legacy provider aliases"
         rm -rf "$fixture_root"
         return
     fi

--- a/tests/component/test_moltis_search_memory_diagnostics.sh
+++ b/tests/component/test_moltis_search_memory_diagnostics.sh
@@ -35,7 +35,7 @@ EOF
 {"message":"MCP auto-restart failed"}
 {"tool":"mcp__tavily__tavily_search","message":"tool invocation"}
 {"tool":"memory_search","message":"tool execution failed"}
-all embedding providers failed: openai: HTTP status client error (400 Bad Request) for url (https://api.z.ai/api/coding/paas/v4/embeddings); groq: HTTP status client error (401 Unauthorized) for url (https://api.groq.com/openai/v1/embeddings)
+all embedding providers failed: openai: HTTP status client error (400 Bad Request) for url (https://open.bigmodel.cn/api/coding/paas/v4/embeddings); groq: HTTP status client error (401 Unauthorized) for url (https://api.groq.com/openai/v1/embeddings)
 EOF
 
     test_start "component_diagnostics_script_parses_tavily_and_embedding_failure_taxonomy"

--- a/tests/component/test_prepare_moltis_runtime_config.sh
+++ b/tests/component/test_prepare_moltis_runtime_config.sh
@@ -23,6 +23,11 @@ run_component_prepare_moltis_runtime_config_tests() {
 enabled = true
 model = "gpt-5.4"
 models = ["gpt-5.4"]
+
+[providers.openai]
+enabled = true
+model = "glm-5.1"
+alias = "glm"
 EOF
     printf 'tracked\n' >"$static_dir/subdir/marker.txt"
 
@@ -35,6 +40,9 @@ EOF
     "models": ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
   },
   "zai": {
+    "models": ["glm-5-turbo", "glm-5"]
+  },
+  "custom-zai-telegram-safe": {
     "models": ["glm-5"]
   }
 }
@@ -52,8 +60,15 @@ EOF
 
     if [[ "$(jq -r '."openai-codex".models[0]' "$runtime_dir/provider_keys.json")" != "gpt-5.4" ]] || \
        [[ "$(jq -r '."openai-codex".models[1]' "$runtime_dir/provider_keys.json")" != "gpt-5.4-mini" ]] || \
-       [[ "$(jq -r '.zai.models[0]' "$runtime_dir/provider_keys.json")" != "glm-5" ]]; then
-        test_fail "prepare-moltis-runtime-config.sh must keep tracked gpt-5.4 first while preserving the rest of provider_keys.json"
+       [[ "$(jq -r '.glm.models[0]' "$runtime_dir/provider_keys.json")" != "glm-5.1" ]] || \
+       [[ "$(jq -r '.glm.models[1]' "$runtime_dir/provider_keys.json")" != "glm-5" ]]; then
+        test_fail "prepare-moltis-runtime-config.sh must keep tracked provider preferences primary while migrating legacy Z.ai aliases"
+        rm -rf "$fixture_root"
+        return
+    fi
+
+    if jq -e '.zai or .["custom-zai-telegram-safe"] or .["zai-telegram-safe"]' "$runtime_dir/provider_keys.json" >/dev/null 2>&1; then
+        test_fail "prepare-moltis-runtime-config.sh must remove legacy Z.ai runtime aliases from provider_keys.json"
         rm -rf "$fixture_root"
         return
     fi

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -47,7 +47,7 @@ run_component_telegram_safe_llm_guard_tests() {
     local before_llm_output
     before_llm_output="$(
         run_hook_with_minimal_path \
-            '{"event":"BeforeLLMCall","data":{"session_key":"session:abc","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Ты можешь сейчас изучить полностью официальную инструкцию на Moltis и пошагово научить меня создавать новый навык на примере?"}],"tool_count":37,"iteration":1}}'
+            '{"event":"BeforeLLMCall","data":{"session_key":"session:abc","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Ты можешь сейчас изучить полностью официальную инструкцию на Moltis и пошагово научить меня создавать новый навык на примере?"}],"tool_count":37,"iteration":1}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_output" && \
        jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_output" && \
@@ -67,7 +67,7 @@ run_component_telegram_safe_llm_guard_tests() {
     local before_llm_no_tool_count_output
     before_llm_no_tool_count_output="$(
         run_hook_with_minimal_path \
-            '{"event":"BeforeLLMCall","data":{"session_key":"session:abd","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Изучи полностью официальную документацию Moltis и научи меня делать новый навык"}],"iteration":1}}'
+            '{"event":"BeforeLLMCall","data":{"session_key":"session:abd","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Изучи полностью официальную документацию Moltis и научи меня делать новый навык"}],"iteration":1}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_no_tool_count_output" && \
        jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_no_tool_count_output" && \
@@ -88,7 +88,7 @@ run_component_telegram_safe_llm_guard_tests() {
             MOLTIS_RUNTIME_SKILLS_ROOT="$before_llm_skill_turn_root" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:abg","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Давай создадим навык codex-update-new"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:abg","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Давай создадим навык codex-update-new"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_skill_turn_output" && \
@@ -109,7 +109,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:abv","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:abv","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_skill_visibility_output" && \
@@ -129,7 +129,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:abvh","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Давай создадим навык codex-update-new"},{"role":"assistant","content":"Опиши навык подробнее."},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:abvh","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Давай создадим навык codex-update-new"},{"role":"assistant","content":"Опиши навык подробнее."},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_skill_visibility_history_output" && \
@@ -151,7 +151,7 @@ EOF
             MOLTIS_RUNTIME_SKILLS_ROOT="$before_llm_skill_create_history_root" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:abgi","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"},{"role":"assistant","content":"Навыки (2): codex-update, telegram-learner."},{"role":"user","content":"Создай навык codex-update-new"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:abgi","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"},{"role":"assistant","content":"Навыки (2): codex-update, telegram-learner."},{"role":"user","content":"Создай навык codex-update-new"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_skill_create_history_output" && \
@@ -208,7 +208,7 @@ EOF
     before_llm_skill_apply_output="$(
         env PATH="$MINIMAL_PATH" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:skill-apply-hard","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Давай применим навык codex-update"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:skill-apply-hard","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Давай применим навык codex-update"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_skill_apply_output" && \
@@ -267,7 +267,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_status_send_script" \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_status_stdout" 2>"$fastpath_status_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:faststatus","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"/status"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:faststatus","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"/status"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_status_status=$?
     set -e
@@ -981,7 +981,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_visibility_stdout" 2>"$fastpath_visibility_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:fastvis","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastvis","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_visibility_status=$?
     set -e
@@ -1021,7 +1021,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_template_send_script" \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_template_stdout" 2>"$fastpath_template_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:fasttemplate","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"assistant","content":"Сначала покажу шаблон навыка."},{"role":"user","content":"У тебя должен быть темплейт"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:fasttemplate","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"assistant","content":"Сначала покажу шаблон навыка."},{"role":"user","content":"У тебя должен быть темплейт"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_template_status=$?
     set -e
@@ -1088,7 +1088,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_skill_detail_send_script" \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_skill_detail_stdout" 2>"$fastpath_skill_detail_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:fastdetail","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Расскажи мне про навык telegram-lerner"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastdetail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Расскажи мне про навык telegram-lerner"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_skill_detail_status=$?
     set -e
@@ -1143,7 +1143,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_skill_detail_armfail_send_script" \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_skill_detail_armfail_stdout" 2>"$fastpath_skill_detail_armfail_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:fastdetail-armfail","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Расскажи мне про навык telegram-lerner"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastdetail-armfail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Расскажи мне про навык telegram-lerner"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_skill_detail_armfail_status=$?
     set -e
@@ -1381,7 +1381,7 @@ EOF
         MOLTIS_RUNTIME_SKILLS_ROOT="$fastpath_runtime_skills_root" \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
         bash "$HOOK_HANDLER" >"$fastpath_create_stdout" 2>"$fastpath_create_stderr" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:fastcreate","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай навык codex-update-new-fastpath"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastcreate","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай навык codex-update-new-fastpath"}],"tool_count":37,"iteration":1}}
 EOF
     fastpath_create_status=$?
     set -e
@@ -1409,7 +1409,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$direct_fastpath_tool_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeToolCall","session_key":"session:fastcreate","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","tool":"create_skill","arguments":{"name":"codex-update-new-fastpath"}}
+{"event":"BeforeToolCall","session_key":"session:fastcreate","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"create_skill","arguments":{"name":"codex-update-new-fastpath"}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$direct_fastpath_tool_output" && \
@@ -1937,7 +1937,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$stale_direct_fastpath_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:plain-followup","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Привет"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:plain-followup","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Привет"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$stale_direct_fastpath_output" && \
@@ -1975,7 +1975,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$stale_status_template_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:template-followup","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"<available_skills>\n- codex-update\n</available_skills>"},{"role":"assistant","content":"Статус: Online\nКанал: Telegram (@moltinger_bot)\nМодель: custom-zai-telegram-safe::glm-5\nПровайдер: custom-zai-telegram-safe\nРежим: safe-text"},{"role":"user","content":"У тебя должен быть темплейт"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:template-followup","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"<available_skills>\n- codex-update\n</available_skills>"},{"role":"assistant","content":"Статус: Online\nКанал: Telegram (@moltinger_bot)\nМодель: openai-codex::gpt-5.4\nПровайдер: openai-codex\nРежим: safe-text"},{"role":"user","content":"У тебя должен быть темплейт"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     stale_status_template_intent="$(cat "$stale_status_template_dir/session_template-followup.intent" 2>/dev/null || true)"
@@ -1995,7 +1995,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$stale_visibility_template_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:template-after-visibility","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis\n<available_skills>\n- codex-update\n</available_skills>"},{"role":"assistant","content":"Навыки (3): codex-update, post-close-task-classifier, telegram-learner."},{"role":"user","content":"У тебя должен быть темплейт"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:template-after-visibility","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis\n<available_skills>\n- codex-update\n</available_skills>"},{"role":"assistant","content":"Навыки (3): codex-update, post-close-task-classifier, telegram-learner."},{"role":"user","content":"У тебя должен быть темплейт"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     stale_visibility_template_intent="$(cat "$stale_visibility_template_dir/session_template-after-visibility.intent" 2>/dev/null || true)"
@@ -2017,7 +2017,7 @@ EOF
             MOLTIS_RUNTIME_SKILLS_ROOT="$stale_visibility_create_dir/runtime" \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$stale_visibility_create_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:create-after-visibility","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"assistant","content":"Навыки (3): codex-update, post-close-task-classifier, telegram-learner."},{"role":"user","content":"Создай навык codex-update-new-from-stale"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:create-after-visibility","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"assistant","content":"Навыки (3): codex-update, post-close-task-classifier, telegram-learner."},{"role":"user","content":"Создай навык codex-update-new-from-stale"}],"tool_count":37,"iteration":1}}
 EOF
     )"
     stale_visibility_create_intent="$(cat "$stale_visibility_create_dir/session_create-after-visibility.intent" 2>/dev/null || true)"
@@ -2120,7 +2120,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeLLMCall","data":{"session_key":"session:abgj","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Создай навык codex-update-new"},{"role":"assistant","content":"Окей, создаём `codex-update-new`. Мне нужны детали: описание, тело инструкций и разрешённые инструменты. Что должен делать этот навык?"},{"role":"user","content":"Следить за версиями Codex CLI и уведомлять пользователя о новых релизах."}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:abgj","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Создай навык codex-update-new"},{"role":"assistant","content":"Окей, создаём `codex-update-new`. Мне нужны детали: описание, тело инструкций и разрешённые инструменты. Что должен делать этот навык?"},{"role":"user","content":"Следить за версиями Codex CLI и уведомлять пользователя о новых релизах."}],"tool_count":37,"iteration":1}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_skill_followup_output" && \
@@ -2138,7 +2138,7 @@ EOF
     local before_llm_existing_guard_output
     before_llm_existing_guard_output="$(
         run_hook_with_minimal_path \
-            '{"event":"BeforeLLMCall","data":{"session_key":"session:abf","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"system","content":"Telegram-safe long-research guard: stale copy"},{"role":"user","content":"Изучи полностью официальную документацию Moltis и научи меня делать новый навык"}],"tool_count":37,"iteration":2}}'
+            '{"event":"BeforeLLMCall","data":{"session_key":"session:abf","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"system","content":"Telegram-safe long-research guard: stale copy"},{"role":"user","content":"Изучи полностью официальную документацию Moltis и научи меня делать новый навык"}],"tool_count":37,"iteration":2}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_existing_guard_output" && \
        jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_existing_guard_output" && \
@@ -2154,7 +2154,7 @@ EOF
     local before_llm_general_output
     before_llm_general_output="$(
         run_hook_with_minimal_path \
-            '{"event":"BeforeLLMCall","data":{"session_key":"session:abe","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Ответь кратко, что умеет этот бот."}],"tool_count":37,"iteration":1}}'
+            '{"event":"BeforeLLMCall","data":{"session_key":"session:abe","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Ответь кратко, что умеет этот бот."}],"tool_count":37,"iteration":1}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_general_output" && \
        jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_general_output" && \
@@ -2172,7 +2172,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeToolCall","data":{"session_key":"session:tool","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","tool":"exec","arguments":{"command":"ls -la ~/.moltis/skills/"}}}
+{"event":"BeforeToolCall","data":{"session_key":"session:tool","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"exec","arguments":{"command":"ls -la ~/.moltis/skills/"}}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_tool_exec_output" && \
@@ -2191,7 +2191,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"BeforeToolCall","data":{"session_key":"session:toolq","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","tool":"exec","arguments":{"command":"bash -lc \"ls -la ~/.moltis/skills/\""}}}
+{"event":"BeforeToolCall","data":{"session_key":"session:toolq","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"exec","arguments":{"command":"bash -lc \"ls -la ~/.moltis/skills/\""}}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_tool_quoted_exec_output" && \
@@ -2210,7 +2210,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$top_level_tool_intent_dir" \
         MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
         bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
-{"event":"BeforeLLMCall","data":{"session_key":"session:tooltop","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:tooltop","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
 EOF
     before_tool_top_level_output="$(
         env PATH="$MINIMAL_PATH" \
@@ -2237,7 +2237,7 @@ EOF
     env PATH="$MINIMAL_PATH" \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$top_level_status_intent_dir" \
         bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
-{"event":"BeforeLLMCall","data":{"session_key":"session:toolstatus","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984"},{"role":"user","content":"/status"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:toolstatus","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984"},{"role":"user","content":"/status"}],"tool_count":37,"iteration":1}}
 EOF
     before_tool_status_output="$(
         env PATH="$MINIMAL_PATH" \
@@ -2262,7 +2262,7 @@ EOF
     local before_tool_create_output
     before_tool_create_output="$(
         run_hook_with_minimal_path \
-            '{"event":"BeforeToolCall","data":{"session_key":"session:tool2","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","tool":"create_skill","arguments":{"name":"codex-update-new"}}}'
+            '{"event":"BeforeToolCall","data":{"session_key":"session:tool2","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"create_skill","arguments":{"name":"codex-update-new"}}}'
     )"
     if [[ -z "$before_tool_create_output" ]]; then
         test_pass
@@ -2285,6 +2285,22 @@ EOF
         test_pass
     else
         test_fail "BeforeToolCall guard must fail closed on disallowed browser-style tools while keeping the safe-lane note aligned with the Tavily passthrough contract"
+    fi
+
+    test_start "component_before_tool_guard_suppresses_non_telegram_malformed_known_tools"
+    local before_tool_non_telegram_malformed_output
+    before_tool_non_telegram_malformed_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:nontelegram-tool-malformed","provider":"glm","model":"glm::glm-5.1","tool":"exec","arguments":{"cmd":"cat /home/moltis/.moltis/skills/codex-update/SKILL.md"}}}'
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_tool_non_telegram_malformed_output" && \
+       jq -e '.data.session_key == "session:nontelegram-tool-malformed"' >/dev/null 2>&1 <<<"$before_tool_non_telegram_malformed_output" && \
+       jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$before_tool_non_telegram_malformed_output" && \
+       jq -e '.data.tool_name == "exec"' >/dev/null 2>&1 <<<"$before_tool_non_telegram_malformed_output" && \
+       jq -e '.data.arguments.command == "true"' >/dev/null 2>&1 <<<"$before_tool_non_telegram_malformed_output"; then
+        test_pass
+    else
+        test_fail "BeforeToolCall guard must rewrite malformed known-tool calls into a harmless exec no-op outside Telegram-safe lane as well"
     fi
 
     test_start "component_before_tool_guard_allows_tavily_passthrough_in_safe_lane"
@@ -2358,13 +2374,13 @@ EOF
     local after_status_output
     after_status_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:ghi","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"**Статус системы**\nПроцессы в tmux: нет\nМодель: zai::glm-5","tool_calls":[{"name":"process","arguments":{"action":"list"}},{"name":"cron","arguments":{"action":"list"}}]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:ghi","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"**Статус системы**\nПроцессы в tmux: нет\nМодель: openai-codex::gpt-5.4","tool_calls":[{"name":"process","arguments":{"action":"list"}},{"name":"cron","arguments":{"action":"list"}}]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_status_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_status_output" && \
        jq -e '.data.text == "Статус: Online\nКанал: Telegram (@moltinger_bot)\nМодель: openai-codex::gpt-5.4\nПровайдер: openai-codex\nРежим: safe-text"' >/dev/null 2>&1 <<<"$after_status_output" && \
-       jq -e '.data.provider == "custom-zai-telegram-safe"' >/dev/null 2>&1 <<<"$after_status_output" && \
-       jq -e '.data.model == "custom-zai-telegram-safe::glm-5"' >/dev/null 2>&1 <<<"$after_status_output"; then
+       jq -e '.data.provider == "openai-codex"' >/dev/null 2>&1 <<<"$after_status_output" && \
+       jq -e '.data.model == "openai-codex::gpt-5.4"' >/dev/null 2>&1 <<<"$after_status_output"; then
         test_pass
     else
         test_fail "AfterLLMCall guard must replace Telegram-safe status tool fallbacks with a canonical safe-text status reply without depending on jq in the runtime container"
@@ -2374,7 +2390,7 @@ EOF
     local after_general_output
     after_general_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:jkl","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Сейчас проверю через browser и cron.","tool_calls":[{"name":"browser","arguments":{"action":"navigate"}}]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:jkl","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Сейчас проверю через browser и cron.","tool_calls":[{"name":"browser","arguments":{"action":"navigate"}}]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_general_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_general_output" && \
@@ -2385,13 +2401,28 @@ EOF
         test_fail "AfterLLMCall guard must suppress general Telegram-safe tool fallbacks and replace them with a clean user-facing fallback"
     fi
 
+    test_start "component_after_llm_guard_fail_closes_non_telegram_missing_required_argument_tool_calls"
+    local after_non_telegram_malformed_output
+    after_non_telegram_malformed_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"AfterLLMCall","data":{"session_key":"session:nontelegram-malformed","provider":"glm","model":"glm::glm-5.1","text":"Сейчас проверю память и потом покажу лог ошибки.","tool_calls":[{"name":"memory_search","arguments":{}}]}}'
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_non_telegram_malformed_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_non_telegram_malformed_output" && \
+       jq -e '.data.text | contains("Внутренний tool-path сформировал некорректный вызов")' >/dev/null 2>&1 <<<"$after_non_telegram_malformed_output" && \
+       jq -e '.data.text | contains("не показываю сырые tool-ошибки")' >/dev/null 2>&1 <<<"$after_non_telegram_malformed_output"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall guard must fail closed for non-Telegram malformed known-tool calls so web/UI lanes never surface raw missing-parameter cards"
+    fi
+
     test_start "component_after_llm_guard_rewrites_generic_skill_count_reply_to_deterministic_runtime_skill_list"
     local after_skill_visibility_output
     after_skill_visibility_output="$(
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:skillvis","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"У меня 3 навыка. Ты спрашиваешь третий раз. Что ты хочешь сделать?","tool_calls":[],"messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:skillvis","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"У меня 3 навыка. Ты спрашиваешь третий раз. Что ты хочешь сделать?","tool_calls":[],"messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_visibility_output" && \
@@ -2408,7 +2439,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:skillvish","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"У меня 3 навыка. Что ты хочешь сделать?","tool_calls":[],"messages":[{"role":"system","content":"base system"},{"role":"user","content":"Создай навык codex-update-new"},{"role":"assistant","content":"Опиши его подробнее."},{"role":"user","content":"А что у тебя с навыками/skills?"}]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:skillvish","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"У меня 3 навыка. Что ты хочешь сделать?","tool_calls":[],"messages":[{"role":"system","content":"base system"},{"role":"user","content":"Создай навык codex-update-new"},{"role":"assistant","content":"Опиши его подробнее."},{"role":"user","content":"А что у тебя с навыками/skills?"}]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_visibility_history_output" && \
@@ -2425,7 +2456,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:skillstop","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"3 навыка в конфиге, файлов нет в sandbox. Стоп.","tool_calls":[]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:skillstop","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"3 навыка в конфиге, файлов нет в sandbox. Стоп.","tool_calls":[]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_visibility_stop_output" && \
@@ -2442,7 +2473,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:skillnofiles","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"3 навыка в конфиге. Файлов нет. Хочешь создать — дай инструкцию.","tool_calls":[]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:skillnofiles","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"3 навыка в конфиге. Файлов нет. Хочешь создать — дай инструкцию.","tool_calls":[]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_visibility_no_files_output" && \
@@ -2460,14 +2491,14 @@ EOF
         MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$persisted_intent_dir" \
         bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
-{"event":"BeforeLLMCall","data":{"session_key":"session:skillpersist-after","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:skillpersist-after","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
 EOF
     after_skill_visibility_persisted_output="$(
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$persisted_intent_dir" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:skillpersist-after","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"3 навыка. Создать новый?","tool_calls":[]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:skillpersist-after","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"3 навыка. Создать новый?","tool_calls":[]}}
 EOF
     )"
     rm -rf "$persisted_intent_dir"
@@ -2488,7 +2519,7 @@ EOF
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$stale_status_visibility_dir" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:status-visibility","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"assistant","content":"Статус: Online\nКанал: Telegram (@moltinger_bot)\nМодель: custom-zai-telegram-safe::glm-5\nПровайдер: custom-zai-telegram-safe\nРежим: safe-text"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"text":"**Навыки: 4 в конфиге, файлов нет в sandbox.** Ты 12-й раз спрашиваешь.","tool_calls":[]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:status-visibility","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"assistant","content":"Статус: Online\nКанал: Telegram (@moltinger_bot)\nМодель: openai-codex::gpt-5.4\nПровайдер: openai-codex\nРежим: safe-text"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"text":"**Навыки: 4 в конфиге, файлов нет в sandbox.** Ты 12-й раз спрашиваешь.","tool_calls":[]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_visibility_from_status_output" && \
@@ -2503,7 +2534,7 @@ EOF
     local after_skill_tool_output
     after_skill_tool_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:skilltool","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Пользователь просит создать навык. У меня есть доступ к create_skill. Сначала найду шаблон.","tool_calls":[{"name":"create_skill","arguments":{"name":"codex-update-new"}}]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:skilltool","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Пользователь просит создать навык. У меня есть доступ к create_skill. Сначала найду шаблон.","tool_calls":[{"name":"create_skill","arguments":{"name":"codex-update-new"}}]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_tool_output" && \
        jq -e '.data.tool_calls[0].name == "create_skill"' >/dev/null 2>&1 <<<"$after_skill_tool_output" && \
@@ -2557,7 +2588,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:skilltoolstop","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"3 навыка в конфиге, файлов нет в sandbox. Стоп.","tool_calls":[{"name":"create_skill","arguments":{"name":"codex-update-new"}}]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:skilltoolstop","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"3 навыка в конфиге, файлов нет в sandbox. Стоп.","tool_calls":[{"name":"create_skill","arguments":{"name":"codex-update-new"}}]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_tool_stop_output" && \
@@ -2573,7 +2604,7 @@ EOF
     local after_skill_false_negative_output
     after_skill_false_negative_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:false","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"По факту: папки /home/moltis/.moltis/skills/ не существует. Навыки либо были удалены, либо ещё не созданы.","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:false","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"По факту: папки /home/moltis/.moltis/skills/ не существует. Навыки либо были удалены, либо ещё не созданы.","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_false_negative_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_skill_false_negative_output" && \
@@ -2599,7 +2630,7 @@ EOF
     after_general_stdout_file="$(mktemp)"
     after_general_stderr_file="$(mktemp)"
     printf '%s\n' \
-        '{"event":"AfterLLMCall","data":{"session_key":"session:jkm","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Хорошо, Сергей! Начинаю прямо сейчас. Сначала найду официальную документацию Moltis и изучу существующий навык `codex-update`:","tool_calls":[]}}' \
+        '{"event":"AfterLLMCall","data":{"session_key":"session:jkm","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Хорошо, Сергей! Начинаю прямо сейчас. Сначала найду официальную документацию Moltis и изучу существующий навык `codex-update`:","tool_calls":[]}}' \
         | env PATH="$MINIMAL_PATH" bash "$HOOK_SCRIPT" >"$after_general_stdout_file" 2>"$after_general_stderr_file"
     after_general_output_clean="$(cat "$after_general_stdout_file")"
     after_general_stderr="$(cat "$after_general_stderr_file")"
@@ -2616,7 +2647,7 @@ EOF
     local telemetry_only_output
     telemetry_only_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:pqr","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"📋 Activity log • 💻 Running: `find /home/moltis/.moltis/skills` • 🧠 Searching memory...","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:pqr","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"📋 Activity log • 💻 Running: `find /home/moltis/.moltis/skills` • 🧠 Searching memory...","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$telemetry_only_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$telemetry_only_output" && \
@@ -2630,7 +2661,7 @@ EOF
     local tool_intent_output
     tool_intent_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qrs","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"No remote nodes available. Let me check the available skills and search the Moltis documentation for you.","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qrs","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"No remote nodes available. Let me check the available skills and search the Moltis documentation for you.","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$tool_intent_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$tool_intent_output" && \
@@ -2644,7 +2675,7 @@ EOF
     local observed_long_research_output
     observed_long_research_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qst","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Нашёл официальную документацию Moltis. Давай изучу её полностью:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qst","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Нашёл официальную документацию Moltis. Давай изучу её полностью:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$observed_long_research_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$observed_long_research_output" && \
@@ -2658,7 +2689,7 @@ EOF
     local mounted_workspace_output
     mounted_workspace_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsu","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Попробую найти навыки через mounted workspace:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsu","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Попробую найти навыки через mounted workspace:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$mounted_workspace_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$mounted_workspace_output" && \
@@ -2672,7 +2703,7 @@ EOF
     local template_probe_output
     template_probe_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Хорошо! Давай найду темплейт навыка и структуру. Смотрю в директории skills:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Хорошо! Давай найду темплейт навыка и структуру. Смотрю в директории skills:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$template_probe_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$template_probe_output" && \
@@ -2686,7 +2717,7 @@ EOF
     local short_template_probe_output
     short_template_probe_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz2","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Поищу темплейт в системе:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz2","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Поищу темплейт в системе:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$short_template_probe_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$short_template_probe_output" && \
@@ -2700,7 +2731,7 @@ EOF
     local short_template_searching_output
     short_template_searching_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz3","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Ищу темплейт:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz3","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Ищу темплейт:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$short_template_searching_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$short_template_searching_output" && \
@@ -2714,7 +2745,7 @@ EOF
     local github_repo_fetch_output
     github_repo_fetch_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsv","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Нашёл официальный репозиторий Moltis на GitHub. Давайте получу полную документацию:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsv","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Нашёл официальный репозиторий Moltis на GitHub. Давайте получу полную документацию:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$github_repo_fetch_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$github_repo_fetch_output" && \
@@ -2728,7 +2759,7 @@ EOF
     local internal_monologue_output
     internal_monologue_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsw","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Пользователь просит изучить официальную документацию Moltis. У меня есть доступ к mcp__tavily__tavily_search, mcp__tavily__tavily_skill и create_skill. Сначала найду официальную документацию Moltis.","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsw","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Пользователь просит изучить официальную документацию Moltis. У меня есть доступ к mcp__tavily__tavily_search, mcp__tavily__tavily_skill и create_skill. Сначала найду официальную документацию Moltis.","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$internal_monologue_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$internal_monologue_output" && \
@@ -2742,7 +2773,7 @@ EOF
     local live_doc_search_plan_output
     live_doc_search_plan_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsx","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Хорошо, изучу документацию Moltis и существующие навыки как примеры. Начну с поиска официальной документации и анализа имеющегося навыка codex-update, который как раз занимается проверкой версий.","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsx","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Хорошо, изучу документацию Moltis и существующие навыки как примеры. Начну с поиска официальной документации и анализа имеющегося навыка codex-update, который как раз занимается проверкой версий.","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$live_doc_search_plan_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$live_doc_search_plan_output" && \
@@ -2756,7 +2787,7 @@ EOF
     local live_friendly_doc_search_plan_output
     live_friendly_doc_search_plan_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsy","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Отлично! Давай изучу официальную документацию и существующие навыки как примеры. Начну с поиска документации Moltis и анализа навыка codex-update (он как раз проверяет версии):","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsy","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Отлично! Давай изучу официальную документацию и существующие навыки как примеры. Начну с поиска документации Moltis и анализа навыка codex-update (он как раз проверяет версии):","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$live_friendly_doc_search_plan_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$live_friendly_doc_search_plan_output" && \
@@ -2770,7 +2801,7 @@ EOF
     local live_named_doc_study_output
     live_named_doc_study_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsy2","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Хорошо, Сергей! Давай изучу официальную документацию Moltis и существующий навык `codex-update` как реальный пример. Начинаю:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsy2","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Хорошо, Сергей! Давай изучу официальную документацию Moltis и существующий навык `codex-update` как реальный пример. Начинаю:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$live_named_doc_study_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$live_named_doc_study_output" && \
@@ -2784,7 +2815,7 @@ EOF
     local live_codex_update_reading_output
     live_codex_update_reading_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Давай наконец сделаю это! Читаю существующий навык `codex-update` как пример и найду документацию:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qsz","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Давай наконец сделаю это! Читаю существующий навык `codex-update` как пример и найду документацию:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$live_codex_update_reading_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$live_codex_update_reading_output" && \
@@ -2800,7 +2831,7 @@ EOF
         env PATH="$MINIMAL_PATH" \
             MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:codex-update-scheduler-after","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","user_message":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?","text":"Навык есть, но автопроверка по крону не подтверждена.","tool_calls":[]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:codex-update-scheduler-after","provider":"openai-codex","model":"openai-codex::gpt-5.4","user_message":"А разе у тебя нет крона по проверке вышедшей новой версии Codex cli?","text":"Навык есть, но автопроверка по крону не подтверждена.","tool_calls":[]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_llm_codex_update_scheduler_output" && \
@@ -2815,7 +2846,7 @@ EOF
     local live_named_doc_search_plan_output
     live_named_doc_search_plan_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:qt0","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","text":"Хорошо, Сергей! Давай изучу официальную документацию Moltis и существующий навык `codex-update` как реальный пример. Начинаю:","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:qt0","provider":"openai-codex","model":"openai-codex::gpt-5.4","text":"Хорошо, Сергей! Давай изучу официальную документацию Moltis и существующий навык `codex-update` как реальный пример. Начинаю:","tool_calls":[]}}'
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$live_named_doc_search_plan_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$live_named_doc_search_plan_output" && \
@@ -2968,7 +2999,7 @@ EOF
         MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
         MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$persisted_intent_send_dir" \
         bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
-{"event":"BeforeLLMCall","data":{"session_key":"session:skillpersist-send","provider":"custom-zai-telegram-safe","model":"custom-zai-telegram-safe::glm-5","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
+{"event":"BeforeLLMCall","data":{"session_key":"session:skillpersist-send","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"А что у тебя с навыками/skills?"}],"tool_count":37,"iteration":1}}
 EOF
     message_sending_skill_visibility_persisted_output="$(
         env PATH="$MINIMAL_PATH" \
@@ -3006,7 +3037,7 @@ EOF
             MOLTIS_RUNTIME_SKILLS_ROOT="$skill_detail_runtime_root" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"MessageSending","session_id":"session:skilldetail-send","data":{"account_id":"moltis-bot","to":"262872988","reply_to_message_id":959,"user_message":"Расскажи мне про навык telegram-lerner","text":"Похоже, у меня сейчас не сработало чтение файла навыка через инструмент. 📋 Activity log • 💻 Running: `cat /home/moltis/.moltis/skills/telegram-learner/SKILL.md` • ❌ missing 'command' parameter"}}"
+{"event":"MessageSending","session_id":"session:skilldetail-send","data":{"account_id":"moltis-bot","to":"262872988","reply_to_message_id":959,"user_message":"Расскажи мне про навык telegram-lerner","text":"Похоже, у меня сейчас не сработало чтение файла навыка через инструмент. 📋 Activity log • 💻 Running: `cat /home/moltis/.moltis/skills/telegram-learner/SKILL.md` • ❌ missing 'command' parameter"}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$message_sending_skill_detail_output" && \
@@ -3082,7 +3113,7 @@ EOF
             MOLTIS_RUNTIME_SKILLS_ROOT="$similar_learner_dir" \
             MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,openclaw-improvement-learner,telegram-learner' \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"MessageSending","session_id":"session:similar-learner","data":{"account_id":"moltis-bot","to":"262872990","reply_to_message_id":961,"user_message":"Расскажи мне про навык openclaw-improvement-learner","text":"Сейчас скажу честно: инструмент чтения навыка опять не сработал. 📋 Activity log • 💻 Running: `cat /home/moltis/.moltis/skills/openclaw-improvement-learner/SKILL.md` • ❌ missing 'command' parameter"}}"
+{"event":"MessageSending","session_id":"session:similar-learner","data":{"account_id":"moltis-bot","to":"262872990","reply_to_message_id":961,"user_message":"Расскажи мне про навык openclaw-improvement-learner","text":"Сейчас скажу честно: инструмент чтения навыка опять не сработал. 📋 Activity log • 💻 Running: `cat /home/moltis/.moltis/skills/openclaw-improvement-learner/SKILL.md` • ❌ missing 'command' parameter"}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$message_sending_similar_learner_output" && \
@@ -3344,7 +3375,7 @@ EOF
     local non_safe_output
     non_safe_output="$(
         run_hook_with_minimal_path \
-            '{"event":"AfterLLMCall","data":{"session_key":"session:mno","provider":"zai","model":"zai::glm-5","text":"plain response","tool_calls":[]}}'
+            '{"event":"AfterLLMCall","data":{"session_key":"session:mno","provider":"glm","model":"glm::glm-5.1","text":"plain response","tool_calls":[]}}'
     )"
     if [[ -z "$non_safe_output" ]]; then
         test_pass

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -318,8 +318,8 @@ NODE
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";
 const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
-const badReply = "model 'custom-zai-telegram-safe::glm-5' not found. available: [\"zai::glm-5\"]";
-const goodReply = "Статус: Online | Модель: custom-zai-telegram-safe::glm-5";
+const badReply = "model 'glm::glm-5.1' not found. available: [\"openai-codex::gpt-5.4\",\"ollama::gemini-3-flash-preview:cloud\",\"anthropic::claude-sonnet-4-20250514\"]";
+const goodReply = "Статус: Online | Модель: openai-codex::gpt-5.4";
 if (!isReplyErrorSignature(badReply)) {
   throw new Error("expected model-not-found reply to be treated as error signature");
 }
@@ -333,6 +333,30 @@ NODE
         test_fail "Model-not-found responses must be rejected by reply-quality checks"
     fi
 
+    test_start "component_telegram_web_probe_marks_no_models_available_as_error_signature"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
+const badReplies = [
+  "No models available.",
+  "model 'zai::glm-5-turbo' not found. available: []"
+];
+const goodReply = "Модель: openai-codex::gpt-5.4";
+for (const badReply of badReplies) {
+  if (!isReplyErrorSignature(badReply)) {
+    throw new Error(`expected model catalog failure to be rejected: ${badReply}`);
+  }
+}
+if (isReplyErrorSignature(goodReply)) {
+  throw new Error("expected healthy model summary to remain clean");
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Model catalog exhaustion replies must be rejected by reply-quality checks"
+    fi
+
     test_start "component_telegram_web_probe_marks_activity_log_replies_as_error_signature"
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";
@@ -342,7 +366,7 @@ const badReplies = [
   "cron list снова вернул missing 'action' parameter, memory_search — missing 'query' parameter, exec — missing 'command' parameter",
   "Timed out: Agent run timed out after 90s"
 ];
-const goodReply = "Я на месте. - Имя: Молтингер - Пользователь: Сергей - Модель: custom-zai-telegram-safe::glm-5";
+const goodReply = "Я на месте. - Имя: Молтингер - Пользователь: Сергей - Модель: openai-codex::gpt-5.4";
 for (const badReply of badReplies) {
   if (!isReplyErrorSignature(badReply)) {
     throw new Error(`expected error signature to be rejected: ${badReply}`);

--- a/tests/fixtures/config/moltis.toml
+++ b/tests/fixtures/config/moltis.toml
@@ -84,9 +84,9 @@ api_key = "${OLLAMA_API_KEY}"
 [providers.openai]
 enabled = false
 api_key = "${GLM_API_KEY}"
-model = "glm-5"
-base_url = "https://api.z.ai/api/coding/paas/v4"
-alias = "zai"
+model = "glm-5.1"
+base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
+alias = "glm"
 
 [chat]
 message_queue_mode = "followup"

--- a/tests/lib/core.sh
+++ b/tests/lib/core.sh
@@ -392,16 +392,16 @@ assert_lt() {
 }
 
 mock_glm_failure() {
-    export GLM_API_ENDPOINT_REAL="${GLM_API_ENDPOINT:-https://open.bigmodel.cn/api/paas/v4/chat/completions}"
-    export GLM_API_ENDPOINT="http://127.0.0.1:49999"
+    export GLM_API_BASE_REAL="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
+    export GLM_API_BASE="http://127.0.0.1:49999"
 }
 
 restore_glm() {
-    if [[ -n "${GLM_API_ENDPOINT_REAL:-}" ]]; then
-        export GLM_API_ENDPOINT="$GLM_API_ENDPOINT_REAL"
-        unset GLM_API_ENDPOINT_REAL
+    if [[ -n "${GLM_API_BASE_REAL:-}" ]]; then
+        export GLM_API_BASE="$GLM_API_BASE_REAL"
+        unset GLM_API_BASE_REAL
     else
-        unset GLM_API_ENDPOINT
+        unset GLM_API_BASE
     fi
 }
 

--- a/tests/live_external/test_provider_live.sh
+++ b/tests/live_external/test_provider_live.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/test_helpers.sh"
 
-GLM_API_HOST="${GLM_API_HOST:-https://api.z.ai}"
+GLM_API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
 GLM_API_KEY="${GLM_API_KEY:-}"
 OLLAMA_HOST="${OLLAMA_HOST:-}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-20}"
@@ -29,7 +29,7 @@ run_live_provider_tests() {
     test_start "live_provider_glm_models_endpoint"
     if require_secret_or_skip GLM_API_KEY "GLM_API_KEY"; then
         local glm_code
-        glm_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TEST_TIMEOUT" -H "Authorization: Bearer $GLM_API_KEY" "${GLM_API_HOST%/}/v1/models" 2>/dev/null || echo '000')
+        glm_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TEST_TIMEOUT" -H "Authorization: Bearer $GLM_API_KEY" "${GLM_API_BASE%/}/models" 2>/dev/null || echo '000')
         if [[ "$glm_code" =~ ^(200|201)$ ]]; then
             test_pass
         else

--- a/tests/resilience/test_full_failover_chain.sh
+++ b/tests/resilience/test_full_failover_chain.sh
@@ -6,6 +6,7 @@ source "$SCRIPT_DIR/../lib/test_helpers.sh"
 
 ALLOW_DESTRUCTIVE_TESTS="${ALLOW_DESTRUCTIVE_TESTS:-0}"
 GLM_API_KEY="${GLM_API_KEY:-}"
+GLM_API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
 OLLAMA_HOST="${OLLAMA_HOST:-}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-15}"
 MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
@@ -44,17 +45,17 @@ run_resilience_failover_chain_tests() {
         test_fail "OpenAI Codex auth should be valid before failover drill"
     fi
 
-    test_start "resilience_failover_zai_health"
+    test_start "resilience_failover_glm_health"
     require_secret_or_skip GLM_API_KEY "GLM_API_KEY" || {
         generate_report
         return
     }
     local glm_code
-    glm_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TEST_TIMEOUT" -H "Authorization: Bearer $GLM_API_KEY" "https://api.z.ai/v1/models" 2>/dev/null || echo '000')
+    glm_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TEST_TIMEOUT" -H "Authorization: Bearer $GLM_API_KEY" "${GLM_API_BASE%/}/models" 2>/dev/null || echo '000')
     if [[ "$glm_code" =~ ^(200|201)$ ]]; then
         test_pass
     else
-        test_fail "Z.ai fallback provider should be reachable before failover drill (got $glm_code)"
+        test_fail "GLM fallback provider should be reachable before failover drill (got $glm_code)"
     fi
 
     test_start "resilience_failover_ollama_health"

--- a/tests/static/test_pr_review_handoff_workflow.sh
+++ b/tests/static/test_pr_review_handoff_workflow.sh
@@ -44,7 +44,7 @@ run_all_tests() {
 
     test_start "pr_review_handoff_workflow_removes_ai_provider_dependencies"
     if [[ -f "$WORKFLOW_FILE" ]] && \
-       ! rg -q 'GLM_API_KEY|AI_REVIEW_PROVIDER|GLM_API_BASE|GLM_MODEL|zai_chat_completion\.sh|Provider\*\*: Z\.ai|AI review did not run' "$WORKFLOW_FILE"; then
+       ! rg -q 'GLM_API_KEY|AI_REVIEW_PROVIDER|GLM_API_BASE|GLM_MODEL|glm_chat_completion\.sh|Provider\*\*: Z\.ai|AI review did not run' "$WORKFLOW_FILE"; then
         test_pass
     else
         test_fail "PR review workflow must not depend on GLM or any in-workflow AI provider path"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -801,6 +801,7 @@ test_render_moltis_env_script_renders_runtime_contract() {
     output_file="$tmp_dir/moltis.env"
 
     if ! MOLTIS_PASSWORD="secret" \
+        ANTHROPIC_API_KEY="anthropic-key" \
         GLM_API_KEY="glm-key" \
         OLLAMA_API_KEY="ollama-key" \
         TAVILY_API_KEY="tavily-key" \
@@ -817,6 +818,7 @@ test_render_moltis_env_script_renders_runtime_contract() {
     fi
 
     if ! grep -Fq "MOLTIS_PASSWORD=secret" "$output_file" || \
+       ! grep -Fq "ANTHROPIC_API_KEY=anthropic-key" "$output_file" || \
        ! grep -Fq "GLM_API_KEY=glm-key" "$output_file" || \
        ! grep -Fq "MOLTIS_DOMAIN=moltis.example.com" "$output_file" || \
        ! grep -Fq "MOLTIS_RUNTIME_CONFIG_DIR=/srv/runtime-config" "$output_file"; then

--- a/tests/unit/test_glm_ci_helpers.sh
+++ b/tests/unit/test_glm_ci_helpers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Unit tests for CI helpers used by Z.ai GitHub workflows.
+# Unit tests for CI helpers used by official GLM GitHub workflows.
 
 set -euo pipefail
 
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../lib/test_helpers.sh"
 
-HELPER="$PROJECT_ROOT/scripts/ci/zai_chat_completion.sh"
+HELPER="$PROJECT_ROOT/scripts/ci/glm_chat_completion.sh"
 
 get_free_port() {
     python3 - <<'PY'
@@ -67,7 +67,7 @@ PY
 
 # Test 1: Missing key should fail with dedicated code.
 test_missing_glm_api_key() {
-    test_start "zai_chat_completion should fail when GLM_API_KEY is missing"
+    test_start "glm_chat_completion helper should fail when GLM_API_KEY is missing"
 
     local prompt_file output_file
     prompt_file="$(mktemp)"
@@ -89,7 +89,7 @@ test_missing_glm_api_key() {
 
 # Test 2: Successful response should be written to output file.
 test_success_response_parsing() {
-    test_start "zai_chat_completion should write content on successful response"
+    test_start "glm_chat_completion helper should write content on successful response"
 
     local prompt_file output_file port
     prompt_file="$(mktemp)"
@@ -119,7 +119,7 @@ test_success_response_parsing() {
 
 # Test 3: API non-200 should return dedicated error code.
 test_api_error_code() {
-    test_start "zai_chat_completion should return code 5 on API error"
+    test_start "glm_chat_completion helper should return code 5 on API error"
 
     local prompt_file output_file port
     prompt_file="$(mktemp)"
@@ -150,7 +150,7 @@ test_api_error_code() {
 
 # Test 4: Array content payload should be flattened safely.
 test_array_content_parsing() {
-    test_start "zai_chat_completion should flatten array-based content"
+    test_start "glm_chat_completion helper should flatten array-based content"
 
     local prompt_file output_file port output
     prompt_file="$(mktemp)"
@@ -186,7 +186,7 @@ run_all_tests() {
     if [[ "$OUTPUT_JSON" != "true" ]]; then
         echo ""
         echo "========================================="
-        echo "  Z.ai CI Helper Unit Tests"
+        echo "  GLM CI Helper Unit Tests"
         echo "========================================="
         echo ""
     fi


### PR DESCRIPTION
## Summary
- remove the active Z.ai provider path from runtime, deploy, and fallback contracts
- harden malformed known-tool handling so non-Telegram surfaces fail closed instead of leaking raw tool-card errors
- update spec artifacts and RCA for the observed UI and Telegram regressions

## Validation
- /bin/bash tests/unit/test_glm_ci_helpers.sh
- /bin/bash tests/component/test_prepare_moltis_runtime_config.sh
- /bin/bash tests/component/test_moltis_runtime_attestation.sh
- /bin/bash tests/component/test_telegram_web_probe_correlation.sh
- /bin/bash tests/component/test_telegram_safe_llm_guard.sh
- /bin/bash tests/unit/test_deploy_workflow_guards.sh
- /bin/bash tests/component/test_moltis_search_memory_diagnostics.sh
- git diff --check

## Notes
- live Telegram failure was confirmed against deployed /server/config/moltis.toml still carrying legacy zai aliases and fallback entries
- follow-up Beads issue created for provisioning ANTHROPIC_API_KEY so the Claude fallback remains operational in production