### PR TITLE
fix: harden tracked deploy and update contracts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -397,10 +397,10 @@ jobs:
             exit 0
           fi
 
-          REMOTE_VERSION="${REMOTE_IMAGE##*:}"
+          REMOTE_VERSION_RAW="${REMOTE_IMAGE##*:}"
 
-          if [[ ! "$REMOTE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z._-]+)?$ ]]; then
-            echo "::warning::Running Moltis image uses non-semver tag '$REMOTE_VERSION'; skipping version regression guard."
+          if ! REMOTE_VERSION="$(bash ./scripts/moltis-version.sh normalize-tag "$REMOTE_VERSION_RAW" 2>/dev/null)"; then
+            echo "::warning::Running Moltis image uses unsupported explicit tag '$REMOTE_VERSION_RAW'; skipping version regression guard."
             exit 0
           fi
 

--- a/.github/workflows/moltis-update-proposal.yml
+++ b/.github/workflows/moltis-update-proposal.yml
@@ -51,45 +51,17 @@ jobs:
 
           TRACKED_VERSION="$(bash ./scripts/moltis-version.sh version)"
           LATEST_RELEASE_TAG="$(gh api repos/moltis-org/moltis/releases/latest --jq '.tag_name')"
-          CANDIDATE_VERSION="${LATEST_RELEASE_TAG#v}"
           FORCE_MODE="${FORCE_INPUT}"
+          resolver_args=(
+            --tracked-version "$TRACKED_VERSION"
+            --latest-release-tag "$LATEST_RELEASE_TAG"
+          )
 
-          {
-            echo "tracked_version=$TRACKED_VERSION"
-            echo "latest_release_tag=$LATEST_RELEASE_TAG"
-            echo "candidate_version=$CANDIDATE_VERSION"
-          } >> "$GITHUB_OUTPUT"
-
-          if [[ ! "$CANDIDATE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z._-]+)?$ ]]; then
-            echo "::error::Latest release tag '$LATEST_RELEASE_TAG' does not normalize to a valid GHCR runtime tag"
-            exit 1
+          if [[ "$FORCE_MODE" == "true" ]]; then
+            resolver_args+=(--force)
           fi
 
-          if [[ "$CANDIDATE_VERSION" == "$TRACKED_VERSION" ]]; then
-            {
-              echo "should_update=false"
-              echo "skip_reason=tracked version already equals latest release candidate"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$FORCE_MODE" != "true" ]]; then
-            NEWEST="$(printf '%s\n%s\n' "$TRACKED_VERSION" "$CANDIDATE_VERSION" | sort -V | tail -n1)"
-            if [[ "$NEWEST" != "$CANDIDATE_VERSION" ]]; then
-              {
-                echo "should_update=false"
-                echo "skip_reason=latest release candidate is not newer than tracked version"
-              } >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          if ! docker manifest inspect "ghcr.io/moltis-org/moltis:$CANDIDATE_VERSION" >/dev/null 2>&1; then
-            echo "::error::Normalized GHCR tag ghcr.io/moltis-org/moltis:$CANDIDATE_VERSION is not pullable"
-            exit 1
-          fi
-
-          echo "should_update=true" >> "$GITHUB_OUTPUT"
+          bash ./scripts/moltis-update-proposal-resolver.sh "${resolver_args[@]}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare proposal branch
         id: branch
@@ -152,7 +124,7 @@ jobs:
           ## Safety checks already passed
 
           - upstream release discovered from official \`moltis-org/moltis\`
-          - release tag normalized to GHCR runtime tag (\`vX.Y.Z -> X.Y.Z\`)
+          - release tag normalized and validated against explicit GHCR runtime tag rules
           - \`ghcr.io/moltis-org/moltis:${CANDIDATE_VERSION}\` is pullable
           - compose tracked defaults updated consistently
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -69,8 +69,6 @@ services:
       TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-}
       # Tavily API for MCP server
       TAVILY_API_KEY: ${TAVILY_API_KEY}
-      # GLM-5.1 API key for official BigModel Coding Plan (OpenAI-compatible)
-      GLM_API_KEY: ${GLM_API_KEY}
       # Ollama Cloud API key for cloud-backed fallback chat models
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,15 +88,12 @@ services:
       TELEGRAM_ALLOWED_USERS: ${TELEGRAM_ALLOWED_USERS:-}
       # Tavily API for MCP server
       TAVILY_API_KEY_FILE: /run/secrets/tavily_api_key
-      # GLM-5.1 API key for official BigModel Coding Plan (OpenAI-compatible)
-      GLM_API_KEY_FILE: /run/secrets/glm_api_key
 
     # Docker secrets for secure credential management
     secrets:
       - moltis_password
       - telegram_bot_token
       - tavily_api_key
-      - glm_api_key
 
     healthcheck:
       <<: *healthcheck
@@ -144,8 +141,6 @@ secrets:
     file: ./secrets/telegram_bot_token.txt
   tavily_api_key:
     file: ./secrets/tavily_api_key.txt
-  glm_api_key:
-    file: ./secrets/glm_api_key.txt
 
 # ============================================================================
 # NETWORKS

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-20
-**Total Lessons**: 84
+**Total Lessons**: 85
 
 ---
 
@@ -14,8 +14,9 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (40 lessons)
+#### P1 (41 lessons)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
+- [GitHub Actions bad logs from post-deploy image prune and calendar tag rejection](../docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md)
 - [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
 - [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
@@ -109,7 +110,8 @@
 ### By Category
 
 
-#### cicd (29 lessons)
+#### cicd (30 lessons)
+- [GitHub Actions bad logs from post-deploy image prune and calendar tag rejection](../docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md)
 - [Deploy host automation missing cron package bootstrap](../docs/rca/2026-04-14-deploy-host-automation-missing-cron-package-bootstrap.md)
 - [Tracked deploy empty stdout broke GitHub Actions JSON contract](../docs/rca/2026-04-02-tracked-deploy-empty-stdout-broke-json-contract.md)
 - [Tracked Moltis deploy failed because the repo skill sync helper crashed in its EXIT trap under set -u](../docs/rca/2026-03-28-moltis-repo-skill-sync-trap-broke-deploy-verification.md)
@@ -213,10 +215,10 @@
 ### Popular Tags
 
 - `rca` (32 lessons)
-- `moltis` (26 lessons)
+- `moltis` (27 lessons)
 - `telegram` (21 lessons)
-- `deploy` (19 lessons)
-- `github-actions` (17 lessons)
+- `deploy` (20 lessons)
+- `github-actions` (18 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `skills` (12 lessons)
@@ -230,10 +232,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 84 |
-| Critical (P0/P1) | 41 |
+| Total Lessons | 85 |
+| Critical (P0/P1) | 42 |
 | Categories | 8 |
-| Unique Tags | 165 |
+| Unique Tags | 166 |
 
 ---
 

--- a/docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md
+++ b/docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md
@@ -1,0 +1,114 @@
+---
+title: "GitHub Actions bad logs from post-deploy image prune and calendar tag rejection"
+date: 2026-04-20
+severity: P1
+category: cicd
+tags: [github-actions, deploy, update-proposal, moltis, ghcr, docker]
+root_cause: "Deploy and update-proposal workflows still relied on stale contracts: post-deploy reclaim pruned a tracked browser image, version normalization stayed semver-only, and active deploy surfaces still referenced removed GLM secrets."
+---
+
+# RCA: GitHub Actions bad logs from post-deploy image prune and calendar tag rejection
+
+**Дата:** 2026-04-20  
+**Статус:** Resolved in code, merge pending  
+**Влияние:** `main` показывал ложный красный `Deploy Moltis`, scheduled `Moltis Update Proposal` падал на валидном upstream release tag, а deploy logs дополнительно шумели предупреждением про уже удалённый `GLM_API_KEY`.  
+**Контекст:** beads `moltinger-4hqr.2`, runs `24665090156` (`Deploy Moltis`) и `24658547770` (`Moltis Update Proposal`).
+
+## Ошибка
+
+Наблюдались три связанных симптома:
+
+1. `Deploy Moltis` run `24665090156` завершался `failure`, хотя deploy доходил до healthy runtime.
+2. `Moltis Update Proposal` run `24658547770` падал со строкой `Latest release tag '20260417.02' does not normalize to a valid GHCR runtime tag`.
+3. В deploy logs оставалось предупреждение `The "GLM_API_KEY" variable is not set. Defaulting to a blank string.`
+
+Ключевой факт по deploy run:
+
+- итоговый JSON payload показывал `"health": "healthy"`, но runtime attestation падала с `BROWSER_SANDBOX_IMAGE_UNAVAILABLE` для `moltis-browserless-chrome:tracked`.
+
+Ключевой факт по update-proposal run:
+
+- официальный latest release уже шёл в календарном формате (`20260417.02`, позже `20260420.02`), а workflow и общий helper-контракт всё ещё трактовали только semver-style runtime tags.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag deploy`
+- `./scripts/query-lessons.sh --tag moltis`
+- `docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md`
+
+**Релевантные прошлые RCA/уроки:**
+
+1. `docs/rca/2026-04-02-tracked-deploy-empty-stdout-broke-json-contract.md` — красный deploy при healthy runtime нельзя считать “просто шумом GitHub”, нужно искать сломанный boundary contract.
+2. `docs/rca/2026-03-28-moltis-deploy-auto-rollback-recreate-and-health-monitor-interference.md` — background cleanup в production не должен мутировать deploy-managed surface без awareness к rollout contract.
+3. `docs/rca/2026-03-20-moltis-ghcr-tag-normalization-and-production-deploy-gate-hardening.md` — release tag normalization должен быть централизованным contract-слоем, а не adhoc логикой по workflow.
+
+**Что могло быть упущено без этой сверки:**
+
+- можно было чинить только один workflow и оставить тот же дефект в общем version helper;
+- можно было посчитать `BROWSER_SANDBOX_IMAGE_UNAVAILABLE` новой production anomaly вместо self-inflicted cleanup drift;
+- можно было убрать предупреждение про `GLM_API_KEY` только из `.env` rendering, но оставить его в active compose/preflight surface.
+
+**Что в текущем инциденте действительно новое:**
+
+- post-deploy reclaim path удалял именно tracked browser sandbox image, который затем требовался для финальной runtime attestation;
+- upstream release contract сдвинулся к календарным тегам, и repo source of truth не был полностью под это обновлён.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему на GitHub появились плохие логи и красные workflow? | Потому что `Deploy Moltis` и `Moltis Update Proposal` исполняли уже устаревшие контракты относительно tracked runtime surface и release tag format. | `gh run view 24665090156 --log-failed`, `gh run view 24658547770 --log-failed` |
+| 2 | Почему `Deploy Moltis` стал красным при healthy runtime? | Потому что после успешного rollout post-deploy reclaim запускал docker image prune и удалял tracked browser sandbox image до финальной attestation. | deploy log с `BROWSER_SANDBOX_IMAGE_UNAVAILABLE`, код `scripts/deploy.sh` + `scripts/moltis-storage-maintenance.sh` |
+| 3 | Почему `Moltis Update Proposal` падал на валидном release tag? | Потому что workflow и `scripts/moltis-version.sh` принимали только semver-like tracked tags и отвергали календарные release tags, хотя upstream уже публиковал их как официальный latest release. | log line `Latest release tag '20260417.02' ...`, latest release `20260420.02`, старый код workflow/helper |
+| 4 | Почему warning про `GLM_API_KEY` продолжал шуметь в deploy logs после отказа от Z.ai? | Потому что `.env` rendering уже не использовал этот secret, но active compose/preflight surface всё ещё ссылался на `GLM_API_KEY` / `glm_api_key`. | `docker-compose.yml`, `docker-compose.prod.yml`, `scripts/preflight-check.sh` до фикса |
+| 5 | Почему эти три дефекта прошли вместе? | Потому что migration work шёл послойно и частично: source config, workflow logic, shared helpers и active deploy surface обновлялись не как единый CI/runtime contract. | разрыв между workflow YAML, shared scripts и live deploy logs |
+
+## Корневая причина
+
+Root cause был не в одном конкретном workflow, а в неполной миграции shared contract:
+
+- deploy control plane не защищал tracked browser sandbox image от post-deploy cleanup;
+- release normalization contract оставался semver-only вместо общей explicit GHCR tag grammar;
+- active deploy surface хранил следы удалённого GLM/Z.ai секрета, хотя runtime source of truth уже был обновлён.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Actionable? | yes | Исправляется в shared scripts, workflows и active deploy config surface |
+| Systemic? | yes | Проблема затрагивает общий CI/runtime contract, а не разовый ручной шаг |
+| Preventable? | yes | Покрывается централизованной normalization logic, static guards и targeted tests |
+
+## Принятые меры
+
+1. **Немедленное исправление:**  
+   `scripts/deploy.sh` теперь вызывает reclaim c `--skip-docker-image-prune`, чтобы post-deploy cleanup не удалял tracked browser sandbox image.
+2. **Предотвращение:**  
+   Добавлен shared helper `scripts/moltis-update-proposal-resolver.sh`, а `scripts/moltis-version.sh` получил общий `normalize-tag` и explicit GHCR tag validation для semver и календарных тегов.
+3. **Конфигурационная санация:**  
+   Из active deploy surface удалены `GLM_API_KEY` / `glm_api_key` ссылки в `docker-compose.yml`, `docker-compose.prod.yml` и `scripts/preflight-check.sh`.
+4. **Тестовое покрытие:**  
+   Добавлены/обновлены component/static/unit tests на:
+   - calendar-tag normalization;
+   - update-proposal resolver;
+   - deploy browser-sandbox preservation contract;
+   - отсутствие active GLM secret contract.
+5. **Документация:**  
+   Создан этот RCA и запланирован rebuild lessons index.
+
+## Связанные обновления
+
+- [ ] Новый файл правила создан
+- [ ] Краткая ссылка добавлена в CLAUDE.md
+- [ ] Новые навыки созданы
+- [x] Тесты добавлены
+- [x] Новый RCA создан
+
+## Уроки
+
+1. Post-deploy cleanup нельзя запускать вслепую против deploy-managed Docker surface; cleanup обязан знать, какие tracked artifacts ещё нужны для attestation.
+2. Workflow-level tag parsing нельзя держать как локальную ad hoc логику; нормализация release/runtime tags должна идти через один shared helper.
+3. Provider-removal или secret-removal считается завершённым только тогда, когда очищены все active deploy surfaces, а не только source `.env` generation.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1604,6 +1604,7 @@ run_post_deploy_storage_reclaim() {
         if ! MOLTIS_STORAGE_KEEP_PREDEPLOY_BACKUPS="$POST_DEPLOY_STORAGE_KEEP_PREDEPLOY_BACKUPS" \
             "$STORAGE_MAINTENANCE_SCRIPT" reclaim \
                 --ignore-deploy-mutex \
+                --skip-docker-image-prune \
                 --skip-journal-vacuum 1>&2; then
             log_warn "Post-deploy storage reclaim reported warnings; continuing because rollout is already healthy"
             return 0
@@ -1611,6 +1612,7 @@ run_post_deploy_storage_reclaim() {
     elif ! MOLTIS_STORAGE_KEEP_PREDEPLOY_BACKUPS="$POST_DEPLOY_STORAGE_KEEP_PREDEPLOY_BACKUPS" \
         "$STORAGE_MAINTENANCE_SCRIPT" reclaim \
             --ignore-deploy-mutex \
+            --skip-docker-image-prune \
             --skip-journal-vacuum; then
         log_warn "Post-deploy storage reclaim reported warnings; continuing because rollout is already healthy"
         return 0

--- a/scripts/moltis-update-proposal-resolver.sh
+++ b/scripts/moltis-update-proposal-resolver.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+MOLTIS_VERSION_HELPER="$PROJECT_ROOT/scripts/moltis-version.sh"
+MOLTIS_IMAGE_PREFIX="${MOLTIS_IMAGE_PREFIX:-ghcr.io/moltis-org/moltis:}"
+
+TRACKED_VERSION=""
+LATEST_RELEASE_TAG=""
+FORCE_MODE=false
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/moltis-update-proposal-resolver.sh \
+  --tracked-version <tag> \
+  --latest-release-tag <tag> \
+  [--force]
+
+Outputs shell-style key=value pairs suitable for appending to $GITHUB_OUTPUT.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tracked-version)
+            TRACKED_VERSION="${2:-}"
+            shift 2
+            ;;
+        --latest-release-tag)
+            LATEST_RELEASE_TAG="${2:-}"
+            shift 2
+            ;;
+        --force)
+            FORCE_MODE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "moltis-update-proposal-resolver.sh: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$TRACKED_VERSION" || -z "$LATEST_RELEASE_TAG" ]]; then
+    echo "moltis-update-proposal-resolver.sh: --tracked-version and --latest-release-tag are required" >&2
+    usage >&2
+    exit 2
+fi
+
+TRACKED_VERSION="$(bash "$MOLTIS_VERSION_HELPER" normalize-tag "$TRACKED_VERSION")"
+CANDIDATE_VERSION="$(bash "$MOLTIS_VERSION_HELPER" normalize-tag "$LATEST_RELEASE_TAG")"
+CANDIDATE_IMAGE="${MOLTIS_IMAGE_PREFIX}${CANDIDATE_VERSION}"
+SHOULD_UPDATE=true
+SKIP_REASON=""
+
+if [[ "$CANDIDATE_VERSION" == "$TRACKED_VERSION" ]]; then
+    SHOULD_UPDATE=false
+    SKIP_REASON="tracked version already equals latest release candidate"
+elif [[ "$FORCE_MODE" != "true" ]]; then
+    NEWEST="$(printf '%s\n%s\n' "$TRACKED_VERSION" "$CANDIDATE_VERSION" | sort -V | tail -n1)"
+    if [[ "$NEWEST" != "$CANDIDATE_VERSION" ]]; then
+        SHOULD_UPDATE=false
+        SKIP_REASON="latest release candidate is not newer than tracked version"
+    fi
+fi
+
+if [[ "$SHOULD_UPDATE" == "true" ]] && ! docker manifest inspect "$CANDIDATE_IMAGE" >/dev/null 2>&1; then
+    SHOULD_UPDATE=false
+    SKIP_REASON="normalized GHCR tag ${CANDIDATE_IMAGE} is not pullable yet"
+fi
+
+printf 'tracked_version=%s\n' "$TRACKED_VERSION"
+printf 'latest_release_tag=%s\n' "$LATEST_RELEASE_TAG"
+printf 'candidate_version=%s\n' "$CANDIDATE_VERSION"
+printf 'candidate_image=%s\n' "$CANDIDATE_IMAGE"
+printf 'should_update=%s\n' "$SHOULD_UPDATE"
+printf 'skip_reason=%s\n' "$SKIP_REASON"

--- a/scripts/moltis-version.sh
+++ b/scripts/moltis-version.sh
@@ -6,6 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 COMPOSE_DEV="$PROJECT_ROOT/docker-compose.yml"
 COMPOSE_PROD="$PROJECT_ROOT/docker-compose.prod.yml"
 MOLTIS_IMAGE_PREFIX="ghcr.io/moltis-org/moltis:"
+EXPLICIT_GHCR_TAG_REGEX='^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'
 
 usage() {
     cat <<'EOF'
@@ -14,6 +15,8 @@ Usage: scripts/moltis-version.sh {version|image|assert-tracked}
 Commands:
   version         Print the tracked Moltis version from compose files
   image           Print the tracked Moltis image reference from compose files
+  normalize-tag   Normalize a release tag into an explicit GHCR runtime tag
+                  (for example: v0.10.18 -> 0.10.18)
   assert-tracked  Fail unless docker-compose.yml and docker-compose.prod.yml
                   resolve to the same pinned Moltis image (not latest)
 EOF
@@ -104,9 +107,8 @@ tracked_moltis_version() {
     printf '%s\n' "${image_ref#${MOLTIS_IMAGE_PREFIX}}"
 }
 
-assert_tracked_contract() {
-    local version
-    version="$(tracked_moltis_version)"
+assert_explicit_release_tag() {
+    local version="${1:-}"
 
     if [[ -z "$version" ]]; then
         echo "Tracked Moltis version is empty" >&2
@@ -119,15 +121,33 @@ assert_tracked_contract() {
     fi
 
     if [[ "$version" == v* ]]; then
-        echo "Tracked Moltis version must use GHCR tag format without leading 'v' (example: 0.10.18)" >&2
+        echo "Tracked Moltis version must use GHCR tag format without leading 'v' (example: 0.10.18 or 20260420.02)" >&2
         return 1
     fi
 
-    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z._-]+)?$ ]]; then
-        echo "Tracked Moltis version is not a valid explicit release tag: $version" >&2
+    if [[ ! "$version" =~ $EXPLICIT_GHCR_TAG_REGEX ]]; then
+        echo "Tracked Moltis version is not a valid explicit GHCR release tag: $version" >&2
+        return 1
+    fi
+}
+
+normalize_release_tag() {
+    local raw_tag="${1:-}"
+    local normalized_tag="${raw_tag#v}"
+
+    if [[ -z "$raw_tag" ]]; then
+        echo "Release tag is empty" >&2
         return 1
     fi
 
+    assert_explicit_release_tag "$normalized_tag"
+    printf '%s\n' "$normalized_tag"
+}
+
+assert_tracked_contract() {
+    local version
+    version="$(tracked_moltis_version)"
+    assert_explicit_release_tag "$version"
 }
 
 main() {
@@ -141,6 +161,10 @@ main() {
         image)
             assert_tracked_contract
             tracked_moltis_image_ref
+            ;;
+        normalize-tag)
+            shift
+            normalize_release_tag "${1:-}"
             ;;
         assert-tracked)
             assert_tracked_contract

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -138,7 +138,6 @@ configure_target() {
                 "moltis_password"
                 "telegram_bot_token"
                 "tavily_api_key"
-                "glm_api_key"
             )
             OPTIONAL_SECRETS=(
                 "smtp_password"

--- a/tests/component/test_moltis_update_proposal_resolver.sh
+++ b/tests/component/test_moltis_update_proposal_resolver.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../lib/test_helpers.sh"
+
+RESOLVER_SCRIPT="$PROJECT_ROOT/scripts/moltis-update-proposal-resolver.sh"
+
+create_fake_docker_bin() {
+    local fixture_root="$1"
+    local fake_bin="${fixture_root}/bin"
+
+    mkdir -p "$fake_bin"
+    cat > "${fake_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "manifest" && "${2:-}" == "inspect" ]]; then
+    requested_image="${3:-}"
+    for allowed in ${FAKE_PULLABLE_IMAGES:-}; do
+        if [[ "$requested_image" == "$allowed" ]]; then
+            exit 0
+        fi
+    done
+    exit 1
+fi
+
+printf 'unsupported fake docker command: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "${fake_bin}/docker"
+    printf '%s\n' "$fake_bin"
+}
+
+kv_value() {
+    local key="$1"
+    local payload="$2"
+
+    awk -F= -v key="$key" '$1 == key { sub($1 FS, ""); print; exit }' <<<"$payload"
+}
+
+run_component_moltis_update_proposal_resolver_tests() {
+    start_timer
+
+    local fixture_root fake_bin
+    fixture_root="$(mktemp -d /tmp/moltis-update-proposal-resolver.XXXXXX)"
+    fake_bin="$(create_fake_docker_bin "$fixture_root")"
+
+    test_start "component_moltis_update_proposal_resolver_accepts_calendar_release_tag_when_pullable"
+    local calendar_output
+    calendar_output="$(
+        PATH="${fake_bin}:$PATH" \
+        FAKE_PULLABLE_IMAGES="ghcr.io/moltis-org/moltis:20260420.02" \
+        bash "$RESOLVER_SCRIPT" \
+            --tracked-version "0.10.18" \
+            --latest-release-tag "20260420.02"
+    )"
+
+    if [[ "$(kv_value should_update "$calendar_output")" == "true" ]] && \
+       [[ "$(kv_value candidate_version "$calendar_output")" == "20260420.02" ]]; then
+        test_pass
+    else
+        test_fail "Resolver should accept a pullable calendar-style GHCR release tag"
+    fi
+
+    test_start "component_moltis_update_proposal_resolver_skips_when_candidate_equals_tracked"
+    local equal_output
+    equal_output="$(
+        PATH="${fake_bin}:$PATH" \
+        FAKE_PULLABLE_IMAGES="ghcr.io/moltis-org/moltis:0.10.18" \
+        bash "$RESOLVER_SCRIPT" \
+            --tracked-version "0.10.18" \
+            --latest-release-tag "v0.10.18"
+    )"
+
+    if [[ "$(kv_value should_update "$equal_output")" == "false" ]] && \
+       [[ "$(kv_value skip_reason "$equal_output")" == "tracked version already equals latest release candidate" ]]; then
+        test_pass
+    else
+        test_fail "Resolver should green-skip when upstream candidate already matches the tracked version"
+    fi
+
+    test_start "component_moltis_update_proposal_resolver_skips_when_candidate_not_pullable_yet"
+    local unpullable_output
+    unpullable_output="$(
+        PATH="${fake_bin}:$PATH" \
+        FAKE_PULLABLE_IMAGES="" \
+        bash "$RESOLVER_SCRIPT" \
+            --tracked-version "0.10.18" \
+            --latest-release-tag "20260420.02"
+    )"
+
+    if [[ "$(kv_value should_update "$unpullable_output")" == "false" ]] && \
+       [[ "$(kv_value skip_reason "$unpullable_output")" == "normalized GHCR tag ghcr.io/moltis-org/moltis:20260420.02 is not pullable yet" ]]; then
+        test_pass
+    else
+        test_fail "Resolver should green-skip instead of failing when the normalized GHCR tag is not pullable yet"
+    fi
+
+    test_start "component_moltis_update_proposal_resolver_rejects_invalid_release_tag"
+    if PATH="${fake_bin}:$PATH" \
+        FAKE_PULLABLE_IMAGES="" \
+        bash "$RESOLVER_SCRIPT" \
+            --tracked-version "0.10.18" \
+            --latest-release-tag "release/20260420" >/dev/null 2>&1; then
+        test_fail "Resolver must fail closed when official release tag cannot normalize into an explicit GHCR runtime tag"
+    else
+        test_pass
+    fi
+
+    rm -rf "$fixture_root"
+    generate_report
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    run_component_moltis_update_proposal_resolver_tests
+fi

