### PR TITLE
fix: enforce codex primary and ollama-only fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -957,8 +957,6 @@ jobs:
       - name: Generate .env from Secrets
         env:
           MOLTIS_PASSWORD: ${{ secrets.MOLTIS_PASSWORD }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/.github/workflows/uat-gate.yml
+++ b/.github/workflows/uat-gate.yml
@@ -349,8 +349,6 @@ jobs:
       - name: Generate .env from Secrets
         env:
           MOLTIS_PASSWORD: ${{ secrets.MOLTIS_PASSWORD }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -5,7 +5,7 @@
 # Changes require a restart to take effect.
 #
 # Environment variable substitution is supported: ${ENV_VAR}
-# Example: api_key = "${ANTHROPIC_API_KEY}"
+# Example: api_key = "${OLLAMA_API_KEY}"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SERVER
@@ -207,7 +207,7 @@ timezone = "Europe/Moscow"
 #
 # Each provider supports:
 #   enabled   - Whether to use this provider (default: true)
-#   api_key   - API key (or use env var like ANTHROPIC_API_KEY)
+#   api_key   - API key (or use provider-specific env vars such as OLLAMA_API_KEY)
 #   base_url  - Override API endpoint
 #   model     - Default model for this provider
 #   alias     - Custom name for metrics labels (useful for multiple instances)
@@ -216,22 +216,12 @@ timezone = "Europe/Moscow"
 offered = [
     "openai-codex",  # Primary: ChatGPT subscription OAuth
     "ollama",        # Fallback 1: Ollama cloud Gemini
-    "anthropic",     # Fallback 2: Claude Sonnet
-    "openai",        # Fallback 3: GLM-5.1 via official BigModel Coding Plan
 ] # Providers shown in onboarding/picker UI ([] = show all)
 # All available providers:
 #   "anthropic", "openai", "gemini", "groq", "xai", "deepseek",
 #   "mistral", "openrouter", "cerebras", "minimax", "moonshot",
 #   "venice", "ollama", "local-llm", "openai-codex", "github-copilot",
 #   "kimi-code"
-
-# ── Anthropic (Claude) ────────────────────────────────────────
-[providers.anthropic]
-enabled = true                      # Enabled as fallback; requires ANTHROPIC_API_KEY in runtime env
-api_key = "${ANTHROPIC_API_KEY}"    # Or set ANTHROPIC_API_KEY env var
-model = "claude-sonnet-4-20250514"  # Default model
-base_url = "https://api.anthropic.com"
-alias = "anthropic"
 
 # ── OpenAI Codex via ChatGPT OAuth ────────────────────────────
 [providers.openai-codex]
@@ -240,22 +230,8 @@ model = "gpt-5.4"
 alias = "openai-codex"
 models = ["gpt-5.4"]
 tool_mode = "auto"
-
-# ── OpenAI-compatible GLM-5.1 via BigModel Coding Plan ────────────────────────
-# Official BigModel Coding Plan OpenAI-compatible endpoint:
-# https://docs.bigmodel.cn/cn/coding-plan/tool/opencode
-[providers.openai]
-enabled = true
-api_key = "${GLM_API_KEY}"                               # Official BigModel API key
-model = "glm-5.1"                                       # Default fallback model
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-alias = "glm"
-models = ["glm-5.1"]
-
-# ── GLM (Zhipu AI) - DISABLED (invalid provider name) ────────────────────────
-# This section is NOT a valid Moltis provider! Use [providers.openai] instead.
-[providers.glm-coding]
-enabled = false
+# Reasoning tier such as xhigh is controlled by the OAuth-backed client/runtime
+# profile; static Moltis TOML only pins the canonical model id.
 
 # ── Google Gemini ─────────────────────────────────────────────
 # Direct Gemini provider stays disabled to keep one explicit fallback path
@@ -313,18 +289,14 @@ message_queue_mode = "followup"   # How to handle messages during an active agen
                                   #   "collect"  - Buffer messages, concatenate as single message
 # priority_models = ["claude-opus-4-5", "gpt-5.4", "gemini-3-flash"]  # Optional: models to pin first in selectors
 # allowed_models = ["opus", "gpt 5.4", "gemini-3"]  # Optional: only show models matching these patterns (local-llm/ollama are always included)
-# Preferred chain: GPT-5.4 (OAuth) -> Ollama Gemini 3 Flash Preview -> Claude -> GLM-5.1
+# Preferred chain: GPT-5.4 (OAuth) -> Ollama Gemini 3 Flash Preview
 allowed_models = [
     "openai-codex::gpt-5.4",                    # Primary
     "ollama::gemini-3-flash-preview:cloud",     # Fallback 1
-    "anthropic::claude-sonnet-4-20250514",      # Fallback 2
-    "glm::glm-5.1"                              # Fallback 3
 ]
 priority_models = [
     "openai-codex::gpt-5.4",
     "ollama::gemini-3-flash-preview:cloud",
-    "anthropic::claude-sonnet-4-20250514",
-    "glm::glm-5.1",
 ]
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -626,7 +598,7 @@ prometheus_endpoint = true        # Expose /metrics endpoint for Prometheus scra
 [heartbeat]
 enabled = true                    # Enable periodic heartbeats
 every = "30m"                     # Interval between heartbeats (e.g., "30m", "1h", "6h")
-# model = "anthropic/claude-sonnet-4-20250514"  # Override model for heartbeats
+# model = "openai-codex::gpt-5.4"  # Optional heartbeat override; primary reasoning tier comes from OAuth runtime profile
 # prompt = "..."                  # Custom heartbeat prompt (default: built-in)
 ack_max_chars = 300               # Max characters for acknowledgment reply
 sandbox_enabled = true            # Run heartbeat commands in sandbox
@@ -645,13 +617,11 @@ timezone = "local"                # Timezone: "local" or IANA name like "Europe/
 
 [failover]
 enabled = true                    # Enable automatic failover
-# Fallback chain: GPT-5.4 → Ollama Gemini → Claude → GLM-5.1
+# Fallback chain: GPT-5.4 → Ollama Gemini
 fallback_models = [
     "ollama::gemini-3-flash-preview:cloud",  # Primary fallback: Ollama sidecar
-    "anthropic::claude-sonnet-4-20250514",   # Secondary fallback: Claude
-    "glm::glm-5.1"                           # Final fallback: official BigModel GLM-5.1
 ]
-# Chain: gpt-5.4 → ollama-gemini → claude-sonnet-4 → glm-5.1
+# Chain: gpt-5.4 → ollama-gemini
 
 # ══════════════════════════════════════════════════════════════════════════════
 # VOICE

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -303,8 +303,6 @@ docker logs moltis --tail 100
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `MOLTIS_PASSWORD` | Yes | Authentication password |
-| `ANTHROPIC_API_KEY` | No | Claude fallback API key |
-| `GLM_API_KEY` | Yes | Official BigModel GLM-5.1 last-fallback API key |
 | `OLLAMA_API_KEY` | No | Ollama Cloud key for `gemini-3-flash-preview:cloud` fallback |
 | `MOLTIS_DOMAIN` | No | Domain for Traefik |
 | `MOLTIS_RUNTIME_CONFIG_DIR` | No | Writable live Moltis config path on server (default `/opt/moltinger-state/config-runtime`) |

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -138,9 +138,7 @@ make logs LOGS_OPTS=-f
 |--------|--------|---------|
 | TELEGRAM_BOT_TOKEN | ✅ | Bot token |
 | TELEGRAM_ALLOWED_USERS | ✅ | Allowed user IDs |
-| OLLAMA_API_KEY | ✅/optional | Ollama Cloud first fallback |
-| ANTHROPIC_API_KEY | ✅/optional | Claude fallback |
-| GLM_API_KEY | ✅ | Official BigModel GLM-5.1 last fallback + interactive assistant workflow |
+| OLLAMA_API_KEY | ✅/optional | Ollama Cloud fallback |
 | SSH_PRIVATE_KEY | ✅ | Deploy |
 
 Runtime-only auth state:

--- a/docs/SECRETS-MANAGEMENT.md
+++ b/docs/SECRETS-MANAGEMENT.md
@@ -21,8 +21,7 @@
 │                   GitHub Repository                      │
 │  ┌───────────────────────────────────────────────────┐  │
 │  │              GitHub Secrets                        │  │
-│  │  • ANTHROPIC_API_KEY                              │  │
-│  │  • GLM_API_KEY                                    │  │
+│  │  • OLLAMA_API_KEY                                 │  │
 │  │  • BRAVE_API_KEY                                  │  │
 │  │  • ELEVENLABS_API_KEY                             │  │
 │  │  • MOLTIS_PASSWORD                                │  │
@@ -60,8 +59,7 @@ gh secret set SECRET_NAME --repo owner/repo
 
 # Use in GitHub Actions
 env:
-  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+  OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 ```
 
 ### 2. Environment Variables via CI/CD
@@ -70,8 +68,7 @@ env:
 # .github/workflows/deploy.yml
 - name: Create .env file
   run: |
-    echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" > .env
-    echo "GLM_API_KEY=${{ secrets.GLM_API_KEY }}" >> .env
+    echo "OLLAMA_API_KEY=${{ secrets.OLLAMA_API_KEY }}" > .env
     scp .env $SSH_USER@$SSH_HOST:$DEPLOY_PATH/.env
 ```
 
@@ -128,9 +125,7 @@ gh workflow run deploy.yml
 
 | Secret | Purpose | Where Used |
 |--------|---------|------------|
-| `ANTHROPIC_API_KEY` | Claude fallback | Moltis config + runtime fallback chain |
-| `GLM_API_KEY` | GLM/Zhipu AI LLM (Last fallback) | Moltis config + interactive assistant workflow |
-| `OLLAMA_API_KEY` | Ollama Cloud first fallback | Docker secrets |
+| `OLLAMA_API_KEY` | Ollama Cloud fallback | Moltis config + runtime fallback chain |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot auth | Moltis config |
 | `TELEGRAM_WEBHOOK_URL` | Telegram webhook endpoint URL (optional) | Controlled webhook rollout |
 | `TELEGRAM_WEBHOOK_SECRET` | Telegram webhook anti-spoofing token (optional) | Controlled webhook rollout |
@@ -163,10 +158,10 @@ Rules:
 
 ### AI Workflow Secrets
 
-- Interactive assistant and deploy surfaces use `GLM_API_KEY` only against the official BigModel Coding Plan endpoint (`open.bigmodel.cn`), not Z.ai.
+- Interactive assistant and deploy surfaces no longer use provider API-key secrets beyond `OLLAMA_API_KEY` for the optional Ollama Cloud fallback lane.
 - `.github/workflows/claude-code-review.yml` no longer invokes an AI provider in GitHub Actions; it prepares a deterministic handoff for manual review in AI IDE.
 - `CLAUDE_CODE_OAUTH_TOKEN` is not required for current CI workflows.
-- `ANTHROPIC_API_KEY` is required when the Claude fallback lane must be active in runtime/deploy paths.
+- The tracked Moltis runtime/deploy contract now uses only `OLLAMA_API_KEY` as an optional fallback secret.
 - Legacy compatibility kill-switch: repository variable `AI_REVIEW_PROVIDER=off` may stay set, but the current review workflow is already deterministic-only and does not invoke an AI provider in GitHub Actions.
 - Rollback artifacts for legacy Anthropic workflows are stored in:
   - `.github/workflows/claude.legacy.yml.disabled`
@@ -193,26 +188,6 @@ The Ollama fallback system requires the following secret:
 ```bash
 gh secret set OLLAMA_API_KEY --repo RussianLioN/moltinger
 ```
-
-### Claude Fallback Secret
-
-| Secret | Required | Purpose |
-|--------|----------|---------|
-| `ANTHROPIC_API_KEY` | Optional but recommended | Claude Sonnet fallback lane |
-
-**When ANTHROPIC_API_KEY is needed:**
-- When Claude must participate in the tracked fallback chain
-- When deploy/runtime should expose `anthropic::claude-sonnet-4-20250514`
-
-### GLM Last-Fallback Secret
-
-| Secret | Required | Purpose |
-|--------|----------|---------|
-| `GLM_API_KEY` | Required for full fallback chain | Final fallback to `glm-5.1` via official BigModel |
-
-**When GLM_API_KEY is needed:**
-- When Codex, Ollama, and Claude are unavailable
-- For AI workflow jobs that still use the official BigModel Coding Plan path outside the Moltis primary runtime path
 
 ### Runtime Config Persistence
 

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -198,16 +198,10 @@ check_http_health() {
 # LLM PROVIDER HEALTH CHECKS (Circuit Breaker Support)
 # ========================================================================
 
-# Production chain defaults: OpenAI Codex OAuth -> Ollama -> Claude -> GLM.
+# Production chain defaults: OpenAI Codex OAuth -> Ollama Cloud.
 PRIMARY_PROVIDER="${PRIMARY_PROVIDER:-openai-codex}"
 FALLBACK_PROVIDER="${FALLBACK_PROVIDER:-ollama}"
 MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
-
-# GLM API configuration (official BigModel Coding Plan endpoint)
-GLM_API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
-GLM_API_KEY="${GLM_API_KEY:-}"
-GLM_MODEL="${GLM_MODEL:-glm-5.1}"
-GLM_HEALTH_TIMEOUT="${GLM_HEALTH_TIMEOUT:-10}"
 
 # Ollama API configuration
 OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
@@ -236,53 +230,6 @@ check_openai_codex_health() {
 
     log_error "OpenAI Codex auth is not valid"
     return 1
-}
-
-# Check official GLM (BigModel) API health
-check_glm_health() {
-    local timeout="${1:-$GLM_HEALTH_TIMEOUT}"
-    local url="${GLM_API_BASE%/}/models"
-    local response_code
-
-    # If no API key, skip check
-    if [[ -z "$GLM_API_KEY" ]]; then
-        log_warn "GLM_API_KEY not set, skipping GLM health check"
-        return 2  # Degraded - can't check
-    fi
-
-    log_info "Checking GLM API health at $url"
-
-    response_code=$(curl -s -o /dev/null -w "%{http_code}" \
-        --max-time "$timeout" \
-        -H "Authorization: Bearer $GLM_API_KEY" \
-        "$url" 2>/dev/null || echo "000")
-
-    case "$response_code" in
-        200|201)
-            log_info "GLM API is healthy (HTTP $response_code)"
-            return 0
-            ;;
-        401|403)
-            log_error "GLM API authentication failed (HTTP $response_code)"
-            return 1
-            ;;
-        429)
-            log_warn "GLM API rate limited (HTTP $response_code)"
-            return 1
-            ;;
-        500|502|503|504)
-            log_error "GLM API server error (HTTP $response_code)"
-            return 1
-            ;;
-        000)
-            log_error "GLM API unreachable (timeout or connection refused)"
-            return 1
-            ;;
-        *)
-            log_warn "GLM API unexpected response (HTTP $response_code)"
-            return 1
-            ;;
-    esac
 }
 
 # Check Ollama API health
