### PR TITLE
fix: contain telegram tool diagnostic chatter

### DIFF
--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -2332,7 +2332,7 @@ text_looks_like_maintenance_request() {
 
     [[ -n "$source_text" ]] || return 1
 
-    printf '%s' "$source_text" | grep -Eiq '(почин(и|ить|им|ю|ите)|исправ(ь|ить|им|лю|ьте)|отлад(ь|ить|им|ка|ку)|разбер(и|ись|ем|у)|расслед(уй|овать|уем)|диагност(ируй|ировать|ика)|debug|repair|fix|troubleshoot|investigat(e|ion)|inspect|лог(и|ов|ами|ах)?|logs?|ошибк(а|и|у|ой)|error|errors|не работает|не срабатывает|не отвечает|сломал(ось|ся|и)?|сломано|root cause|rca)'
+    printf '%s' "$source_text" | grep -Eiq '(почин(и|ить|им|ю|ите)|исправ(ь|ить|им|лю|ьте)|отлад(ь|ить|им|ка|ку)|разбер(и|ись|ем|у)|расслед(уй|овать|уем)|диагност(ируй|ировать|ика)|debug|repair|fix|troubleshoot|investigat(e|ion)|inspect|лог(и|ов|ами|ах)?|logs?|ошибк(а|и|у|ой)|error|errors|не работает|не срабатывает|не отвечает|сломал(ось|ся|и)?|сломан(а|о|ы)?|root cause|rca)'
 }
 
 flag_enabled() {
@@ -3091,10 +3091,10 @@ response_has_delivery_internal_trace() {
             | sed 's/[[:space:]][[:space:]]*/ /g'
     )"
 
-    if printf '%s' "$flat" | grep -Eiq "activity log([[:space:]]|$).*(•|running:|searching memory|fetching (github\\.com|https?://)|mcp tool error|validation errors for call\\[|tool-progress|mcp__|nodes_list|sessions_list|missing '(action|query|command)' parameter|list failed:)"; then
+    if printf '%s' "$flat" | grep -Eiq "activity log([[:space:]]|$).*(•|running:|searching memory|fetching (github\\.com|https?://)|mcp tool error|validation errors for call\\[|tool-progress|mcp__|nodes_list|sessions_list|missing '(action|query|command|name|pattern)'( parameter)?|list failed:)"; then
         return 0
     fi
-    if printf '%s' "$flat" | grep -Eiq "running:|searching memory|nodes_list|sessions_list|missing '(action|query|command)' parameter|list failed:|mcp tool error|validation errors for call\\[|fetching (github\\.com|https?://)|tool-progress"; then
+    if printf '%s' "$flat" | grep -Eiq "running:|searching memory|nodes_list|sessions_list|missing '(action|query|command|name|pattern)'( parameter)?|list failed:|mcp tool error|validation errors for call\\[|fetching (github\\.com|https?://)|tool-progress"; then
         return 0
     fi
     if printf '%s' "$flat" | grep -Eiq '(^|[[:space:]])(•|🔧|🗺️|💻|🔗|🌐|🧠|❌)[[:space:]]*mcp__'; then
@@ -3114,7 +3114,7 @@ delivery_internal_suffix_is_appended() {
             | sed 's/[[:space:]][[:space:]]*/ /g'
     )"
 
-    if printf '%s' "$flat" | grep -Eiq '^.+[^[:space:]][[:space:]]+Activity log[[:space:]]+(•|running:|searching memory|fetching (github\.com|https?://)|mcp tool error|validation errors for call\[|tool-progress|mcp__|nodes_list|sessions_list|missing '\''(action|query|command)'\'' parameter|list failed:)'; then
+    if printf '%s' "$flat" | grep -Eiq '^.+[^[:space:]][[:space:]]+Activity log[[:space:]]+(•|running:|searching memory|fetching (github\.com|https?://)|mcp tool error|validation errors for call\[|tool-progress|mcp__|nodes_list|sessions_list|missing '\''(action|query|command|name|pattern)'\''( parameter)?|list failed:)'; then
         return 0
     fi
     if printf '%s' "$flat" | grep -Eiq '^.+[^[:space:]][[:space:]]+•[[:space:]]+mcp__[A-Za-z0-9_:.:-]+'; then
@@ -3140,7 +3140,7 @@ strip_delivery_internal_suffix() {
 
     cleaned="$(
         printf '%s' "$cleaned" \
-            | sed -E 's/[[:space:]]+Activity log([[:space:]]*[•:-][[:space:]]*(mcp__|Running:|Searching memory|Thinking|Fetching (github\.com|https?:\/\/)|tool-progress|tool call|missing '\''(action|query|command)'\'' parameter).*)$//I' \
+            | sed -E 's/[[:space:]]+Activity log([[:space:]]*[•:-][[:space:]]*(mcp__|Running:|Searching memory|Thinking|Fetching (github\.com|https?:\/\/)|tool-progress|tool call|missing '\''(action|query|command|name|pattern)'\''( parameter)?).*)$//I' \
             | sed -E 's/[[:space:]]+•[[:space:]]*(mcp__|Running:|Searching memory|Thinking|Fetching (github\.com|https?:\/\/)|tool-progress|tool call).*$//I'
     )"
 
