### PR TITLE
fix: contain telegram-safe maintenance turns

### DIFF
--- a/.moltis/hooks/telegram-safe-llm-guard/HOOK.md
+++ b/.moltis/hooks/telegram-safe-llm-guard/HOOK.md
@@ -17,6 +17,9 @@ path for the Telegram safe lane. It rewrites `BeforeLLMCall`,
 `AfterLLMCall`, `BeforeToolCall`, and `MessageSending` payloads when the
 `custom-zai-telegram-safe` provider tries to drift into tool-backed or
 telemetry-leaking behavior or filesystem-based skill false negatives.
+It also fail-closes skill/codex-update maintenance-debug turns (`почини`,
+`исправь`, `отладь`, logs/root-cause requests) into a deterministic text-only
+boundary instead of letting runtime tool chatter leak back into Telegram.
 
 Repository note:
 

--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -144,6 +144,9 @@ soul = """
 - Для вопросов про навыки и skill-authoring не используй sandbox filesystem как primary truth. Если hook/runtime snapshot не подтверждает список навыков, честно скажи, что это не доказательство отсутствия навыков.
 - Если live Telegram runtime проигнорировал repo/user hooks, всё равно соблюдай эти Telegram-safe правила как прямой fallback-контракт ответа.
 - Для skill visibility/create/update/delete в user-facing Telegram предпочитай dedicated tools `create_skill`, `update_skill`, `delete_skill`, а не `exec`/browser/web-search пути.
+- Для запросов вида `почини/исправь/отладь навык ...`, `почини codex-update`, `посмотри логи skill/codex-update`, `найди root cause` в user-facing Telegram/DM не запускай внутренние инструменты, не читай SKILL.md и не открывай логи.
+- Для такого maintenance/debug класса Telegram-safe ответ должен сразу переводить пользователя в text-only boundary: кратко объясни, что repair/debug/log inspection продолжаются только в web UI/операторской сессии.
+- В этом же классе запросов разрешено упомянуть, что простые правки навыка возможны только по явной CRUD-команде через `create_skill`, `update_skill` или `delete_skill`.
 - Для вопросов вида `какие у тебя навыки`, `что у тебя с навыками`, `skills?` сначала дай прямой список имён навыков, если runtime snapshot их подтверждает.
 - Для такого skill visibility ответа не ограничивайся только количеством навыков и не задавай встречный вопрос до явного перечисления имён.
 - Если пользователь в Telegram/DM пишет короткую команду вида `создай навык <name>` или `create <name> skill` и уже дал конкретное имя/slug, считай это достаточным разрешением для первой попытки `create_skill`.
@@ -157,6 +160,7 @@ soul = """
 - Для таких вопросов не используй `memory_search`, общую память чата или формулировки `в памяти не найдено` как замену чтению runtime state.
 - Если trusted operator/local surface реально видит `/server` и writable runtime state, можно использовать канонический runtime `bash /server/scripts/moltis-codex-update-run.sh --mode manual --stdout summary`.
 - Если канонический local runtime path недоступен на текущей surface, используй official внешние источники как primary truth вместо ложного вывода “skill path не существует”.