@@ -336,9 +283,6 @@ check_primary_provider_health() {
         openai-codex)
             check_openai_codex_health "$@"
             ;;
-        glm)
-            check_glm_health "$@"
-            ;;
         ollama)
             check_ollama_health "$@"
             ;;
@@ -353,9 +297,6 @@ check_fallback_provider_health() {
     case "$FALLBACK_PROVIDER" in
         ollama)
             check_ollama_health "$@"
-            ;;
-        glm)
-            check_glm_health "$@"
             ;;
         openai-codex)
             check_openai_codex_health "$@"

--- a/scripts/render-moltis-env.sh
+++ b/scripts/render-moltis-env.sh
@@ -60,8 +60,6 @@ if [[ -z "$OUTPUT_PATH" ]]; then
 fi
 
 assert_single_line "MOLTIS_PASSWORD" "${MOLTIS_PASSWORD:-}"
-assert_single_line "ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY:-}"
-assert_single_line "GLM_API_KEY" "${GLM_API_KEY:-}"
 assert_single_line "OLLAMA_API_KEY" "${OLLAMA_API_KEY:-}"
 assert_single_line "TAVILY_API_KEY" "${TAVILY_API_KEY:-}"
 assert_single_line "TELEGRAM_BOT_TOKEN" "${TELEGRAM_BOT_TOKEN:-}"
@@ -80,11 +78,8 @@ cat > "$OUTPUT_PATH" <<EOF
 # Authentication
 MOLTIS_PASSWORD=${MOLTIS_PASSWORD:-}
 