@@ -3157,7 +3157,7 @@ clean_delivery_text_is_safe_for_direct_send() {
 
     [[ -n "$text" ]] || return 1
 
-    if printf '%s' "$text" | grep -Eiq 'running:|searching memory|thinking|nodes_list|sessions_list|mcp__|mcp tool error|validation errors for call\[|missing required argument|missing '\''(action|query|command)'\'' parameter|unexpected keyword argument|fetching (github\.com|https?://)|tool-progress|tool call'; then
+    if printf '%s' "$text" | grep -Eiq 'running:|searching memory|thinking|nodes_list|sessions_list|mcp__|mcp tool error|validation errors for call\[|missing required argument|missing '\''(action|query|command|name|pattern)'\''( parameter)?|unexpected keyword argument|fetching (github\.com|https?://)|tool-progress|tool call'; then
         return 1
     fi
 

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -3323,6 +3323,26 @@ EOF
         test_fail "BeforeLLMCall guard must fail-close generic log/root-cause maintenance turns even when the user omitted an explicit skill or codex-update subject"
     fi
 
+    test_start "component_before_llm_guard_hard_overrides_live_tool_broken_confirmation_turn"
+    local before_llm_tool_broken_confirmation_output
+    before_llm_tool_broken_confirmation_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$(secure_temp_dir telegram-safe-tool-broken-before)" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:tool-broken-confirmation","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Ты проверил, что инструменты сломаны? Убедился?"}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_tool_broken_confirmation_output" && \
+       jq -e '.data.messages | length == 2' >/dev/null 2>&1 <<<"$before_llm_tool_broken_confirmation_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe maintenance hard override")' >/dev/null 2>&1 <<<"$before_llm_tool_broken_confirmation_output" && \
+       jq -e '.data.messages[0].content | contains("не провожу repair/debug/log inspection")' >/dev/null 2>&1 <<<"$before_llm_tool_broken_confirmation_output" && \
+       jq -e '.data.messages[1].content == "Верни в ответ ровно указанную в системном сообщении фразу. Не добавляй ничего."' >/dev/null 2>&1 <<<"$before_llm_tool_broken_confirmation_output" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_tool_broken_confirmation_output"; then
+        test_pass
+    else
+        test_fail "BeforeLLMCall guard must classify the live 'инструменты сломаны' confirmation as Telegram-safe maintenance instead of letting the model prove tool breakage"
+    fi
+
     test_start "component_before_llm_guard_direct_fastpaths_codex_update_maintenance_when_enabled"
     local fastpath_maintenance_tmp fastpath_maintenance_send_script fastpath_maintenance_log fastpath_maintenance_stdout fastpath_maintenance_stderr fastpath_maintenance_status fastpath_maintenance_intent_dir fastpath_maintenance_suppress_file
     fastpath_maintenance_tmp="$(secure_temp_dir telegram-safe-fastpath-maintenance)"
@@ -3404,6 +3424,23 @@ EOF
         test_pass
     else
         test_fail "MessageSending guard must rewrite leaked codex-update maintenance/debug runtime chatter into the deterministic Telegram-safe boundary reply"
+    fi
+
+    test_start "component_message_sending_guard_rewrites_live_plain_tool_runtime_diagnostic_chatter"
+    local plain_tool_runtime_diagnostic_output
+    plain_tool_runtime_diagnostic_output="$(
+        env PATH="$MINIMAL_PATH" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"MessageSending","session_id":"session:plain-tool-runtime-diagnostic","data":{"account_id":"moltis-bot","to":"262872984","reply_to_message_id":1435,"user_message":"Ты не можешь настроить отправку новости о новой версии один раз?","text":"Могу. Логика понятная: хранить `last_announced_version`, и если cron снова видит ту же версию — ничего не слать.\n\nНо прямо сейчас именно настроить сам я не могу, потому что в этой сессии инструменты сломаны: даже базовые вызовы чтения skill, памяти, cron и shell возвращают ошибки вида `missing 'name'`, `missing 'query'`, `missing 'action'`, `missing 'command'` при корректных аргументах."}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$plain_tool_runtime_diagnostic_output" && \
+       jq -e '.data.text | contains("не запускаю инструменты и не показываю внутренние логи")' >/dev/null 2>&1 <<<"$plain_tool_runtime_diagnostic_output" && \
+       jq -e '.data.reply_to_message_id == 1435' >/dev/null 2>&1 <<<"$plain_tool_runtime_diagnostic_output" && \
+       jq -e '.data.text | test("missing '\''name'\''|missing '\''query'\''|missing '\''action'\''|missing '\''command'\''|инструменты сломаны|read_skill|memory_search|cron|shell") | not' >/dev/null 2>&1 <<<"$plain_tool_runtime_diagnostic_output"; then
+        test_pass
+    else
+        test_fail "MessageSending guard must rewrite plain live tool-runtime diagnostic chatter even when the leaked text does not use the word parameter"
     fi
 
     test_start "component_message_sending_guard_rewrites_plain_skill_maintenance_runtime_failure"


### PR DESCRIPTION
## Summary
- analyzed live @moltinger_bot logs and the latest dialog around repeated Codex update notifications and broken-tool claims
- classifies Russian plural `инструменты сломаны` as Telegram-safe maintenance instead of letting the model prove tool breakage
- treats plain `missing 'name'`, `missing 'pattern'`, `missing 'query'`, `missing 'action'`, and `missing 'command'` as internal telemetry even without the word `parameter`
- adds regressions for the live last-message patterns so Telegram replies no longer expose pseudo system logs or repair prompts

Refs: moltinger-e2wd

## Tests
- `bash -n scripts/telegram-safe-llm-guard.sh tests/component/test_telegram_safe_llm_guard.sh`
- `git diff --check`
- `bash tests/component/test_telegram_safe_llm_guard.sh` (137/137)
- `bash tests/static/test_config_validation.sh` (153/153)