+- Если пользователь в Telegram/DM просит именно починить/отладить `codex-update`, прочитать его `SKILL.md`, открыть его логи или расследовать runtime error, не превращай это в advisory/release check. Это maintenance/debug boundary, который не обслуживается в этом чате.
 - Локальную установленную версию Codex CLI или локальный auto-update behavior обсуждай только если пользователь явно спрашивает именно про локальную машину.
 - Для запросов про создание или обновление Moltis skills сначала используй локальные проектные гайды `/server/docs/moltis-skill-agent-authoring.md` и `/server/docs/knowledge/MOLTIS-SELF-LEARNING-INSTRUCTION.md`.
 - Official docs Moltis для skill-authoring открывай точечно по релевантным разделам (`creating a skill`, `updating a skill`, `system prompt`, `session state`, `scheduling`), а не буквальным обходом всего сайта в одном run.

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-04-15
-**Total Lessons**: 83
+**Generated**: 2026-04-20
+**Total Lessons**: 84
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (39 lessons)
+#### P1 (40 lessons)
+- [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
 - [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
@@ -185,7 +186,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (4 lessons)
+#### product (5 lessons)
+- [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
 - [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
 - [Telegram codex-update direct fastpath raced underlying run](../docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md)
@@ -210,15 +212,15 @@
 
 ### Popular Tags
 
-- `rca` (31 lessons)
+- `rca` (32 lessons)
 - `moltis` (26 lessons)
-- `telegram` (20 lessons)
+- `telegram` (21 lessons)
 - `deploy` (19 lessons)
 - `github-actions` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
+- `skills` (12 lessons)
 - `beads` (12 lessons)
-- `skills` (11 lessons)
 - `process` (9 lessons)
 
 
@@ -228,10 +230,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 83 |
-| Critical (P0/P1) | 40 |
+| Total Lessons | 84 |
+| Critical (P0/P1) | 41 |
 | Categories | 8 |
-| Unique Tags | 164 |
+| Unique Tags | 165 |
 
 ---
 

--- a/docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md
+++ b/docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md
@@ -1,0 +1,127 @@
+---
+title: "Telegram-safe maintenance turns fell into upstream tool-boundary errors"
+date: 2026-04-20
+severity: P1
+category: product
+tags: [telegram, skills, codex-update, hook, runtime, maintenance, rca]
+root_cause: "Live Moltis runtime accepted correct tool arguments from the model but still raised missing-parameter errors at the execution boundary, while the repo-owned Telegram-safe guard had no dedicated maintenance/debug intent for skill/codex-update repair turns and therefore failed to terminalize those turns before tool/runtime chatter leaked into user-visible Telegram replies."
+---
+
+# RCA: Telegram-safe maintenance turns fell into upstream tool-boundary errors
+
+Date: 2026-04-20  
+Status: Resolved in source, pending landing/deploy/live re-verification  
+Context: beads `moltinger-evgq`, Telegram-safe Moltis lane for skill/codex-update questions
+
+## Ошибка
+
+В user-facing Telegram бот отвечал не итогом, а смесью обычного текста и внутренних runtime-ошибок:
+
+```text
+Если хочешь, я сразу напишу готовую новую версию инструкции...
+📋 Activity log
+• 💻 Running: `sed -n '1,220p' /home/moltis/.moltis/skills/codex-update/SKILL.md`
+• 🧠 Searching memory...
+• ❌ missing 'command' parameter
+• ❌ missing 'query' parameter
+```
+
+Пользовательский запрос был по сути maintenance/debug turn: починить `codex-update`/skill-path и убрать leakage.  
+Вместо deterministic Telegram-safe boundary runtime ушёл в tool-backed path и показал сырой хвост.
+
+## Проверка прошлых уроков
+
+Проверены:
+
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag codex-update`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Релевантные прошлые RCA:
+
+1. `docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md`  
+   Уже фиксировал, что live Telegram runtime может игнорировать красивый in-band path и что надо смотреть на production evidence, а не только на локальную логику.
+2. `docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md`  
+   Уже покрывал тему terminalization после blocked tool follow-up.
+3. `docs/rca/2026-04-05-telegram-skill-detail-general-hardening.md`  
+   Уже показывал, что skill-related Telegram turns нельзя оставлять на filesystem/tool-heavy explanations.
+
+Что оказалось новым:
+
+- текущий инцидент был не scheduler/release question, а maintenance/debug turn по skill/codex-update;
+- production logs показали, что model/runtime формировали корректные аргументы для `exec` и `memory_search`, но execution boundary всё равно терял их и возвращал `missing 'command' parameter` / `missing 'query' parameter`;
+- repo-owned guard не имел отдельного класса для maintenance/debug turn и поэтому не переводил такие turns в fail-closed text-only boundary заранее.
+
+## Evidence
+
+Authoritative evidence была собрана с live host `root@ainetic.tech`:
+
+1. `docker logs moltis` показал фактические tool calls с корректными аргументами:
+   - `exec` с `{"command":"sed -n '1,220p' /home/moltis/.moltis/skills/codex-update/SKILL.md", ...}`
+   - `memory_search` с `{"query":"codex-update уведомление версия cron ...","limit":10}`
+2. Тот же live runtime сразу после этого возвращал:
+   - `missing 'command' parameter`
+   - `missing 'query' parameter`
+3. Checksums repo script и live script совпали:
+   - local `scripts/telegram-safe-llm-guard.sh`
+   - live `/server/scripts/telegram-safe-llm-guard.sh`
+4. Hook registration в live config была активна:
+   - `telegram-safe-llm-guard`
+   - `events = ["BeforeLLMCall", "AfterLLMCall", "BeforeToolCall", "MessageSending"]`
+5. Live runtime version была `moltis 0.10.18`, что подтверждало известную ненадёжность некоторых hook/delivery surfaces и необходимость repo-owned fail-closed containment.
+
+## 5 Whys
+
+| Level | Question | Answer |
+|---|---|---|
+| 1 | Почему пользователь увидел `Activity log` и `missing 'query' parameter`? | Потому что maintenance/debug turn ушёл в tool-backed path и поздний runtime tail не был переведён в deterministic Telegram-safe reply. |
+| 2 | Почему turn вообще ушёл в tool-backed path? | Потому что guard не распознал запрос как отдельный maintenance/debug класс и не сделал раннюю terminalization через text-only boundary. |
+| 3 | Почему отсутствие отдельного maintenance intent оказалось критичным? | Потому что существующие special cases покрывали skill visibility/template/create/detail и codex-update release/scheduler, но не generic repair/debug/log/root-cause turns. |
+| 4 | Почему поздний tool tail был особенно вредным? | Потому что upstream runtime boundary на live Moltis 0.10.18 терял уже корректно сформированные tool arguments и превращал их в ложные `missing parameter` ошибки, которые потом протекали наружу. |
+| 5 | Почему это стало системной проблемой, а не единичной ошибкой исполнения? | Потому что repo-owned containment полагался на то, что generic turn либо пройдёт нормально, либо будет пойман существующими overrides, но новый класс maintenance/debug turns не был формально описан и поэтому не имел ни intent persistence, ни BeforeToolCall suppression, ни dedicated MessageSending rewrite. |
+
+## Root Cause
+
+Корень проблемы состоял из двух слоёв:
+
+1. **External/upstream runtime defect**  
+   Live Moltis tool execution boundary в `0.10.18` принимал корректно сформированные model arguments, но местами терял их и возвращал ложные `missing required parameter` ошибки.
+2. **Repo-owned containment gap**  
+   Telegram-safe guard не выделял maintenance/debug turns по skill/codex-update в отдельный intent и не терминализировал их заранее, поэтому upstream runtime bug получал шанс стать user-visible.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - добавлен отдельный maintenance/debug intent для:
+     - skill repair/debug/log/root-cause turns;
+     - `codex-update` repair/debug/log/root-cause turns;
+   - maintenance turns теперь принудительно переводятся в text-only boundary до запуска инструментов;
+   - добавлена intent persistence для поздних `AfterLLMCall` / `MessageSending` hooks;
+   - добавлен dedicated `BeforeToolCall` suppression для maintenance turns;
+   - добавлен dedicated reply override для leaked maintenance/runtime chatter;
+   - bare `update` больше не считается release-signal для любого упоминания `codex-update`, чтобы `codex-update` maintenance turns не путались с advisory/release path.
+2. `config/moltis.toml`
+   - закреплён операторский контракт: maintenance/debug/log inspection по skill/codex-update не обслуживаются в user-facing Telegram/DM;
+   - отдельно зафиксировано, что простые CRUD-правки навыков допустимы только по явной команде через `create_skill/update_skill/delete_skill`.
+3. `.moltis/hooks/telegram-safe-llm-guard/HOOK.md`
+   - обновлено hook-level описание boundary для maintenance/debug turns.
+4. `tests/component/test_telegram_safe_llm_guard.sh`
+   - добавлены regressions на:
+     - early hard override для `почини codex-update`;
+     - exact live-style `Activity log` leak;
+     - plain runtime-failure leak без явного `Activity log`;
+     - контроль, что explicit `update_skill` остаётся allowlisted CRUD flow, а не попадает в maintenance bucket.
+
+## Prevention
+
+1. Любой новый user-facing Telegram turn family должен иметь явный intent class, если он отличается по risk profile от уже существующих safe routes.
+2. Для live Moltis `0.10.18` нельзя считать upstream tool boundary надёжным доказательством корректности user-facing reply даже при правильных model arguments.
+3. Skill/codex-update repair/debug/log turns должны закрываться fail-closed ещё на `BeforeLLMCall`, а не надеяться на generic fallback после tool execution.
+4. Если live evidence показывает “правильные аргументы вошли, но runtime сказал missing parameter”, проблема классифицируется как execution-boundary defect, а не как модельный prompt bug.
+
+## Уроки
+
+1. Maintenance/debug turns по skill/codex-update — это отдельный Telegram-safe contract, а не частный случай skill detail или codex-update advisory.
+2. Для user-facing Telegram нужно отдельно защищать turns, где пользователь просит “починить/отладить/посмотреть логи”, даже если похожие informational turns уже покрыты другими guard branches.
+3. В presence upstream runtime defects repo-owned guard обязан fail-close на уровне intent routing, иначе даже корректные аргументы и корректные tool names всё равно могут протечь наружу как ложные runtime errors.

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -2045,6 +2045,11 @@ build_skill_maintenance_reply_text() {
         return 0
     fi
 
+    if [[ "$target_kind" == "generic" ]]; then
+        printf '%s' 'В Telegram-safe режиме я не провожу repair/debug/log inspection через внутренние инструменты, логи и чтение файлов. Если нужна простая правка навыка, дай явную команду create_skill/update_skill/delete_skill, а для диагностики и runtime-проверки продолжим в web UI/операторской сессии.'
+        return 0
+    fi
+
     if [[ -n "$skill_name" && "$skill_name" != "generic" ]]; then
         printf 'В Telegram-safe режиме я не чиню и не отлаживаю навык `%s` через внутренние инструменты, логи и чтение файлов. Для простой правки скажи явно create_skill/update_skill/delete_skill, а для диагностики и runtime-проверки продолжим в web UI/операторской сессии.' "$skill_name"
         return 0
@@ -3734,7 +3739,7 @@ if [[ "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_fl
     current_turn_codex_update_scheduler_request=true
     current_turn_codex_update_request=true
 fi
-if [[ "$current_turn_codex_update_request" != true && "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(обновлен|обновлени|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового|новой|новая|новую|changelog|release notes)'; then
+if [[ "$current_turn_codex_update_request" != true && "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(обнови|обновить|обновлен|обновлени|upgrade|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового|новой|новая|новую|changelog|release notes)'; then
     current_turn_codex_update_request=true
 fi
 
@@ -3844,6 +3849,7 @@ fi
 persisted_codex_update_request=false
 persisted_codex_update_scheduler_request=false
 persisted_codex_update_maintenance_request=false
+persisted_generic_maintenance_request=false
 case "${persisted_turn_intent:-}" in
     codex_update)
         persisted_codex_update_request=true
@@ -3854,6 +3860,9 @@ case "${persisted_turn_intent:-}" in
         ;;
     codex_update_maintenance)
         persisted_codex_update_maintenance_request=true
+        ;;
+    maintenance_generic)
+        persisted_generic_maintenance_request=true
         ;;
 esac
 if [[ -z "$resolved_skill_name" && -n "$persisted_skill_detail_name" ]]; then
@@ -3873,20 +3882,23 @@ elif printf '%s' "$intent_text_flat" | grep -Eiq '(навык|skills?|skill)'; t
 fi
 current_turn_skill_maintenance_request=false
 current_turn_codex_update_maintenance_request=false
+current_turn_generic_maintenance_request=false
 if [[ "$maintenance_request_detected" == true ]]; then
     if [[ "$codex_update_subject_request" == true ]]; then
         current_turn_codex_update_maintenance_request=true
     elif [[ "$skill_subject_request" == true && "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true ]]; then
         current_turn_skill_maintenance_request=true
         looks_like_skill_turn=true
+    elif [[ "$looks_like_status" != true && "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true ]]; then
+        current_turn_generic_maintenance_request=true
     fi
 fi
-if [[ "$current_turn_skill_maintenance_request" == true || "$current_turn_codex_update_maintenance_request" == true ]]; then
+if [[ "$current_turn_skill_maintenance_request" == true || "$current_turn_codex_update_maintenance_request" == true || "$current_turn_generic_maintenance_request" == true ]]; then
     current_turn_codex_update_request=false
     current_turn_codex_update_scheduler_request=false
 fi
 if [[ "$current_turn_skill_detail_request" != true && "$looks_like_skill_turn" != true && -n "$requested_skill_reference_name" ]]; then
-    if [[ "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true && "$current_turn_skill_maintenance_request" != true ]]; then
+    if [[ "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true && "$current_turn_skill_maintenance_request" != true && "$current_turn_generic_maintenance_request" != true ]]; then
         current_turn_skill_detail_request=true
         looks_like_skill_turn=true
     fi
@@ -3982,6 +3994,8 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         next_turn_intent="skill_template"
     elif [[ "$current_turn_codex_update_maintenance_request" == true ]]; then
         next_turn_intent="codex_update_maintenance"
+    elif [[ "$current_turn_generic_maintenance_request" == true ]]; then
+        next_turn_intent="maintenance_generic"
     elif [[ "$current_turn_skill_maintenance_request" == true ]]; then
         next_turn_intent="skill_maintenance:${resolved_skill_name:-${requested_skill_reference_name:-generic}}"
     elif [[ "$current_turn_codex_update_request" == true ]]; then
@@ -4036,6 +4050,7 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     persisted_codex_update_request=false
     persisted_codex_update_scheduler_request=false
     persisted_codex_update_maintenance_request=false
+    persisted_generic_maintenance_request=false
     case "${persisted_turn_intent:-}" in
         codex_update)
             persisted_codex_update_request=true
@@ -4046,6 +4061,9 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             ;;
         codex_update_maintenance)
             persisted_codex_update_maintenance_request=true
+            ;;
+        maintenance_generic)
+            persisted_generic_maintenance_request=true
             ;;
     esac
 
@@ -4081,6 +4099,13 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         if [[ "$current_turn_codex_update_maintenance_request" == true ]]; then
             maintenance_reply_text="$(build_skill_maintenance_reply_text "codex_update" || true)"
             if [[ -n "$maintenance_reply_text" ]] && direct_fastpath_send_with_suppression "maintenance" "$telegram_chat_id" "$maintenance_reply_text" "maintenance:codex_update"; then
+                clear_turn_intent "${turn_session_key:-}"
+                exit 0
+            fi
+        fi
+        if [[ "$current_turn_generic_maintenance_request" == true ]]; then
+            maintenance_reply_text="$(build_skill_maintenance_reply_text "generic" || true)"
+            if [[ -n "$maintenance_reply_text" ]] && direct_fastpath_send_with_suppression "maintenance" "$telegram_chat_id" "$maintenance_reply_text" "maintenance:generic"; then
                 clear_turn_intent "${turn_session_key:-}"
                 exit 0
             fi
@@ -4161,13 +4186,19 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             emit_before_llm_modified_payload "$messages_json" 0
             exit 0
         fi
-        if [[ "$current_turn_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true ]]; then
-            maintenance_reply_text="$(build_skill_maintenance_reply_text "$([[ "$current_turn_codex_update_maintenance_request" == true ]] && printf 'codex_update' || printf 'skill')" "${resolved_skill_name:-${requested_skill_reference_name:-generic}}" || true)"
+        if [[ "$current_turn_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || "$current_turn_generic_maintenance_request" == true ]]; then
+            maintenance_target_kind="skill"
+            if [[ "$current_turn_codex_update_maintenance_request" == true ]]; then
+                maintenance_target_kind="codex_update"
+            elif [[ "$current_turn_generic_maintenance_request" == true ]]; then
+                maintenance_target_kind="generic"
+            fi
+            maintenance_reply_text="$(build_skill_maintenance_reply_text "$maintenance_target_kind" "${resolved_skill_name:-${requested_skill_reference_name:-generic}}" || true)"
             if [[ -n "$maintenance_reply_text" ]]; then
                 maintenance_guard="$(build_skill_maintenance_hard_override_message "$maintenance_reply_text")"
                 maintenance_user=$'Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего.'
                 messages_json="[$(build_message_json system "$maintenance_guard"),$(build_message_json user "$maintenance_user")]"
-                write_audit_line "before_modify reason=maintenance_hard_override tool_count=0 skill=${resolved_skill_name:-${requested_skill_reference_name:-generic}} codex_update=$current_turn_codex_update_maintenance_request"
+                write_audit_line "before_modify reason=maintenance_hard_override tool_count=0 target=$maintenance_target_kind skill=${resolved_skill_name:-${requested_skill_reference_name:-generic}} codex_update=$current_turn_codex_update_maintenance_request"
                 emit_before_llm_modified_payload "$messages_json" 0
                 exit 0
             fi
@@ -4265,13 +4296,19 @@ if [[ "$event" == "BeforeToolCall" && "$is_telegram_safe_lane" == true ]]; then
         exit 0
     fi
 
-    if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || -n "$persisted_skill_maintenance_name" ]]; then
-        maintenance_reply_text="$(build_skill_maintenance_reply_text "$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf 'codex_update' || printf 'skill')" "${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}}" || true)"
+    if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || -n "$persisted_skill_maintenance_name" || "$current_turn_generic_maintenance_request" == true || "$persisted_generic_maintenance_request" == true ]]; then
+        maintenance_target_kind="skill"
+        if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]]; then
+            maintenance_target_kind="codex_update"
+        elif [[ "$current_turn_generic_maintenance_request" == true || "$persisted_generic_maintenance_request" == true ]]; then
+            maintenance_target_kind="generic"
+        fi
+        maintenance_reply_text="$(build_skill_maintenance_reply_text "$maintenance_target_kind" "${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}}" || true)"
         if [[ -z "$maintenance_reply_text" ]]; then
             maintenance_reply_text='В Telegram-safe режиме debug/repair ход уже переведён в текстовый ответ без инструментов.'
         fi
         synthetic_command="$(build_exec_heredoc_command "$maintenance_reply_text")"
-        write_audit_line "emit_modify event=$event reason=maintenance_tool_suppress tool=${tool_name:-missing} skill=${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}} codex_update=$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf true || printf false)"
+        write_audit_line "emit_modify event=$event reason=maintenance_tool_suppress tool=${tool_name:-missing} target=$maintenance_target_kind skill=${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}} codex_update=$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf true || printf false)"
         emit_before_tool_modified_payload "exec" "{\"command\":\"$(json_escape "$synthetic_command")\"}"
         exit 0
     fi
@@ -4349,10 +4386,16 @@ if [[ "$event" == "MessageSending" && -n "$effective_delivery_suppression" && "$
 fi
 
 if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
-    if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || -n "$persisted_skill_maintenance_name" ]]; then
-        maintenance_reply_text="$(build_skill_maintenance_reply_text "$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf 'codex_update' || printf 'skill')" "${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}}" || true)"
+    if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || -n "$persisted_skill_maintenance_name" || "$current_turn_generic_maintenance_request" == true || "$persisted_generic_maintenance_request" == true ]]; then
+        maintenance_target_kind="skill"
+        if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]]; then
+            maintenance_target_kind="codex_update"
+        elif [[ "$current_turn_generic_maintenance_request" == true || "$persisted_generic_maintenance_request" == true ]]; then
+            maintenance_target_kind="generic"
+        fi
+        maintenance_reply_text="$(build_skill_maintenance_reply_text "$maintenance_target_kind" "${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}}" || true)"
         if [[ -n "$maintenance_reply_text" ]]; then
-            write_audit_line "emit_modify event=$event reason=maintenance_reply_override skill=${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}} codex_update=$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf true || printf false)"
+            write_audit_line "emit_modify event=$event reason=maintenance_reply_override target=$maintenance_target_kind skill=${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}} codex_update=$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf true || printf false)"
             if [[ "$event" == "AfterLLMCall" ]]; then
                 emit_modified_payload "$maintenance_reply_text" true
             else
@@ -4412,7 +4455,7 @@ if [[ "$event" == "MessageSending" && "$is_telegram_safe_lane" == true && "$look
     fi
 fi
 
-if [[ "$event" == "MessageSending" && "$looks_like_status" != true && "$looks_like_skill_visibility_request" != true && "$looks_like_skill_template_request" != true && "$current_turn_skill_detail_request" != true && "$current_turn_skill_maintenance_request" != true && "$current_turn_codex_update_maintenance_request" != true && -z "$persisted_skill_detail_name" && -z "$persisted_skill_maintenance_name" && -z "$persisted_skill_create_state" && "$persisted_codex_update_maintenance_request" != true && "$has_delivery_internal_telemetry" != true && "$has_after_llm_tool_intent" != true && "$has_user_visible_internal_planning" != true && "$has_skill_path_false_negative" != true && "$has_skill_visibility_generic_mismatch" != true ]]; then
+if [[ "$event" == "MessageSending" && "$looks_like_status" != true && "$looks_like_skill_visibility_request" != true && "$looks_like_skill_template_request" != true && "$current_turn_skill_detail_request" != true && "$current_turn_skill_maintenance_request" != true && "$current_turn_codex_update_maintenance_request" != true && "$current_turn_generic_maintenance_request" != true && -z "$persisted_skill_detail_name" && -z "$persisted_skill_maintenance_name" && -z "$persisted_skill_create_state" && "$persisted_codex_update_maintenance_request" != true && "$persisted_generic_maintenance_request" != true && "$has_delivery_internal_telemetry" != true && "$has_after_llm_tool_intent" != true && "$has_user_visible_internal_planning" != true && "$has_skill_path_false_negative" != true && "$has_skill_visibility_generic_mismatch" != true ]]; then
     exit 0
 fi
 if [[ "$looks_like_status" == true ]]; then

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -2036,6 +2036,28 @@ build_skill_apply_hard_override_message() {
     build_text_only_hard_override_message "Telegram-safe skill-apply hard override" "$reply_text"
 }
 
+build_skill_maintenance_reply_text() {
+    local target_kind="${1:-skill}"
+    local skill_name="${2:-}"
+
+    if [[ "$target_kind" == "codex_update" ]]; then
+        printf '%s' 'В Telegram-safe режиме я не чиню и не отлаживаю `codex-update` через внутренние инструменты, логи и чтение файлов. Для простой правки навыка дай явную команду create_skill/update_skill/delete_skill, а для диагностики и runtime-проверки продолжим в web UI/операторской сессии.'
+        return 0
+    fi
+
+    if [[ -n "$skill_name" && "$skill_name" != "generic" ]]; then
+        printf 'В Telegram-safe режиме я не чиню и не отлаживаю навык `%s` через внутренние инструменты, логи и чтение файлов. Для простой правки скажи явно create_skill/update_skill/delete_skill, а для диагностики и runtime-проверки продолжим в web UI/операторской сессии.' "$skill_name"
+        return 0
+    fi
+
+    printf '%s' 'В Telegram-safe режиме я не чиню и не отлаживаю навыки через внутренние инструменты, логи и чтение файлов. Для простой правки скажи явно create_skill/update_skill/delete_skill, а для диагностики и runtime-проверки продолжим в web UI/операторской сессии.'
+}
+
+build_skill_maintenance_hard_override_message() {
+    local reply_text="$1"
+    build_text_only_hard_override_message "Telegram-safe maintenance hard override" "$reply_text"
+}
+
 build_skill_detail_hard_override_message() {
     local reply_text="$1"
     build_text_only_hard_override_message "Telegram-safe skill-detail hard override" "$reply_text"
@@ -2275,6 +2297,14 @@ description: Базовый навык <skill-name>. Использовать, �
 
 Если хочешь, следующим сообщением я создам такой базовый навык по имени/slug.
 EOF
+}
+
+text_looks_like_maintenance_request() {
+    local source_text="${1:-}"
+
+    [[ -n "$source_text" ]] || return 1
+
+    printf '%s' "$source_text" | grep -Eiq '(почин(и|ить|им|ю|ите)|исправ(ь|ить|им|лю|ьте)|отлад(ь|ить|им|ка|ку)|разбер(и|ись|ем|у)|расслед(уй|овать|уем)|диагност(ируй|ировать|ика)|debug|repair|fix|troubleshoot|investigat(e|ion)|inspect|лог(и|ов|ами|ах)?|logs?|ошибк(а|и|у|ой)|error|errors|не работает|не срабатывает|не отвечает|сломал(ось|ся|и)?|сломано|root cause|rca)'
 }
 
 flag_enabled() {
@@ -3642,6 +3672,11 @@ if printf '%s' "$intent_text_flat" | grep -Eiq '((изучи|изучить|ис
     looks_like_broad_research_request=true
 fi
 
+maintenance_request_detected=false
+if text_looks_like_maintenance_request "$intent_text_flat"; then
+    maintenance_request_detected=true
+fi
+
 looks_like_skill_turn=false
 if printf '%s' "$intent_text_flat" | grep -Eiq '((созда(й|дим|ть)|добав(ь|им|ить)|обнов(и|им|ить)|измени(ть|м)|удали(ть|м)?).{0,120}(навык|skills?|skill))|((какие|что).{0,80}(навык(и|ов)?|skills?))|((темплейт|template|шаблон).{0,120}(навык|skills?|skill))|((create|update|delete)[ _-]?skill)'; then
     looks_like_skill_turn=true
@@ -3699,7 +3734,7 @@ if [[ "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_fl
     current_turn_codex_update_scheduler_request=true
     current_turn_codex_update_request=true
 fi
-if [[ "$current_turn_codex_update_request" != true && "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(обновлен|обновлени|update|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового|новой|новая|новую)'; then
+if [[ "$current_turn_codex_update_request" != true && "$codex_update_subject_request" == true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(обновлен|обновлени|релиз|release|releases|version|versions|верси|latest|stable|стабильн|что нового|нового|новой|новая|новую|changelog|release notes)'; then
     current_turn_codex_update_request=true
 fi
 
@@ -3784,12 +3819,6 @@ resolved_skill_name=""
 requested_skill_reference_name="$(extract_referenced_skill_candidate "${latest_user_message:-${user_message:-}}" || true)"
 skill_runtime_snapshot_csv="$(discover_runtime_skill_names_csv || true)"
 resolved_skill_name="$(resolve_runtime_skill_name_from_text "${latest_user_message:-${user_message:-}}" "$skill_runtime_snapshot_csv" || true)"
-if [[ "$current_turn_skill_detail_request" != true && -n "$requested_skill_reference_name" ]]; then
-    if [[ "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true ]]; then
-        current_turn_skill_detail_request=true
-        looks_like_skill_turn=true
-    fi
-fi
 requested_skill_name="$(extract_requested_skill_name "${latest_user_message:-${user_message:-}}" || true)"
 requested_skill_name_re=""
 if [[ -n "$requested_skill_name" ]]; then
@@ -3808,8 +3837,13 @@ persisted_skill_detail_name=""
 if [[ "$persisted_turn_intent" =~ ^skill_detail:([A-Za-z0-9._-]+)$ ]]; then
     persisted_skill_detail_name="${BASH_REMATCH[1]}"
 fi
+persisted_skill_maintenance_name=""
+if [[ "$persisted_turn_intent" =~ ^skill_maintenance:([A-Za-z0-9._-]+)$ ]]; then
+    persisted_skill_maintenance_name="${BASH_REMATCH[1]}"
+fi
 persisted_codex_update_request=false
 persisted_codex_update_scheduler_request=false
+persisted_codex_update_maintenance_request=false
 case "${persisted_turn_intent:-}" in
     codex_update)
         persisted_codex_update_request=true
@@ -3818,12 +3852,44 @@ case "${persisted_turn_intent:-}" in
         persisted_codex_update_request=true
         persisted_codex_update_scheduler_request=true
         ;;
+    codex_update_maintenance)
+        persisted_codex_update_maintenance_request=true
+        ;;
 esac
 if [[ -z "$resolved_skill_name" && -n "$persisted_skill_detail_name" ]]; then
     resolved_skill_name="$persisted_skill_detail_name"
 fi
+if [[ -z "$resolved_skill_name" && -n "$persisted_skill_maintenance_name" && "$persisted_skill_maintenance_name" != "generic" ]]; then
+    resolved_skill_name="$persisted_skill_maintenance_name"
+fi
 if [[ -z "$requested_skill_reference_name" && -n "$resolved_skill_name" ]]; then
     requested_skill_reference_name="$resolved_skill_name"
+fi
+skill_subject_request=false
+if [[ -n "$requested_skill_reference_name" || -n "$resolved_skill_name" ]]; then
+    skill_subject_request=true
+elif printf '%s' "$intent_text_flat" | grep -Eiq '(навык|skills?|skill)'; then
+    skill_subject_request=true
+fi
+current_turn_skill_maintenance_request=false
+current_turn_codex_update_maintenance_request=false
+if [[ "$maintenance_request_detected" == true ]]; then
+    if [[ "$codex_update_subject_request" == true ]]; then
+        current_turn_codex_update_maintenance_request=true
+    elif [[ "$skill_subject_request" == true && "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true ]]; then
+        current_turn_skill_maintenance_request=true
+        looks_like_skill_turn=true
+    fi
+fi
+if [[ "$current_turn_skill_maintenance_request" == true || "$current_turn_codex_update_maintenance_request" == true ]]; then
+    current_turn_codex_update_request=false
+    current_turn_codex_update_scheduler_request=false
+fi
+if [[ "$current_turn_skill_detail_request" != true && "$looks_like_skill_turn" != true && -n "$requested_skill_reference_name" ]]; then
+    if [[ "$current_turn_skill_visibility_request" != true && "$current_turn_skill_template_request" != true && "$current_turn_sparse_skill_create_request" != true && "$current_turn_skill_apply_request" != true && "$current_turn_skill_maintenance_request" != true ]]; then
+        current_turn_skill_detail_request=true
+        looks_like_skill_turn=true
+    fi
 fi
 if [[ "$has_current_user_turn" != true && -n "$persisted_skill_create_state" && -n "$requested_skill_name" && -n "$requested_skill_name_re" ]] && \
    printf '%s' "${intent_text_flat} ${latest_user_message_flat} ${latest_assistant_message_flat} ${response_text_flat} ${payload_flat}" \
@@ -3914,6 +3980,10 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         next_turn_intent="skill_visibility"
     elif [[ "$looks_like_skill_template_request" == true ]]; then
         next_turn_intent="skill_template"
+    elif [[ "$current_turn_codex_update_maintenance_request" == true ]]; then
+        next_turn_intent="codex_update_maintenance"
+    elif [[ "$current_turn_skill_maintenance_request" == true ]]; then
+        next_turn_intent="skill_maintenance:${resolved_skill_name:-${requested_skill_reference_name:-generic}}"
     elif [[ "$current_turn_codex_update_request" == true ]]; then
         if [[ "$current_turn_codex_update_scheduler_request" == true ]]; then
             next_turn_intent="codex_update_scheduler"
@@ -3965,6 +4035,7 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     fi
     persisted_codex_update_request=false
     persisted_codex_update_scheduler_request=false
+    persisted_codex_update_maintenance_request=false
     case "${persisted_turn_intent:-}" in
         codex_update)
             persisted_codex_update_request=true
@@ -3972,6 +4043,9 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         codex_update_scheduler)
             persisted_codex_update_request=true
             persisted_codex_update_scheduler_request=true
+            ;;
+        codex_update_maintenance)
+            persisted_codex_update_maintenance_request=true
             ;;
     esac
 
@@ -4000,6 +4074,20 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         # the fallback when direct send is disabled or unavailable.
         if [[ "$current_turn_status_request" == true ]]; then
             if direct_fastpath_send_with_suppression "status" "$telegram_chat_id" "$canonical_status" "status"; then
+                clear_turn_intent "${turn_session_key:-}"
+                exit 0
+            fi
+        fi
+        if [[ "$current_turn_codex_update_maintenance_request" == true ]]; then
+            maintenance_reply_text="$(build_skill_maintenance_reply_text "codex_update" || true)"
+            if [[ -n "$maintenance_reply_text" ]] && direct_fastpath_send_with_suppression "maintenance" "$telegram_chat_id" "$maintenance_reply_text" "maintenance:codex_update"; then
+                clear_turn_intent "${turn_session_key:-}"
+                exit 0
+            fi
+        fi
+        if [[ "$current_turn_skill_maintenance_request" == true ]]; then
+            maintenance_reply_text="$(build_skill_maintenance_reply_text "skill" "${resolved_skill_name:-${requested_skill_reference_name:-generic}}" || true)"
+            if [[ -n "$maintenance_reply_text" ]] && direct_fastpath_send_with_suppression "maintenance" "$telegram_chat_id" "$maintenance_reply_text" "maintenance:${resolved_skill_name:-${requested_skill_reference_name:-generic}}" "skill=${resolved_skill_name:-${requested_skill_reference_name:-generic}}"; then
                 clear_turn_intent "${turn_session_key:-}"
                 exit 0
             fi
@@ -4072,6 +4160,17 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
             write_audit_line "before_modify reason=long_research_hard_override tool_count=0 guard_reapplied=true previously_present=$already_guarded_long_research"
             emit_before_llm_modified_payload "$messages_json" 0
             exit 0
+        fi
+        if [[ "$current_turn_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true ]]; then
+            maintenance_reply_text="$(build_skill_maintenance_reply_text "$([[ "$current_turn_codex_update_maintenance_request" == true ]] && printf 'codex_update' || printf 'skill')" "${resolved_skill_name:-${requested_skill_reference_name:-generic}}" || true)"
+            if [[ -n "$maintenance_reply_text" ]]; then
+                maintenance_guard="$(build_skill_maintenance_hard_override_message "$maintenance_reply_text")"
+                maintenance_user=$'Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего.'
+                messages_json="[$(build_message_json system "$maintenance_guard"),$(build_message_json user "$maintenance_user")]"
+                write_audit_line "before_modify reason=maintenance_hard_override tool_count=0 skill=${resolved_skill_name:-${requested_skill_reference_name:-generic}} codex_update=$current_turn_codex_update_maintenance_request"
+                emit_before_llm_modified_payload "$messages_json" 0
+                exit 0
+            fi
         fi
         if [[ "$looks_like_skill_visibility_request" == true ]]; then
             skill_snapshot_csv="$(discover_runtime_skill_names_csv || true)"
@@ -4166,6 +4265,17 @@ if [[ "$event" == "BeforeToolCall" && "$is_telegram_safe_lane" == true ]]; then
         exit 0
     fi
 
+    if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || -n "$persisted_skill_maintenance_name" ]]; then
+        maintenance_reply_text="$(build_skill_maintenance_reply_text "$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf 'codex_update' || printf 'skill')" "${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}}" || true)"
+        if [[ -z "$maintenance_reply_text" ]]; then
+            maintenance_reply_text='В Telegram-safe режиме debug/repair ход уже переведён в текстовый ответ без инструментов.'
+        fi
+        synthetic_command="$(build_exec_heredoc_command "$maintenance_reply_text")"
+        write_audit_line "emit_modify event=$event reason=maintenance_tool_suppress tool=${tool_name:-missing} skill=${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}} codex_update=$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf true || printf false)"
+        emit_before_tool_modified_payload "exec" "{\"command\":\"$(json_escape "$synthetic_command")\"}"
+        exit 0
+    fi
+
     if [[ "$current_turn_codex_update_request" == true || "$persisted_codex_update_request" == true ]]; then
         codex_update_terminal_token="release"
         if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
@@ -4239,6 +4349,19 @@ if [[ "$event" == "MessageSending" && -n "$effective_delivery_suppression" && "$
 fi
 
 if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
+    if [[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true || "$current_turn_skill_maintenance_request" == true || -n "$persisted_skill_maintenance_name" ]]; then
+        maintenance_reply_text="$(build_skill_maintenance_reply_text "$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf 'codex_update' || printf 'skill')" "${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}}" || true)"
+        if [[ -n "$maintenance_reply_text" ]]; then
+            write_audit_line "emit_modify event=$event reason=maintenance_reply_override skill=${resolved_skill_name:-${requested_skill_reference_name:-${persisted_skill_maintenance_name:-generic}}} codex_update=$([[ "$current_turn_codex_update_maintenance_request" == true || "$persisted_codex_update_maintenance_request" == true ]] && printf true || printf false)"
+            if [[ "$event" == "AfterLLMCall" ]]; then
+                emit_modified_payload "$maintenance_reply_text" true
+            else
+                clear_turn_intent "${turn_session_key:-}"
+                emit_modified_payload "$maintenance_reply_text" false
+            fi
+            exit 0
+        fi
+    fi
     if [[ "$current_turn_codex_update_request" == true || "$persisted_codex_update_request" == true ]]; then
         codex_update_reply_mode="release"
         if [[ "$current_turn_codex_update_scheduler_request" == true || "$persisted_codex_update_scheduler_request" == true ]]; then
@@ -4289,7 +4412,7 @@ if [[ "$event" == "MessageSending" && "$is_telegram_safe_lane" == true && "$look
     fi
 fi
 
-if [[ "$event" == "MessageSending" && "$looks_like_status" != true && "$looks_like_skill_visibility_request" != true && "$looks_like_skill_template_request" != true && "$current_turn_skill_detail_request" != true && -z "$persisted_skill_detail_name" && -z "$persisted_skill_create_state" && "$has_delivery_internal_telemetry" != true && "$has_after_llm_tool_intent" != true && "$has_user_visible_internal_planning" != true && "$has_skill_path_false_negative" != true && "$has_skill_visibility_generic_mismatch" != true ]]; then
+if [[ "$event" == "MessageSending" && "$looks_like_status" != true && "$looks_like_skill_visibility_request" != true && "$looks_like_skill_template_request" != true && "$current_turn_skill_detail_request" != true && "$current_turn_skill_maintenance_request" != true && "$current_turn_codex_update_maintenance_request" != true && -z "$persisted_skill_detail_name" && -z "$persisted_skill_maintenance_name" && -z "$persisted_skill_create_state" && "$persisted_codex_update_maintenance_request" != true && "$has_delivery_internal_telemetry" != true && "$has_after_llm_tool_intent" != true && "$has_user_visible_internal_planning" != true && "$has_skill_path_false_negative" != true && "$has_skill_visibility_generic_mismatch" != true ]]; then
     exit 0
 fi
 if [[ "$looks_like_status" == true ]]; then

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -3161,6 +3161,95 @@ EOF
         test_fail "MessageSending guard must rewrite codex-update skill-detail failures into a clean Telegram-safe summary instead of falling back to operator-heavy description text"
     fi
 
+    test_start "component_before_llm_guard_hard_overrides_codex_update_maintenance_turn"
+    local before_llm_codex_update_maintenance_output
+    before_llm_codex_update_maintenance_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$(secure_temp_dir telegram-safe-codex-update-maintenance-before)" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-update-maintenance-before","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872995 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Давай починим codex-update: в Telegram течёт Activity log и missing 'query' parameter"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe maintenance hard override")' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
+       jq -e '.data.messages[0].content | contains("не чиню и не отлаживаю `codex-update`")' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output"; then
+        test_pass
+    else
+        test_fail "BeforeLLMCall guard must terminalize codex-update maintenance/debug turns into a deterministic text-only boundary reply"
+    fi
+
+    test_start "component_message_sending_guard_rewrites_codex_update_maintenance_leak_into_boundary_reply"
+    local codex_update_maintenance_intent_dir codex_update_maintenance_message_output
+    codex_update_maintenance_intent_dir="$(secure_temp_dir telegram-safe-codex-update-maintenance-message)"
+    env PATH="$MINIMAL_PATH" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_update_maintenance_intent_dir" \
+        bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
+{"event":"BeforeLLMCall","data":{"session_key":"session:codex-update-maintenance-message","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872995 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Давай починим codex-update: в Telegram течёт Activity log и missing 'query' parameter"}],"tool_count":37,"iteration":1}}
+EOF
+    codex_update_maintenance_message_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_update_maintenance_intent_dir" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:codex-update-maintenance-message","data":{"account_id":"moltis-bot","to":"262872995","reply_to_message_id":965,"text":"Если хочешь, я сразу напишу готовую новую версию инструкции для скилла, где будет: проверка официальной версии.\n\n📋 Activity log\n• 💻 Running: `sed -n '1,220p' /home/moltis/.moltis/skills/codex-update/SKILL.md`\n• 🧠 Searching memory...\n• ❌ missing 'command' parameter\n• ❌ missing 'query' parameter"}} 
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_maintenance_message_output" && \
+       jq -e '.data.text | contains("не чиню и не отлаживаю `codex-update`")' >/dev/null 2>&1 <<<"$codex_update_maintenance_message_output" && \
+       jq -e '.data.text | contains("create_skill/update_skill/delete_skill")' >/dev/null 2>&1 <<<"$codex_update_maintenance_message_output" && \
+       jq -e '.data.text | contains("web UI/операторской сессии")' >/dev/null 2>&1 <<<"$codex_update_maintenance_message_output" && \
+       jq -e '.data.reply_to_message_id == 965' >/dev/null 2>&1 <<<"$codex_update_maintenance_message_output" && \
+       jq -e '.data.text | test("Activity log|Running:|Searching memory|missing '\''command'\'' parameter|missing '\''query'\'' parameter|SKILL.md|/home/moltis") | not' >/dev/null 2>&1 <<<"$codex_update_maintenance_message_output"; then
+        test_pass
+    else
+        test_fail "MessageSending guard must rewrite leaked codex-update maintenance/debug runtime chatter into the deterministic Telegram-safe boundary reply"
+    fi
+
+    test_start "component_message_sending_guard_rewrites_plain_skill_maintenance_runtime_failure"
+    local skill_maintenance_intent_dir skill_maintenance_plain_message_output
+    skill_maintenance_intent_dir="$(secure_temp_dir telegram-safe-skill-maintenance-plain)"
+    env PATH="$MINIMAL_PATH" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$skill_maintenance_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
+        bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
+{"event":"BeforeLLMCall","data":{"session_key":"session:skill-maintenance-plain","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872996 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Почини навык post-close-task-classifier: в ответе течёт Activity log и сырые tool errors"}],"tool_count":37,"iteration":1}}
+EOF
+    skill_maintenance_plain_message_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$skill_maintenance_intent_dir" \
+            MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:skill-maintenance-plain","data":{"account_id":"moltis-bot","to":"262872996","reply_to_message_id":966,"text":"Я бы хотел сначала открыть SKILL.md и посмотреть внутренние логи, но вызов exec сейчас сам падает с missing 'command' parameter, поэтому без runtime-диагностики я не починю этот навык."}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$skill_maintenance_plain_message_output" && \
+       jq -e '.data.text | contains("навык `post-close-task-classifier`")' >/dev/null 2>&1 <<<"$skill_maintenance_plain_message_output" && \
+       jq -e '.data.text | contains("create_skill/update_skill/delete_skill")' >/dev/null 2>&1 <<<"$skill_maintenance_plain_message_output" && \
+       jq -e '.data.text | contains("web UI/операторской сессии")' >/dev/null 2>&1 <<<"$skill_maintenance_plain_message_output" && \
+       jq -e '.data.reply_to_message_id == 966' >/dev/null 2>&1 <<<"$skill_maintenance_plain_message_output" && \
+       jq -e '.data.text | test("Activity log|missing '\''command'\'' parameter|SKILL.md|exec|/home/moltis") | not' >/dev/null 2>&1 <<<"$skill_maintenance_plain_message_output"; then
+        test_pass
+    else
+        test_fail "MessageSending guard must rewrite plain skill-maintenance runtime failures even when the leaked text no longer includes an explicit Activity log block"
+    fi
+
+    test_start "component_after_llm_guard_keeps_explicit_update_skill_flow_out_of_maintenance_bucket"
+    local after_llm_update_skill_control_output
+    after_llm_update_skill_control_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,post-close-task-classifier,telegram-learner' \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:update-skill-control","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872997 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Обнови навык codex-update: замени description на более краткий advisory"}],"text":"Сейчас обновлю навык через update_skill без filesystem-проб.","tool_calls":[{"name":"update_skill","arguments":{"name":"codex-update","description":"Более краткий advisory"}}]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_llm_update_skill_control_output" && \
+       jq -e '.data.text == "Выполняю запрос по навыкам через встроенные инструменты без filesystem-проб. После завершения вернусь с итогом."' >/dev/null 2>&1 <<<"$after_llm_update_skill_control_output" && \
+       jq -e '.data.text | contains("не чиню и не отлаживаю") | not' >/dev/null 2>&1 <<<"$after_llm_update_skill_control_output"; then
+        test_pass
+    else
+        test_fail "Explicit update_skill CRUD turns must keep the allowlisted skill-authoring flow and must not be rewritten as maintenance/debug"
+    fi
+
     test_start "component_after_llm_guard_rewrites_codex_update_scheduler_question_into_remote_safe_contract_reply"
     local codex_update_scheduler_after_output
     codex_update_scheduler_after_output="$(

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -3171,12 +3171,91 @@ EOF
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
+       jq -e '.data.messages | length == 2' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
        jq -e '.data.messages[0].content | contains("Telegram-safe maintenance hard override")' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
        jq -e '.data.messages[0].content | contains("не чиню и не отлаживаю `codex-update`")' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
+       jq -e '.data.messages[1].content == "Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего."' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output" && \
        jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_codex_update_maintenance_output"; then
         test_pass
     else
         test_fail "BeforeLLMCall guard must terminalize codex-update maintenance/debug turns into a deterministic text-only boundary reply"
+    fi
+
+    test_start "component_before_llm_guard_hard_overrides_generic_maintenance_turn_without_explicit_subject"
+    local before_llm_generic_maintenance_output
+    before_llm_generic_maintenance_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$(secure_temp_dir telegram-safe-generic-maintenance-before)" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:generic-maintenance-before","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872998 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Посмотри логи и найди root cause, там снова Activity log и missing 'query' parameter"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_generic_maintenance_output" && \
+       jq -e '.data.messages | length == 2' >/dev/null 2>&1 <<<"$before_llm_generic_maintenance_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe maintenance hard override")' >/dev/null 2>&1 <<<"$before_llm_generic_maintenance_output" && \
+       jq -e '.data.messages[0].content | contains("не провожу repair/debug/log inspection")' >/dev/null 2>&1 <<<"$before_llm_generic_maintenance_output" && \
+       jq -e '.data.messages[1].content == "Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего."' >/dev/null 2>&1 <<<"$before_llm_generic_maintenance_output" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_generic_maintenance_output"; then
+        test_pass
+    else
+        test_fail "BeforeLLMCall guard must fail-close generic log/root-cause maintenance turns even when the user omitted an explicit skill or codex-update subject"
+    fi
+
+    test_start "component_before_llm_guard_direct_fastpaths_codex_update_maintenance_when_enabled"
+    local fastpath_maintenance_tmp fastpath_maintenance_send_script fastpath_maintenance_log fastpath_maintenance_stdout fastpath_maintenance_stderr fastpath_maintenance_status fastpath_maintenance_intent_dir fastpath_maintenance_suppress_file
+    fastpath_maintenance_tmp="$(secure_temp_dir telegram-safe-fastpath-maintenance)"
+    fastpath_maintenance_send_script="$fastpath_maintenance_tmp/send.sh"
+    fastpath_maintenance_log="$fastpath_maintenance_tmp/send.log"
+    fastpath_maintenance_intent_dir="$fastpath_maintenance_tmp/intent"
+    fastpath_maintenance_suppress_file="$fastpath_maintenance_intent_dir/session_fastmaintenance.suppress"
+    cat >"$fastpath_maintenance_send_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+chat_id=""
+text=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chat-id)
+            chat_id="${2:-}"
+            shift 2
+            ;;
+        --text)
+            text="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf 'chat_id=%s\ntext=%s\n' "$chat_id" "$text" >"$FASTPATH_LOG"
+printf '{"ok":true}\n'
+EOF
+    chmod +x "$fastpath_maintenance_send_script"
+    fastpath_maintenance_stdout="$fastpath_maintenance_tmp/stdout.log"
+    fastpath_maintenance_stderr="$fastpath_maintenance_tmp/stderr.log"
+    set +e
+    env PATH="$MINIMAL_PATH" \
+        FASTPATH_LOG="$fastpath_maintenance_log" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$fastpath_maintenance_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_maintenance_send_script" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
+        bash "$HOOK_HANDLER" >"$fastpath_maintenance_stdout" 2>"$fastpath_maintenance_stderr" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:fastmaintenance","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872999 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Давай починим codex-update: в Telegram течёт Activity log и missing 'query' parameter"}],"tool_count":37,"iteration":1}}
+EOF
+    fastpath_maintenance_status=$?
+    set -e
+    if [[ "$fastpath_maintenance_status" -eq 0 ]] && \
+       [[ ! -s "$fastpath_maintenance_stdout" ]] && \
+       [[ ! -s "$fastpath_maintenance_stderr" ]] && \
+       [[ -f "$fastpath_maintenance_suppress_file" ]] && \
+       grep -Fq $'\tmaintenance:codex_update' "$fastpath_maintenance_suppress_file" && \
+       grep -Fq 'chat_id=262872999' "$fastpath_maintenance_log" && \
+       grep -Fq 'text=В Telegram-safe режиме я не чиню и не отлаживаю `codex-update`' "$fastpath_maintenance_log"; then
+        test_pass
+    else
+        test_fail "Direct maintenance fastpath must send the deterministic codex-update boundary reply and store only a delivery-suppression marker"
     fi
 
     test_start "component_message_sending_guard_rewrites_codex_update_maintenance_leak_into_boundary_reply"
@@ -3231,6 +3310,23 @@ EOF
         test_pass
     else
         test_fail "MessageSending guard must rewrite plain skill-maintenance runtime failures even when the leaked text no longer includes an explicit Activity log block"
+    fi
+
+    test_start "component_after_llm_guard_rewrites_codex_update_maintenance_leak_into_boundary_reply"
+    local codex_update_maintenance_after_output
+    codex_update_maintenance_after_output="$(
+        env PATH="$MINIMAL_PATH" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:codex-update-maintenance-after","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262873000 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Давай починим codex-update: в Telegram течёт Activity log и missing 'query' parameter"}],"text":"Сейчас посмотрю логи и открою SKILL.md, потому что exec и memory_search падают с missing 'command' parameter и missing 'query' parameter.","tool_calls":[]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_maintenance_after_output" && \
+       jq -e '.data.text | contains("не чиню и не отлаживаю `codex-update`")' >/dev/null 2>&1 <<<"$codex_update_maintenance_after_output" && \
+       jq -e '.data.text | contains("web UI/операторской сессии")' >/dev/null 2>&1 <<<"$codex_update_maintenance_after_output" && \
+       jq -e '.data.text | test("Activity log|SKILL.md|missing '\''command'\'' parameter|missing '\''query'\'' parameter") | not' >/dev/null 2>&1 <<<"$codex_update_maintenance_after_output"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall guard must rewrite codex-update maintenance/debug chatter into the deterministic Telegram-safe boundary reply before final delivery"
     fi
 
     test_start "component_after_llm_guard_keeps_explicit_update_skill_flow_out_of_maintenance_bucket"


### PR DESCRIPTION
## Summary
- add a dedicated telegram-safe maintenance/debug bucket for codex-update and skill repair turns
- fail closed to deterministic text-only boundary replies instead of leaking tool-boundary runtime chatter
- keep explicit create_skill/update_skill/delete_skill flows on the allowlisted skill-tool path and document the RCA/contract update

## Validation
- bash -n scripts/telegram-safe-llm-guard.sh
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/static/test_config_validation.sh