-# LLM Provider - Claude (Anthropic)
-ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-
-# LLM Provider - GLM (Zhipu AI / BigModel)
-GLM_API_KEY=${GLM_API_KEY:-}
+# LLM Primary - OpenAI Codex OAuth runtime state lives under
+# MOLTIS_RUNTIME_CONFIG_DIR; no static API key is rendered here.
 
 # LLM Fallback - Ollama Cloud (optional, for cloud models)
 OLLAMA_API_KEY=${OLLAMA_API_KEY:-}

--- a/specs/001-fallback-llm-ollama/contracts/circuit-breaker-state.md
+++ b/specs/001-fallback-llm-ollama/contracts/circuit-breaker-state.md
@@ -17,7 +17,7 @@ JSON schema for circuit breaker state file at `/tmp/moltis-llm-state.json`.
   "properties": {
     "current_provider": {
       "type": "string",
-      "enum": ["glm", "ollama"],
+      "enum": ["openai-codex", "ollama"],
       "description": "Currently active LLM provider"
     },
     "circuit_state": {
@@ -67,10 +67,10 @@ JSON schema for circuit breaker state file at `/tmp/moltis-llm-state.json`.
 
 ## Example States
 
-### Normal Operation (GLM active)
+### Normal Operation (OpenAI Codex active)
 ```json
 {
-  "current_provider": "glm",
+  "current_provider": "openai-codex",
   "circuit_state": "closed",
   "failure_count": 0,
   "success_count": null,
@@ -82,7 +82,7 @@ JSON schema for circuit breaker state file at `/tmp/moltis-llm-state.json`.
 }
 ```
 
-### GLM Failed, Ollama Active
+### Primary Failed, Ollama Active
 ```json
 {
   "current_provider": "ollama",
@@ -122,7 +122,7 @@ read_state() {
         cat "$state_file"
     else
         # Return default state
-        echo '{"current_provider":"glm","circuit_state":"closed","failure_count":0,"last_check":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
+        echo '{"current_provider":"openai-codex","circuit_state":"closed","failure_count":0,"last_check":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
     fi
 }
 ```
@@ -154,6 +154,6 @@ write_state() {
 
 State file changes should update Prometheus metrics:
 ```
-moltis_circuit_state{provider="glm"} 0  # 0=closed
-moltis_llm_failures_total{provider="glm"} 3
+moltis_circuit_state{provider="openai-codex"} 0  # 0=closed
+moltis_llm_failures_total{provider="openai-codex"} 3
 ```

--- a/specs/001-fallback-llm-ollama/contracts/moltis-failover-config.md
+++ b/specs/001-fallback-llm-ollama/contracts/moltis-failover-config.md
@@ -19,30 +19,13 @@ model = "gpt-5.4"
 alias = "openai-codex"
 models = ["gpt-5.4"]
 
-# Fallback provider 1 (Ollama sidecar)
+# Fallback provider (Ollama Cloud)
 [providers.ollama]
 enabled = true
 base_url = "http://ollama:11434"
 model = "gemini-3-flash-preview:cloud"
 alias = "ollama"
 api_key = "${OLLAMA_API_KEY}"
-
-# Fallback provider 2 (Claude)
-[providers.anthropic]
-enabled = true
-api_key = "${ANTHROPIC_API_KEY}"
-model = "claude-sonnet-4-20250514"
-base_url = "https://api.anthropic.com"
-alias = "anthropic"
-
-# Final fallback provider 3 (official BigModel GLM)
-[providers.openai]
-enabled = true
-api_key = "${GLM_API_KEY}"
-model = "glm-5.1"
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-alias = "glm"
-models = ["glm-5.1"]
 ```
 
 ### Failover Configuration
@@ -51,9 +34,7 @@ models = ["glm-5.1"]
 [failover]
 enabled = true
 fallback_models = [
-    "ollama::gemini-3-flash-preview:cloud",
-    "anthropic::claude-sonnet-4-20250514",
-    "glm::glm-5.1"
+    "ollama::gemini-3-flash-preview:cloud"
 ]
 health_check_interval = "5s"                        # Health check interval
 failure_threshold = 3                               # Failures before switch
@@ -69,12 +50,6 @@ success_threshold = 2                               # Successes to recover
 |---------|-------|------|----------|---------|
 | providers.openai-codex | enabled | bool | ✅ | false |
 | providers.openai-codex | model | string | ✅ | - |
-| providers.openai | enabled | bool | ✅ | false |
-| providers.openai | api_key | string | ✅ | - |
-| providers.openai | model | string | ✅ | - |
-| providers.anthropic | enabled | bool | ✅ | false |
-| providers.anthropic | api_key | string | ✅ | - |
-| providers.anthropic | model | string | ✅ | - |
 | providers.ollama | enabled | bool | ✅ | false |
 | providers.ollama | base_url | string | ✅ | - |
 | failover | enabled | bool | ✅ | false |
@@ -97,12 +72,6 @@ model = "gpt-5.4"
 alias = "openai-codex"
 models = ["gpt-5.4"]
 
-[providers.anthropic]
-enabled = false
-
-[providers.openai]
-enabled = false
-
 [providers.ollama]
 enabled = false
 
@@ -111,28 +80,13 @@ enabled = false
 fallback_models = []
 ```
 
-### Full (Codex + ordered fallback chain)
+### Full (Codex + Ollama fallback chain)
 ```toml
 [providers.openai-codex]
 enabled = true
 model = "gpt-5.4"
 alias = "openai-codex"
 models = ["gpt-5.4"]
-
-[providers.anthropic]
-enabled = true
-api_key = "${ANTHROPIC_API_KEY}"
-model = "claude-sonnet-4-20250514"
-base_url = "https://api.anthropic.com"
-alias = "anthropic"
-
-[providers.openai]
-enabled = true
-api_key = "${GLM_API_KEY}"
-model = "glm-5.1"
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-alias = "glm"
-models = ["glm-5.1"]
 
 [providers.ollama]
 enabled = true
@@ -144,9 +98,7 @@ api_key = "${OLLAMA_API_KEY}"
 [failover]
 enabled = true
 fallback_models = [
-    "ollama::gemini-3-flash-preview:cloud",
-    "anthropic::claude-sonnet-4-20250514",
-    "glm::glm-5.1"
+    "ollama::gemini-3-flash-preview:cloud"
 ]
 health_check_interval = "5s"
 failure_threshold = 3
@@ -187,14 +139,10 @@ fi
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| GLM_API_KEY | ✅ | Official BigModel API key for final GLM fallback |
-| ANTHROPIC_API_KEY | ⚠️ | Claude Sonnet fallback lane |
 | OLLAMA_API_KEY | ⚠️ | Ollama cloud API key (if using cloud models) |
 
 ## Secrets Files
 
 | File | Content | Permissions |
 |------|---------|-------------|
-| secrets/glm_api_key.txt | GLM API key | 600 |
-| secrets/anthropic_api_key.txt | Anthropic API key | 600 |
 | secrets/ollama_api_key.txt | Ollama API key | 600 |

--- a/specs/001-fallback-llm-ollama/data-model.md
+++ b/specs/001-fallback-llm-ollama/data-model.md
@@ -1,4 +1,4 @@
-# Data Model: Fallback LLM with Ollama Sidecar
+# Data Model: Fallback LLM with Ollama Cloud
 
 **Feature**: 001-fallback-llm-ollama
 **Date**: 2026-03-01
@@ -8,11 +8,9 @@
 ```
 ┌─────────────────┐     ┌─────────────────────┐
 │  LLM Provider   │     │  Circuit Breaker    │
-│  (4 instances)  │────▶│  State              │
+│  (2 instances)  │────▶│  State              │
 │  - openai-codex │     │  (1 instance)       │
 │  - ollama       │     └─────────────────────┘
-│  - anthropic    │
-│  - glm          │
 └────────┬────────┘              │
          │                       │
          │                       ▼
@@ -32,11 +30,11 @@ Represents an LLM API provider (primary or fallback).
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| name | string | Provider identifier | "openai-codex", "ollama", "anthropic", "glm" |
+| name | string | Provider identifier | "openai-codex", "ollama" |
 | type | enum | Provider type | "primary", "fallback" |
 | status | enum | Current availability | "available", "unavailable", "degraded" |
-| base_url | string | API endpoint | "https://api.anthropic.com", "http://localhost:11434", "https://open.bigmodel.cn/api/coding/paas/v4" |
-| model | string | Model identifier | "gpt-5.4", "gemini-3-flash-preview:cloud", "claude-sonnet-4-20250514", "glm-5.1" |
+| base_url | string | API endpoint | "http://localhost:11434" |
+| model | string | Model identifier | "gpt-5.4", "gemini-3-flash-preview:cloud" |
 | latency_p95 | number | 95th percentile latency (ms) | 2500, 12000 |
 | error_count | number | Consecutive errors | 0, 3 |
 | last_check | timestamp | Last health check time | "2026-03-01T12:00:00Z" |
@@ -139,20 +137,6 @@ model = "gpt-5.4"
 alias = "openai-codex"
 models = ["gpt-5.4"]
 
-[providers.anthropic]
-enabled = true
-api_key = "${ANTHROPIC_API_KEY}"
-model = "claude-sonnet-4-20250514"
-base_url = "https://api.anthropic.com"
-alias = "anthropic"
-
-[providers.openai]
-enabled = true
-api_key = "${GLM_API_KEY}"
-model = "glm-5.1"
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-alias = "glm"
-
 [providers.ollama]
 enabled = true
 base_url = "http://ollama:11434"
@@ -164,23 +148,17 @@ api_key = "${OLLAMA_API_KEY}"
 [chat]
 allowed_models = [
   "openai-codex::gpt-5.4",
-  "ollama::gemini-3-flash-preview:cloud",
-  "anthropic::claude-sonnet-4-20250514",
-  "glm::glm-5.1"
+  "ollama::gemini-3-flash-preview:cloud"
 ]
 priority_models = [
   "openai-codex::gpt-5.4",
-  "ollama::gemini-3-flash-preview:cloud",
-  "anthropic::claude-sonnet-4-20250514",
-  "glm::glm-5.1"
+  "ollama::gemini-3-flash-preview:cloud"
 ]
 
 [failover]
 enabled = true
 fallback_models = [
-  "ollama::gemini-3-flash-preview:cloud",
-  "anthropic::claude-sonnet-4-20250514",
-  "glm::glm-5.1"
+  "ollama::gemini-3-flash-preview:cloud"
 ]
 health_check_interval = "5s"
 failure_threshold = 3
@@ -208,8 +186,6 @@ recovery_timeout = "60s"
 # Provider availability (gauge)
 llm_provider_available{provider="openai-codex"} 1
 llm_provider_available{provider="ollama"} 1
-llm_provider_available{provider="anthropic"} 1
-llm_provider_available{provider="glm"} 1
 
 # Failover counter
 llm_fallback_triggered_total{from="openai-codex",to="ollama",reason="health_check_failure"} 2

--- a/specs/001-fallback-llm-ollama/plan.md
+++ b/specs/001-fallback-llm-ollama/plan.md
@@ -1,13 +1,13 @@
-# Implementation Plan: Fallback LLM with Ollama Sidecar
+# Implementation Plan: Fallback LLM with Ollama Cloud
 
 **Branch**: `001-fallback-llm-ollama` | **Date**: 2026-03-01 | **Spec**: [spec.md](./spec.md)
 **Input**: Feature specification from `/specs/001-fallback-llm-ollama/spec.md`
 
 ## Summary
 
-Реализовать отказоустойчивый fallback механизм для Moltis с Ollama sidecar контейнером и Circuit Breaker pattern для автоматического переключения при недоступности GLM API.
+Реализовать отказоустойчивый fallback механизм для Moltis с primary `openai-codex::gpt-5.4` через OAuth и единственным tracked fallback `ollama::gemini-3-flash-preview:cloud`.
 
-**Primary Requirement**: При падении GLM API система автоматически переключается на Ollama с Gemini-3-flash-preview за < 30 секунд.
+**Primary Requirement**: При падении primary Codex lane система автоматически переключается на Ollama Cloud за < 30 секунд.
 
 **Technical Approach**: Docker Compose sidecar + Bash scripts для health monitoring + TOML конфигурация для Moltis providers.
 
@@ -106,7 +106,7 @@ See [research.md](./research.md) for detailed findings.
 See [data-model.md](./data-model.md) for entity definitions.
 
 **Key Entities**:
-1. **LLM Provider** - GLM (primary) and Ollama (fallback)
+1. **LLM Provider** - OpenAI Codex (primary) and Ollama (fallback)
 2. **Circuit Breaker State** - CLOSED, OPEN, HALF-OPEN
 3. **Failover Event** - Switch records for observability
 
@@ -154,7 +154,7 @@ See [quickstart.md](./quickstart.md) for deployment instructions.
 | Ollama cold start (~60s) | Preload model in Docker entrypoint | Phase 1 |
 | Memory competition | Resource limits 8GB for Ollama | Phase 1 |
 | Race conditions | File locking with flock | Phase 3 |
-| GLM false positives | Configure proper timeout (5s) | Phase 3 |
+| False-positive primary outage detection | Configure proper timeout (5s) | Phase 3 |
 
 ## Success Metrics
 

--- a/specs/001-fallback-llm-ollama/quickstart.md
+++ b/specs/001-fallback-llm-ollama/quickstart.md
@@ -1,4 +1,4 @@
-# Quick Start: Fallback LLM with Ollama Sidecar
+# Quick Start: Fallback LLM with Ollama Cloud
 
 **Feature**: 001-fallback-llm-ollama
 **Time to Deploy**: ~30 minutes
@@ -51,7 +51,7 @@ curl http://localhost:11434/api/tags
 # Check circuit breaker state
 cat /tmp/moltis-llm-state.json | jq .
 
-# Simulate GLM failure (test mode)
+# Simulate primary Codex failure (test mode)
 # docker compose -f docker-compose.prod.yml exec moltis ...
 ```
 
@@ -149,7 +149,7 @@ docker compose exec ollama cat /run/secrets/ollama_api_key
 ## Next Steps
 
 1. **Monitor**: Check Prometheus metrics at http://localhost:9090
-2. **Test failover**: Simulate GLM outage and verify switch to Ollama
+2. **Test failover**: Simulate primary outage and verify switch to Ollama
 3. **Alert setup**: Configure AlertManager for failover notifications
 
 ## Rollback

--- a/specs/001-fallback-llm-ollama/research.md
+++ b/specs/001-fallback-llm-ollama/research.md
@@ -1,4 +1,4 @@
-# Research: Fallback LLM with Ollama Sidecar
+# Research: Fallback LLM with Ollama Cloud
 
 **Feature**: 001-fallback-llm-ollama
 **Date**: 2026-03-01
@@ -72,7 +72,7 @@ CLOSED → (3 failures) → OPEN → (60s) → HALF-OPEN → (success) → CLOSE
 **Schema**:
 ```json
 {
-  "current_provider": "glm",
+  "current_provider": "openai-codex",
   "circuit_state": "closed",
   "failure_count": 0,
   "last_failure": null,
@@ -94,9 +94,9 @@ CLOSED → (3 failures) → OPEN → (60s) → HALF-OPEN → (success) → CLOSE
 
 **Probe Implementation**:
 ```bash
-# GLM health check
-check_glm_health() {
-  curl -sf --max-time 5 "${GLM_API_URL}/v1/models" || return 1
+# Primary health check
+check_primary_health() {
+  curl -sf --max-time 5 "${PRIMARY_PROVIDER_HEALTHCHECK_URL}" || return 1
 }
 
 # Ollama health check

--- a/specs/001-fallback-llm-ollama/spec.md
+++ b/specs/001-fallback-llm-ollama/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Fallback LLM with Ollama Sidecar
+# Feature Specification: Fallback LLM with Ollama Cloud
 
 **Feature Branch**: `001-fallback-llm-ollama`
 **Created**: 2026-03-01
@@ -7,11 +7,11 @@
 
 ## Overview
 
-Реализовать отказоустойчивую fallback-цепочку для Moltis: `openai-codex::gpt-5.4` как primary, затем `ollama::gemini-3-flash-preview:cloud`, затем `anthropic::claude-sonnet-4-20250514`, и финальный fallback `glm::glm-5.1` через официальный BigModel Coding Plan.
+Реализовать отказоустойчивую fallback-цепочку для Moltis: `openai-codex::gpt-5.4` как primary и `ollama::gemini-3-flash-preview:cloud` как единственный tracked fallback.
 
 **Problem**: При отказе primary или промежуточного fallback-провайдера пользователь не должен получать raw provider/tool errors или оставаться без ответа.
 
-**Solution**: Ollama Sidecar + ordered failover policy + circuit-breaker style health tracking для автоматического перехода по цепочке `Codex -> Ollama -> Claude -> GLM-5.1`.
+**Solution**: Ollama Sidecar + ordered failover policy + circuit-breaker style health tracking для автоматического перехода по цепочке `Codex -> Ollama`.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -21,12 +21,12 @@
 
 **Why this priority**: Это критическая функциональность - без неё primary LLM outage превращается в пользовательский инцидент.
 
-**Independent Test**: Можно протестировать, симулировав недоступность `openai-codex::gpt-5.4` и проверив, что запросы переходят на Ollama, затем на Claude/GLM-5.1 при дальнейших отказах.
+**Independent Test**: Можно протестировать, симулировав недоступность `openai-codex::gpt-5.4` и проверив, что запросы переходят на Ollama, а при недоступности обоих провайдеров возвращается fail-closed user-facing ошибка без leakage.
 
 **Acceptance Scenarios**:
 
 1. **Given** `openai-codex::gpt-5.4` недоступен (timeout/error), **When** пользователь отправляет запрос к Moltis, **Then** запрос автоматически перенаправляется в Ollama с Gemini
-2. **Given** primary и Ollama одновременно недоступны, **When** пользователь отправляет запрос, **Then** система последовательно переходит на Claude и затем на `glm::glm-5.1` без raw provider-resolution leakage
+2. **Given** primary и Ollama одновременно недоступны, **When** пользователь отправляет запрос, **Then** система возвращает понятную fail-closed ошибку без raw provider-resolution leakage
 3. **Given** primary восстановлен после сбоя, **When** circuit breaker переходит в half-open state, **Then** система автоматически возвращается к `openai-codex::gpt-5.4`
 4. **Given** вся цепочка недоступна, **When** пользователь отправляет запрос, **Then** система возвращает понятную ошибку с информацией о статусе без показа внутренних tool/provider errors
 
@@ -42,9 +42,9 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** система работает, **When** запрашиваются метрики, **Then** возвращаются `llm_provider_available{provider="openai-codex"}`, `llm_provider_available{provider="ollama"}`, `llm_provider_available{provider="anthropic"}` и `llm_provider_available{provider="glm"}`
+1. **Given** система работает, **When** запрашиваются метрики, **Then** возвращаются `llm_provider_available{provider="openai-codex"}` и `llm_provider_available{provider="ollama"}`
 2. **Given** произошёл failover, **When** запрашивается метрика, **Then** `llm_fallback_triggered_total` увеличивается
-3. **Given** в цепочке остаётся только финальный GLM fallback или цепочка полностью деградировала, **When** срабатывает alert, **Then** администратор получает уведомление
+3. **Given** в цепочке остаётся только Ollama fallback или цепочка полностью деградировала, **When** срабатывает alert, **Then** администратор получает уведомление
 
 ---
 
@@ -66,10 +66,10 @@
 
 ### Edge Cases
 
-- Что происходит при одновременном отказе primary, Ollama и Claude?
+- Что происходит при одновременном отказе primary и Ollama?
 - Как система обрабатывает race conditions при множественных instance?
 - Что происходит при cold start Ollama (первая загрузка модели ~30-60s)?
-- Как обрабатываются timeout при медленном ответе финального `glm::glm-5.1`?
+- Какой user-facing текст считать каноническим для ситуации, когда недоступны и primary, и Ollama fallback?
 
 ## Requirements *(mandatory)*
 
@@ -84,7 +84,7 @@
 - **FR-007**: System MUST экспортировать метрики для Prometheus (`llm_fallback_triggered_total`, `llm_provider_available`)
 - **FR-008**: System MUST валидировать Ollama конфигурацию в preflight job CI/CD
 - **FR-009**: System MUST выполнять smoke tests для failover в verify job CI/CD
-- **FR-010**: System MUST управлять `OLLAMA_API_KEY`, `ANTHROPIC_API_KEY` и `GLM_API_KEY` через runtime environment / secret management без hardcoded значений
+- **FR-010**: System MUST управлять `OLLAMA_API_KEY` через runtime environment / secret management без hardcoded значений
 
 ### Non-Functional Requirements
 
@@ -96,7 +96,7 @@
 
 ### Key Entities
 
-- **LLM Provider**: Сущность, представляющая LLM провайдера в ordered chain (`openai-codex`, `ollama`, `anthropic`, `glm`). Атрибуты: name, status (available/unavailable), latency, error_count
+- **LLM Provider**: Сущность, представляющая LLM провайдера в ordered chain (`openai-codex`, `ollama`). Атрибуты: name, status (available/unavailable), latency, error_count
 - **Circuit Breaker State**: Текущее состояние circuit breaker. Атрибуты: state (CLOSED/OPEN/HALF-OPEN), failure_count, last_failure_time, last_success_time
 - **Failover Event**: Событие переключения между провайдерами. Атрибуты: timestamp, from_provider, to_provider, reason
 
@@ -105,7 +105,7 @@
 ### Measurable Outcomes
 
 - **SC-001**: При падении `openai-codex::gpt-5.4`, система переключается на Ollama за < 30 секунд (3 consecutive failures × 5s interval + processing time)
-- **SC-002**: При последовательном отказе primary и Ollama система доходит до Claude/GLM-5.1 без raw `model ... not found` или `No models available` leakage
+- **SC-002**: При последовательном отказе primary и Ollama система возвращает fail-closed user-facing ошибку без raw `model ... not found` или `No models available` leakage
 - **SC-003**: Метрики failover доступны в Prometheus и корректно отображают состояние провайдеров
 - **SC-004**: CI/CD pipeline падает при некорректной конфигурации Ollama (validation работает)
 - **SC-005**: Smoke tests в verify job проходят успешно при корректной конфигурации
@@ -115,10 +115,10 @@
 - OLLAMA_API_KEY будет получен пользователем через подписку на ollama.com
 - Сервер имеет достаточно ресурсов (4+ CPUs, 8GB+ RAM) для Ollama контейнера
 - Moltis поддерживает множественные LLM providers через конфигурацию
-- Официальный BigModel Coding Plan endpoint `https://open.bigmodel.cn/api/coding/paas/v4` остаётся допустимым финальным fallback для `glm::glm-5.1`
 
 ## Out of Scope
 
+- Любые дополнительные fallback lanes beyond Ollama Cloud
 - Локальные модели Ollama (только cloud модели)
 - Prometheus exporter (Phase 2)
 - Grafana dashboard (Phase 2)
@@ -139,7 +139,7 @@
 | Ollama cold start (~60s) | High | Предзагрузка модели при старте контейнера |
 | Memory competition с Moltis | Medium | Resource limits для Ollama (8GB) |
 | Race conditions при failover | Medium | File locking для state file |
-| Final GLM-5.1 false positives | Low | Настройка timeout и retry logic для official BigModel endpoint |
+| False-positive primary outage detection | Low | Настройка timeout, retry logic и clear health thresholds для primary lane |
 
 ## References
 

--- a/specs/001-fallback-llm-ollama/tasks.md
+++ b/specs/001-fallback-llm-ollama/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: Fallback LLM with Ollama Sidecar
+# Tasks: Fallback LLM with Ollama Cloud
 
 **Input**: Design documents from `/specs/001-fallback-llm-ollama/`
 **Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
@@ -79,17 +79,17 @@
 
 ---
 
-## Phase 3: User Story 1 - Automatic Failover on GLM Outage (Priority: P1) 🎯 MVP
+## Phase 3: User Story 1 - Automatic Failover on Primary Outage (Priority: P1) 🎯 MVP
 
-**Goal**: System automatically switches to Ollama when GLM API is unavailable
+**Goal**: System automatically switches to Ollama when the primary Codex lane is unavailable
 
-**Independent Test**: Simulate GLM API unavailability and verify requests go to Ollama
+**Independent Test**: Simulate primary Codex lane unavailability and verify requests go to Ollama
 
 ### Implementation for User Story 1
 
 - [X] T009 [P] [US1] Create scripts/ollama-health.sh for Ollama health checks
   → Artifacts: [scripts/ollama-health.sh](/scripts/ollama-health.sh)
-- [X] T010 [P] [US1] Add GLM health check function to scripts/health-monitor.sh
+- [X] T010 [P] [US1] Add primary-provider health check function to scripts/health-monitor.sh
   → Artifacts: [scripts/health-monitor.sh](/scripts/health-monitor.sh)
 - [X] T011 [US1] Implement circuit breaker state machine in scripts/health-monitor.sh (CLOSED → OPEN → HALF-OPEN)
   → Artifacts: [scripts/health-monitor.sh](/scripts/health-monitor.sh)
@@ -102,7 +102,7 @@
 - [X] T015 [US1] Add graceful recovery logic (half-open state testing) to scripts/health-monitor.sh
   → Artifacts: [scripts/health-monitor.sh](/scripts/health-monitor.sh)
 
-**Checkpoint**: Circuit breaker automatically switches GLM → Ollama on 3 consecutive failures
+**Checkpoint**: Circuit breaker automatically switches OpenAI Codex → Ollama on 3 consecutive failures
 
 ---
 
@@ -122,12 +122,12 @@
   → Artifacts: [scripts/health-monitor.sh](/scripts/health-monitor.sh)
 - [X] T019 [US2] Add circuit breaker state metric (moltis_circuit_state) to scripts/health-monitor.sh
   → Artifacts: [scripts/health-monitor.sh](/scripts/health-monitor.sh)
-- [X] T020 [US2] Add Prometheus alert rules for GLM API unavailability in config/prometheus/alerts.yml
+- [X] T020 [US2] Add Prometheus alert rules for primary-provider unavailability in config/prometheus/alerts.yml
   → Artifacts: [config/prometheus/alert-rules.yml](/config/prometheus/alert-rules.yml)
 - [X] T021 [US2] Add AlertManager notification config for failover events in config/alertmanager/alertmanager.yml
   → Artifacts: [config/alertmanager/alertmanager.yml](/config/alertmanager/alertmanager.yml)
 
-**Checkpoint**: Metrics visible in Prometheus, alerts trigger on GLM outage
+**Checkpoint**: Metrics visible in Prometheus, alerts trigger on primary outage
 
 ---
 
@@ -226,7 +226,7 @@ Task: "Create secrets/ollama_api_key.txt placeholder"
 ```bash
 # Can run in parallel (different files):
 Task: "Create scripts/ollama-health.sh"
-Task: "Add GLM health check to scripts/health-monitor.sh"
+Task: "Add primary-provider health check to scripts/health-monitor.sh"
 ```
 
 ---

--- a/specs/001-moltis-docker-deploy/plan.md
+++ b/specs/001-moltis-docker-deploy/plan.md
@@ -7,7 +7,7 @@
 
 Deploy Moltis AI assistant as a Docker container on ainetic.tech server with:
 - **Reverse Proxy**: Traefik (already deployed) with automatic TLS
-- **LLM Provider**: Primary `openai-codex::gpt-5.4` with ordered fallback `ollama -> anthropic -> glm::glm-5.1`
+- **LLM Provider**: Primary `openai-codex::gpt-5.4` with single fallback `ollama::gemini-3-flash-preview:cloud`
 - **Auto-updates**: Watchtower for automatic container updates
 - **Backup**: Daily cron backup with 7-day retention
 - **Authentication**: MOLTIS_PASSWORD for initial setup
@@ -110,7 +110,7 @@ moltinger/
                                       ▼
                     ┌─────────────────────────────────────────┐
                     │  Provider Chain                         │
-                    │  Codex -> Ollama -> Claude -> GLM 5.1  │
+                    │  Codex -> Ollama Cloud                 │
                     └─────────────────────────────────────────┘
 ```
 
@@ -154,7 +154,7 @@ Routing configuration:
 | Traefik | 3.x | Reverse proxy (existing) |
 | Moltis | latest | AI assistant |
 | Watchtower | latest | Auto-updates |
-| Provider chain | live | Codex primary + ordered fallbacks |
+| Provider chain | live | Codex primary + Ollama Cloud fallback |
 
 ## Security Considerations
 

--- a/specs/001-moltis-docker-deploy/quickstart.md
+++ b/specs/001-moltis-docker-deploy/quickstart.md
@@ -7,7 +7,7 @@ This guide covers the complete deployment process for Moltis AI assistant.
 - [x] Docker 24.x+ installed
 - [x] Traefik 3.x deployed with Let's Encrypt
 - [x] DNS: ainetic.tech pointing to server IP
-- [x] GLM API key from Zhipu AI
+- [x] OpenAI Codex OAuth runtime already bootstrapped on the target host
 
 ## Quick Deploy
 
@@ -19,7 +19,7 @@ cd moltinger
 # 2. Create environment file
 cat > .env << EOF
 MOLTIS_PASSWORD=your-secure-password
-GLM_API_KEY=your-glm-api-key
+OLLAMA_API_KEY=your-ollama-cloud-key
 EOF
 
 # 3. Create directories
@@ -55,17 +55,18 @@ Located at repository root. Contains:
 ### config/moltis.toml
 
 Moltis configuration. Key settings:
-- GLM provider endpoint
+- OpenAI Codex primary model via OAuth runtime state
+- Optional Ollama Cloud fallback lane
 - Sandbox configuration
 - Authentication settings
 
 ### config/provider_keys.json
 
-API keys for LLM providers. Created automatically on first run or manually:
+Runtime credential store for provider integrations. Created automatically on first run or during OAuth/bootstrap:
 
 ```json
 {
-  "glm-coding": "your-glm-api-key"
+  "openai-codex": "oauth-managed-runtime-state"
 }
 ```
 
@@ -165,7 +166,7 @@ tail -f /var/log/moltis-backup.log
 ## Security Checklist
 
 - [ ] MOLTIS_PASSWORD set to strong password
-- [ ] GLM_API_KEY stored in .env (not committed)
+- [ ] OLLAMA_API_KEY stored in .env when Ollama Cloud fallback is required
 - [ ] config/provider_keys.json gitignored
 - [ ] TLS certificate valid (check SSL Labs)
 - [ ] Rate limiting active (5 attempts/60s)
@@ -173,7 +174,7 @@ tail -f /var/log/moltis-backup.log
 
 ## Next Steps
 
-1. Configure GLM provider in Web UI
+1. Confirm Codex OAuth session and optional Ollama Cloud fallback in Web UI
 2. Test sandbox execution with simple command
 3. Set up monitoring for /health endpoint
 4. Document any custom configurations

--- a/specs/001-moltis-docker-deploy/research.md
+++ b/specs/001-moltis-docker-deploy/research.md
@@ -27,11 +27,9 @@ Research completed via deep documentation analysis from https://docs.moltis.org/
 
 ### 2. LLM Provider Chain
 
-**Decision**: Primary `openai-codex::gpt-5.4` with ordered fallback `ollama -> anthropic -> glm::glm-5.1`
+**Decision**: Primary `openai-codex::gpt-5.4` with single ordered fallback `ollama`
 
-**Rationale**: Moltis should keep Codex as the preferred coding model while preserving an explicit failover chain. Legacy Z.ai API-key usage is no longer acceptable outside IDE-only coding flows, so GLM remains only as the final fallback via the official BigModel endpoint.
-
-**Final GLM Endpoint**: `https://open.bigmodel.cn/api/coding/paas/v4`
+**Rationale**: Moltis should keep Codex as the preferred coding model while preserving one explicit failover lane through Ollama Cloud. Legacy Z.ai API-key usage is no longer acceptable outside IDE-only coding flows, and the tracked runtime/deploy contract no longer activates Anthropic or GLM fallback lanes.
 
 **Configuration**:
 ```toml
@@ -40,28 +38,19 @@ enabled = true
 
 [providers.ollama]
 enabled = true
-
-[providers.anthropic]
-enabled = true
-
-[providers.openai]
-enabled = true
-alias = "glm"
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-model = "glm-5.1"
-models = ["glm-5.1"]
+model = "gemini-3-flash-preview:cloud"
+alias = "ollama"
+api_key = "${OLLAMA_API_KEY}"
 
 [failover]
 fallback_models = [
   "ollama::gemini-3-flash-preview:cloud",
-  "anthropic::claude-sonnet-4-20250514",
-  "glm::glm-5.1",
 ]
 ```
 
 **Alternatives Considered**:
 - Z.ai Coding API keys — rejected: provider policy no longer allows non-IDE API-key usage without account risk
-- GLM as primary provider — rejected: operational policy now reserves GLM for final fallback only
+- Anthropic or GLM active fallback lanes — rejected: current operator policy leaves only Ollama Cloud as the tracked fallback surface
 - Local-only LLM — rejected: hardware constraints and weaker coding quality for the primary lane
 
 ---

--- a/specs/001-moltis-docker-deploy/spec.md
+++ b/specs/001-moltis-docker-deploy/spec.md
@@ -11,7 +11,7 @@
 ### Session 2026-02-14
 
 - Q: Какой reverse proxy использовать? → A: **Traefik** (уже развёрнут на сервере)
-- Q: Какой LLM провайдер использовать? → A: **Primary `openai-codex::gpt-5.4` + ordered fallback `ollama -> anthropic -> glm::glm-5.1`**, где GLM идёт только через официальный BigModel endpoint `https://open.bigmodel.cn/api/coding/paas/v4`
+- Q: Какой LLM провайдер использовать? → A: **Primary `openai-codex::gpt-5.4` + single fallback `ollama::gemini-3-flash-preview:cloud`**, при этом reasoning tier для primary управляется OAuth-backed runtime profile, а не статическим TOML-полем
 - Q: Как обновлять контейнер Moltis? → A: **Watchtower** для автоматических обновлений
 - Q: Нужна ли стратегия backup для volumes? → A: **Cron backup** — ежедневное резервирование с rotation 7 дней
 - Q: Что НЕ входит в scope? → A: **Базовый out-of-scope** — кластеризация, multi-region, SLA guarantees
@@ -214,7 +214,7 @@
 - **Data Volume**: Персистентное хранилище для баз данных, сессий, memory files, логов (путь: /home/moltis/.moltis)
 - **Docker Socket**: Unix socket для доступа к Docker daemon, необходим для sandboxed выполнения команд
 - **Reverse Proxy**: Traefik (уже развёрнут на сервере) для TLS-терминации и маршрутизации трафика
-- **LLM Provider**: primary `openai-codex::gpt-5.4` с fallback-цепочкой `ollama -> anthropic -> glm::glm-5.1`, где GLM использует официальный BigModel endpoint `https://open.bigmodel.cn/api/coding/paas/v4`
+- **LLM Provider**: primary `openai-codex::gpt-5.4` с единственным fallback `ollama::gemini-3-flash-preview:cloud`
 - **Credentials**: Пароли (Argon2id хеш), passkeys (WebAuthn), API keys (SHA-256 хеш), session cookies
 
 ## Success Criteria *(mandatory)*
@@ -480,10 +480,9 @@ services:
 ### Endpoint
 
 **Primary**: `openai-codex::gpt-5.4`
-**Fallbacks**: `ollama::gemini-3-flash-preview:cloud` → `anthropic::claude-sonnet-4-20250514` → `glm::glm-5.1`
-**Final GLM Base URL**: `https://open.bigmodel.cn/api/coding/paas/v4`
+**Fallbacks**: `ollama::gemini-3-flash-preview:cloud`
 
-**Auth**: API Key (хранится в `provider_keys.json`)
+**Auth**: OpenAI Codex OAuth runtime state for primary + `OLLAMA_API_KEY` for cloud fallback
 
 ### Configuration (moltis.toml)
 
@@ -500,26 +499,11 @@ base_url = "http://ollama:11434"
 model = "gemini-3-flash-preview:cloud"
 alias = "ollama"
 api_key = "${OLLAMA_API_KEY}"
-
-[providers.anthropic]
-enabled = true
-api_key = "${ANTHROPIC_API_KEY}"
-model = "claude-sonnet-4-20250514"
-base_url = "https://api.anthropic.com"
-alias = "anthropic"
-
-[providers.openai]
-enabled = true
-api_key = "${GLM_API_KEY}"
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-model = "glm-5.1"
-alias = "glm"
-models = ["glm-5.1"]
 ```
 
 ### API Key Setup
 
-OAuth / provider keys устанавливаются через Web UI при первом запуске или напрямую в `~/.config/moltis/provider_keys.json`, но Z.ai-specific provider aliases больше не используются.
+OAuth / provider keys устанавливаются через Web UI при первом запуске или напрямую в `~/.config/moltis/provider_keys.json`. Static deploy contract использует только `OLLAMA_API_KEY` для cloud fallback; Z.ai-specific provider aliases больше не используются.
 
 ---
 

--- a/specs/001-moltis-docker-deploy/tasks.md
+++ b/specs/001-moltis-docker-deploy/tasks.md
@@ -340,22 +340,22 @@
 
 ## Phase 14: Primary Codex + Ordered Fallback Chain
 
-**Goal**: Configure the production provider chain with Codex primary and ordered fallbacks `ollama -> anthropic -> glm::glm-5.1`
+**Goal**: Configure the production provider chain with Codex primary and Ollama Cloud fallback
 
 **Independent Test**:
 1. Open Web UI
 2. Verify `openai-codex::gpt-5.4` remains the primary model
-3. Verify fallback order is `ollama`, then `anthropic`, then official BigModel `glm::glm-5.1`
+3. Verify the only active fallback lane is `ollama::gemini-3-flash-preview:cloud`
 4. Send a test message without any raw provider/tool leakage
 
 ### Implementation
 
-- [X] T052 [P] Create `config/moltis.toml` with primary Codex plus ordered fallback-chain settings
-- [X] T053 Add official BigModel GLM base_url: `https://open.bigmodel.cn/api/coding/paas/v4`
-- [X] T054 Add provider-chain secret requirements to `.env.example` and deployment docs (`OLLAMA_API_KEY`, `ANTHROPIC_API_KEY`, `GLM_API_KEY`)
+- [X] T052 [P] Create `config/moltis.toml` with primary Codex plus Ollama Cloud fallback settings
+- [X] T053 Keep the primary lane on OpenAI Codex OAuth / `gpt-5.4` without static API-key coupling
+- [X] T054 Add provider-chain secret requirements to `.env.example` and deployment docs (`OLLAMA_API_KEY`)
 - [ ] T055 Test Web UI and Telegram entrypoints against the ordered provider chain
 
-**Checkpoint**: Provider chain working without legacy Z.ai aliases
+**Checkpoint**: Provider chain working without legacy Z.ai aliases or any retired non-Ollama fallback lanes
 
 **Artifacts**:
 - `config/moltis.toml`
@@ -502,7 +502,7 @@ Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 14
 
 - [ ] S001 Clone repository on server: `git clone https://github.com/RussianLioN/moltinger.git /opt/moltinger`
 - [ ] S002 Setup environment: `cp .env.example .env && nano .env`
-- [ ] S003 Add secrets to `.env` (`MOLTIS_PASSWORD`, `OLLAMA_API_KEY`, `ANTHROPIC_API_KEY`, `GLM_API_KEY`)
+- [ ] S003 Add secrets to `.env` (`MOLTIS_PASSWORD`, `OLLAMA_API_KEY`)
 - [ ] S004 Run `make setup` to create networks and secrets
 - [ ] S005 Run `make deploy` for initial deployment
 - [ ] S006 Verify health: `curl https://ainetic.tech/health`

--- a/tests/component/test_circuit_breaker.sh
+++ b/tests/component/test_circuit_breaker.sh
@@ -14,7 +14,6 @@ export CIRCUIT_BREAKER_RECOVERY_TIMEOUT=2
 export CIRCUIT_BREAKER_SUCCESS_THRESHOLD=2
 export PRIMARY_PROVIDER="openai-codex"
 export FALLBACK_PROVIDER="ollama"
-export GLM_API_KEY="fixture-glm"
 export OLLAMA_HOST="http://127.0.0.1:11434"
 
 # shellcheck source=scripts/health-monitor.sh

--- a/tests/component/test_llm_failover_component.sh
+++ b/tests/component/test_llm_failover_component.sh
@@ -14,7 +14,6 @@ export CIRCUIT_BREAKER_RECOVERY_TIMEOUT=2
 export CIRCUIT_BREAKER_SUCCESS_THRESHOLD=1
 export PRIMARY_PROVIDER="openai-codex"
 export FALLBACK_PROVIDER="ollama"
-export GLM_API_KEY="fixture-glm"
 export OLLAMA_HOST="http://127.0.0.1:11434"
 
 # shellcheck source=scripts/health-monitor.sh

--- a/tests/component/test_prometheus_metrics.sh
+++ b/tests/component/test_prometheus_metrics.sh
@@ -17,7 +17,6 @@ export PROMETHEUS_METRICS_FILE="$PROM_FILE"
 export CIRCUIT_BREAKER_FAILURE_THRESHOLD=3
 export PRIMARY_PROVIDER="openai-codex"
 export FALLBACK_PROVIDER="ollama"
-export GLM_API_KEY="fixture-glm"
 export OLLAMA_HOST="http://127.0.0.1:11434"
 
 # shellcheck source=scripts/health-monitor.sh

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -318,7 +318,7 @@ NODE
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";
 const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
-const badReply = "model 'glm::glm-5.1' not found. available: [\"openai-codex::gpt-5.4\",\"ollama::gemini-3-flash-preview:cloud\",\"anthropic::claude-sonnet-4-20250514\"]";
+const badReply = "model 'glm::glm-5.1' not found. available: [\"openai-codex::gpt-5.4\",\"ollama::gemini-3-flash-preview:cloud\"]";
 const goodReply = "Статус: Online | Модель: openai-codex::gpt-5.4";
 if (!isReplyErrorSignature(badReply)) {
   throw new Error("expected model-not-found reply to be treated as error signature");

--- a/tests/fixtures/config/moltis.toml
+++ b/tests/fixtures/config/moltis.toml
@@ -72,7 +72,13 @@ name = "Fixture"
 timezone = "Europe/Moscow"
 
 [providers]
-offered = ["ollama"]
+offered = ["openai-codex", "ollama"]
+
+[providers.openai-codex]
+enabled = true
+model = "gpt-5.4"
+alias = "openai-codex"
+models = ["gpt-5.4"]
 
 [providers.ollama]
 enabled = true
@@ -81,17 +87,10 @@ model = "test-model"
 alias = "ollama"
 api_key = "${OLLAMA_API_KEY}"
 
-[providers.openai]
-enabled = false
-api_key = "${GLM_API_KEY}"
-model = "glm-5.1"
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-alias = "glm"
-
 [chat]
 message_queue_mode = "followup"
-allowed_models = ["ollama::test-model"]
-priority_models = ["ollama::test-model"]
+allowed_models = ["openai-codex::gpt-5.4", "ollama::test-model"]
+priority_models = ["openai-codex::gpt-5.4", "ollama::test-model"]
 
 [tools]
 agent_timeout_secs = 15

--- a/tests/live_external/test_provider_live.sh
+++ b/tests/live_external/test_provider_live.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/test_helpers.sh"
 
-GLM_API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
-GLM_API_KEY="${GLM_API_KEY:-}"
 OLLAMA_HOST="${OLLAMA_HOST:-}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-20}"
 
@@ -25,17 +23,6 @@ run_live_provider_tests() {
         generate_report
         return
     }
-
-    test_start "live_provider_glm_models_endpoint"
-    if require_secret_or_skip GLM_API_KEY "GLM_API_KEY"; then
-        local glm_code
-        glm_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TEST_TIMEOUT" -H "Authorization: Bearer $GLM_API_KEY" "${GLM_API_BASE%/}/models" 2>/dev/null || echo '000')
-        if [[ "$glm_code" =~ ^(200|201)$ ]]; then
-            test_pass
-        else
-            test_fail "GLM models endpoint should return 200/201 (got $glm_code)"
-        fi
-    fi
 
     test_start "live_provider_ollama_tags_endpoint"
     if [[ -z "$OLLAMA_HOST" ]]; then

--- a/tests/resilience/test_full_failover_chain.sh
+++ b/tests/resilience/test_full_failover_chain.sh
@@ -5,8 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/test_helpers.sh"
 
 ALLOW_DESTRUCTIVE_TESTS="${ALLOW_DESTRUCTIVE_TESTS:-0}"
-GLM_API_KEY="${GLM_API_KEY:-}"
-GLM_API_BASE="${GLM_API_BASE:-https://open.bigmodel.cn/api/coding/paas/v4}"
 OLLAMA_HOST="${OLLAMA_HOST:-}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-15}"
 MOLTIS_CONTAINER="${MOLTIS_CONTAINER:-moltis}"
@@ -43,19 +41,6 @@ run_resilience_failover_chain_tests() {
         test_pass
     else
         test_fail "OpenAI Codex auth should be valid before failover drill"
-    fi
-
-    test_start "resilience_failover_glm_health"
-    require_secret_or_skip GLM_API_KEY "GLM_API_KEY" || {
-        generate_report
-        return
-    }
-    local glm_code
-    glm_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TEST_TIMEOUT" -H "Authorization: Bearer $GLM_API_KEY" "${GLM_API_BASE%/}/models" 2>/dev/null || echo '000')
-    if [[ "$glm_code" =~ ^(200|201)$ ]]; then
-        test_pass
-    else
-        test_fail "GLM fallback provider should be reachable before failover drill (got $glm_code)"
     fi
 
     test_start "resilience_failover_ollama_health"

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -610,11 +610,12 @@ run_static_config_validation_tests() {
         test_fail "Tracked Moltis version must resolve to an explicit GHCR tag without leading v and be validated by scripts/moltis-version.sh"
     fi
 
-    test_start "static_fixture_disables_openai_for_pr_gate"
-    if rg -n '^\[providers\.openai\]' -A3 "$TEST_FIXTURE_CONFIG" | rg -q 'enabled = false'; then
+    test_start "static_fixture_uses_codex_primary_without_legacy_openai_provider"
+    if rg -q '^\[providers\.openai-codex\]' "$TEST_FIXTURE_CONFIG" && \
+       ! rg -q '^\[providers\.openai\]' "$TEST_FIXTURE_CONFIG"; then
         test_pass
     else
-        test_fail "Fixture config should disable OpenAI provider"
+        test_fail "Fixture config should use openai-codex primary without legacy providers.openai drift"
     fi
 
     test_start "static_fixture_uses_internal_ollama_service"

--- a/tests/unit/test_deploy_workflow_guards.sh
+++ b/tests/unit/test_deploy_workflow_guards.sh
@@ -801,8 +801,6 @@ test_render_moltis_env_script_renders_runtime_contract() {
     output_file="$tmp_dir/moltis.env"
 
     if ! MOLTIS_PASSWORD="secret" \
-        ANTHROPIC_API_KEY="anthropic-key" \
-        GLM_API_KEY="glm-key" \
         OLLAMA_API_KEY="ollama-key" \
         TAVILY_API_KEY="tavily-key" \
         TELEGRAM_BOT_TOKEN="telegram-token" \
@@ -818,8 +816,7 @@ test_render_moltis_env_script_renders_runtime_contract() {
     fi
 
     if ! grep -Fq "MOLTIS_PASSWORD=secret" "$output_file" || \
-       ! grep -Fq "ANTHROPIC_API_KEY=anthropic-key" "$output_file" || \
-       ! grep -Fq "GLM_API_KEY=glm-key" "$output_file" || \
+       ! grep -Fq "OLLAMA_API_KEY=ollama-key" "$output_file" || \
        ! grep -Fq "MOLTIS_DOMAIN=moltis.example.com" "$output_file" || \
        ! grep -Fq "MOLTIS_RUNTIME_CONFIG_DIR=/srv/runtime-config" "$output_file"; then
         test_fail "render-moltis-env.sh output is missing required runtime contract keys"


### PR DESCRIPTION
## Summary
- remove Anthropic and GLM from the active Moltis fallback contract
- keep OpenAI Codex GPT-5.4 as the primary OAuth-backed model and Ollama Cloud as the only tracked fallback lane
- align deploy/runtime docs, specs, and tests with the clarified contract

## Validation
- bash tests/unit/test_deploy_workflow_guards.sh
- bash tests/component/test_telegram_web_probe_correlation.sh
- bash tests/static/test_config_validation.sh
- bash -n scripts/render-moltis-env.sh
- bash -n scripts/health-monitor.sh