--- a/tests/component/test_moltis_version_helper.sh
+++ b/tests/component/test_moltis_version_helper.sh
@@ -84,6 +84,26 @@ run_component_moltis_version_helper_tests() {
         test_fail "Helper should normalize quoted compose image lines, comments, and ${MOLTIS_VERSION-...} defaults"
     fi
 
+    test_start "component_moltis_version_helper_accepts_calendar_release_tags"
+    local calendar_main calendar_prod calendar_version calendar_image normalized_calendar
+    calendar_main="${project_dir}/docker-compose.yml"
+    calendar_prod="${project_dir}/docker-compose.prod.yml"
+    write_compose_fixture "$calendar_main" 'ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260420.02}'
+    write_compose_fixture "$calendar_prod" 'ghcr.io/moltis-org/moltis:20260420.02'
+
+    calendar_version="$("$helper_copy" version)"
+    calendar_image="$("$helper_copy" image)"
+    normalized_calendar="$("$helper_copy" normalize-tag "v20260420.02")"
+
+    if [[ "$calendar_version" == "20260420.02" ]] && \
+       [[ "$calendar_image" == "ghcr.io/moltis-org/moltis:20260420.02" ]] && \
+       [[ "$normalized_calendar" == "20260420.02" ]] && \
+       "$helper_copy" assert-tracked >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "Helper should accept explicit calendar-style GHCR tags and normalize matching release tags with a leading v"
+    fi
+
     test_start "component_moltis_version_helper_rejects_non_defaulted_variable"
     local variable_main variable_prod
     variable_main="${project_dir}/docker-compose.yml"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -164,6 +164,7 @@ suite_entries_for_lane() {
             printf '%s\n' \
                 "bash|component_backup_restore_readiness|Backup restore-readiness component|$SCRIPT_DIR/component/test_backup_restore_readiness.sh" \
                 "bash|component_moltis_version_helper|Moltis version helper component|$SCRIPT_DIR/component/test_moltis_version_helper.sh" \
+                "bash|component_moltis_update_proposal_resolver|Moltis update proposal resolver component|$SCRIPT_DIR/component/test_moltis_update_proposal_resolver.sh" \
                 "bash|component_prepare_moltis_runtime_config|Prepare Moltis runtime config component|$SCRIPT_DIR/component/test_prepare_moltis_runtime_config.sh" \
                 "bash|component_circuit_breaker|Circuit breaker component|$SCRIPT_DIR/component/test_circuit_breaker.sh" \
                 "bash|component_prometheus_metrics|Prometheus metrics component|$SCRIPT_DIR/component/test_prometheus_metrics.sh" \

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -14,6 +14,7 @@ DEPLOY_WORKFLOW="$PROJECT_ROOT/.github/workflows/deploy.yml"
 DEPLOY_STATUS_NOTIFY_WORKFLOW="$PROJECT_ROOT/.github/workflows/deploy-status-notify.yml"
 DEPLOY_STALL_WATCHDOG_WORKFLOW="$PROJECT_ROOT/.github/workflows/deploy-stall-watchdog.yml"
 MOLTIS_UPDATE_PROPOSAL_WORKFLOW="$PROJECT_ROOT/.github/workflows/moltis-update-proposal.yml"
+MOLTIS_UPDATE_PROPOSAL_RESOLVER_SCRIPT="$PROJECT_ROOT/scripts/moltis-update-proposal-resolver.sh"
 CLAWDIY_WORKFLOW="$PROJECT_ROOT/.github/workflows/deploy-clawdiy.yml"
 UAT_GATE_WORKFLOW="$PROJECT_ROOT/.github/workflows/uat-gate.yml"
 FEATURE_DIAGNOSTICS_WORKFLOW="$PROJECT_ROOT/.github/workflows/feature-diagnostics.yml"
@@ -553,10 +554,11 @@ run_static_config_validation_tests() {
        rg -Fq 'prepare_moltis_browser_sandbox_image()' "$DEPLOY_SCRIPT" && \
        rg -q 'docker build \\' "$DEPLOY_SCRIPT" && \
        rg -Fq 'scripts/moltis-browser-sandbox/Dockerfile' "$DEPLOY_SCRIPT" && \
+       rg -Fq -- '--skip-docker-image-prune' "$DEPLOY_SCRIPT" && \
        rg -Fq 'DOCKER_SOCKET_GID' "$DEPLOY_SCRIPT"; then
         test_pass
     else
-        test_fail "Runtime attestation and deploy control plane must guard browser sandbox image availability, docker.sock access, host-gateway routing, writable browser profile storage, and single-instance non-persistent browser concurrency before production traffic hits Telegram"
+        test_fail "Runtime attestation and deploy control plane must guard browser sandbox image availability, keep post-deploy reclaim from pruning the tracked sandbox image before attestation completes, preserve docker.sock access, host-gateway routing, writable browser profile storage, and single-instance non-persistent browser concurrency before production traffic hits Telegram"
     fi
 
     test_start "static_moltis_identity_degrades_tool_heavy_telegram_paths"
@@ -604,7 +606,9 @@ run_static_config_validation_tests() {
     test_start "static_moltis_version_contract_stays_git_tracked_and_pinned"
     if [[ -x "$MOLTIS_VERSION_SCRIPT" ]] && \
        "$MOLTIS_VERSION_SCRIPT" assert-tracked && \
-       [[ "$("$MOLTIS_VERSION_SCRIPT" version)" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z._-]+)?$ ]]; then
+       [[ "$("$MOLTIS_VERSION_SCRIPT" version)" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] && \
+       [[ "$("$MOLTIS_VERSION_SCRIPT" version)" != v* ]] && \
+       [[ "$("$MOLTIS_VERSION_SCRIPT" version)" != "latest" ]]; then
         test_pass
     else
         test_fail "Tracked Moltis version must resolve to an explicit GHCR tag without leading v and be validated by scripts/moltis-version.sh"
@@ -687,6 +691,13 @@ run_static_config_validation_tests() {
         test_pass
     else
         test_fail "Production Moltis container must receive OLLAMA_API_KEY so cloud-backed Ollama chat models can appear in the runtime provider catalog"
+    fi
+
+    test_start "static_active_moltis_deploy_surface_has_no_glm_secret_contract"
+    if ! rg -q 'GLM_API_KEY|GLM_API_KEY_FILE|glm_api_key' "$PROJECT_ROOT/docker-compose.yml" "$COMPOSE_PROD" "$PREFLIGHT_SCRIPT" "$MOLTIS_ENV_RENDER_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Active Moltis deploy surface must not require legacy GLM secrets once GitHub-rendered runtime uses GPT-5.4 OAuth + Ollama cloud fallback only"
     fi
 
     test_start "static_codex_cli_update_delivery_script_is_executable"
@@ -1376,6 +1387,7 @@ run_static_config_validation_tests() {
 
     test_start "static_moltis_update_proposal_workflow_is_safe_and_non_deploying"
     if [[ -f "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" ]] && \
+       [[ -x "$MOLTIS_UPDATE_PROPOSAL_RESOLVER_SCRIPT" ]] && \
        rg -q '^name: Moltis Update Proposal$' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
        rg -q '^  schedule:$' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
        rg -q '^  workflow_dispatch:$' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
@@ -1384,7 +1396,8 @@ run_static_config_validation_tests() {
        rg -q 'group: moltis-update-proposal' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
        rg -q 'scripts/moltis-version\.sh version' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
        rg -q 'gh api repos/moltis-org/moltis/releases/latest' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
-       rg -q 'docker manifest inspect "ghcr\.io/moltis-org/moltis:' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -q 'scripts/moltis-update-proposal-resolver\.sh' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
+       rg -q 'docker manifest inspect' "$MOLTIS_UPDATE_PROPOSAL_RESOLVER_SCRIPT" && \
        rg -q 'gh pr create --base main' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW" && \
        ! rg -q 'gh workflow run "Deploy Moltis"|deploy\.sh --json moltis deploy|docker compose -f docker-compose\.prod\.yml up -d moltis' "$MOLTIS_UPDATE_PROPOSAL_WORKFLOW"; then
         test_pass


### PR DESCRIPTION
## Что сделано
- защитил tracked deploy от post-deploy image prune, который удалял browser sandbox image до runtime attestation
- вынес update-proposal resolve logic в shared helper и добавил поддержку календарных release tags через общий normalize-tag contract
- убрал stale GLM secret contract из active deploy surface и добавил RCA + regression coverage

## Проверки
- bash tests/component/test_moltis_version_helper.sh
- bash tests/component/test_moltis_update_proposal_resolver.sh
- bash tests/static/test_config_validation.sh
- bash tests/unit/test_deploy_workflow_guards.sh