### PR TITLE
Fix Moltis tool argument envelope drift

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
-**Generated**: 2026-04-20
-**Total Lessons**: 85
+**Generated**: 2026-04-23
+**Total Lessons**: 86
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (41 lessons)
+#### P1 (42 lessons)
+- [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [GitHub Actions bad logs from post-deploy image prune and calendar tag rejection](../docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md)
 - [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
@@ -188,7 +189,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (5 lessons)
+#### product (6 lessons)
+- [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
 - [Telegram codex-update hard override did not terminalize blocked tool follow-up](../docs/rca/2026-04-14-telegram-codex-update-hard-override-did-not-terminalize-blocked-tool-followup.md)
@@ -214,16 +216,16 @@
 
 ### Popular Tags
 
-- `rca` (32 lessons)
-- `moltis` (27 lessons)
-- `telegram` (21 lessons)
+- `rca` (33 lessons)
+- `moltis` (28 lessons)
+- `telegram` (22 lessons)
 - `deploy` (20 lessons)
 - `github-actions` (18 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
-- `skills` (12 lessons)
+- `skills` (13 lessons)
 - `beads` (12 lessons)
-- `process` (9 lessons)
+- `hooks` (10 lessons)
 
 
 ---
@@ -232,10 +234,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 85 |
-| Critical (P0/P1) | 42 |
+| Total Lessons | 86 |
+| Critical (P0/P1) | 43 |
 | Categories | 8 |
-| Unique Tags | 166 |
+| Unique Tags | 167 |
 
 ---
 

--- a/docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md
+++ b/docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md
@@ -1,0 +1,87 @@
+---
+title: "Moltis tool argument envelope drift surfaced as missing required parameters"
+date: 2026-04-23
+severity: P1
+category: product
+tags: [telegram, moltis, hooks, tools, skills, runtime, rca]
+root_cause: "Repo-owned hook logic treated visible missing-parameter cards as a delivery hygiene problem while live session artifacts showed a deeper argument-envelope drift: required fields were present in persisted tool-call JSON but reached runner validation as missing."
+---
+
+# RCA: Moltis tool argument envelope drift surfaced as missing required parameters
+
+**Дата:** 2026-04-23
+**Статус:** Resolved
+**Влияние:** Telegram/Web turns could show `missing 'command' parameter`, `missing 'query' parameter`, `missing 'name'`, `missing 'action'`, or `missing 'pattern'` even when the persisted tool-call JSON contained the required field.
+**Контекст:** Moltis `BeforeToolCall` hook, Telegram bot skill editing/maintenance turns, OpenAI Codex provider path.
+
+## Ошибка
+
+Previous containment changed delivery behavior so raw cards were less visible, but it did not fix why valid tool calls were failing. Production session artifacts showed calls like:
+
+- `read_skill` with `name: "codex-update"` and `file_path: null`, followed by `missing 'name'`;
+- `memory_search` with `query: "..."`, followed by `missing 'query' parameter`;
+- `exec` with `command: "..."`, followed by `missing 'command' parameter`;
+- `cron` with `action: "list"`, followed by `missing 'action' parameter`;
+- `Glob` with `pattern: "**/codex-update/**"`, followed by `missing 'pattern' parameter`.
+
+The common shape was not absent required fields. It was an enriched runtime argument envelope with repo/runtime metadata such as `_channel`, `_session_key`, and null optional fields.
+
+## Проверка прошлых уроков
+
+Проверенные источники:
+
+- `MEMORY.md`
+- `SESSION_SUMMARY.md`
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag hooks`
+- `./scripts/query-lessons.sh --tag skills`
+
+Релевантные прошлые уроки:
+
+1. `2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors` already warned that maintenance/debug turns need source-level contracts, not just user-facing cleanup.
+2. `2026-04-14-telegram-codex-update-array-content-bypassed-turn-classifier` covered payload-shape drift as a public hook contract issue.
+3. `2026-04-02-telegram-skill-detail-fell-back-to-tool-error-leak` covered that component tests must prove runtime/container behavior, not host-only assumptions.
+
+Что новое:
+
+- The runner error text was misleading: the required fields were present before execution. The missing piece was canonicalizing the argument object before the runner validates it.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---|---|---|---|
+| 1 | Why did users still see missing-parameter failures? | The hook hid some final messages but valid tool calls still reached runtime in a non-canonical envelope. | Live session JSONL showed required args plus runner errors. |
+| 2 | Why did validation say fields were missing? | The argument object contained runtime metadata/null fields and was not normalized before tool execution. | Same failure family across `read_skill`, `memory_search`, `exec`, `cron`, `Glob`. |
+| 3 | Why was this not fixed in the previous PR? | The fix targeted delivery hygiene and fail-closed suppression, not the `BeforeToolCall` argument boundary. | Existing tests asserted synthetic `exec true` for malformed/blocked calls, not canonical native tool calls. |
+| 4 | Why did the hook allow this class to persist? | It had validators for missing arguments but no path for “required args present, envelope dirty”. | `tool_call_has_missing_required_arguments` could only suppress absent fields. |
+| 5 | Why could the issue recur? | There was no regression test proving that live-like envelopes are normalized to the original tool identity. | New component tests now cover `read_skill`, `memory_search`, `exec`, `cron`, `Glob`, `web_fetch`, and `browser`. |
+
+## Корневая причина
+
+The owning layer was the repo-managed Moltis hook contract. It did not normalize valid enriched `BeforeToolCall.arguments` payloads before runner validation. Treating the resulting errors as Telegram delivery leakage was insufficient because it hid symptoms while preserving the invalid runtime boundary.
+
+## Принятые меры
+
+1. Added a `BeforeToolCall` canonicalization path for known tools when required fields are present but the envelope contains `_channel`, `_session_key`, or null fields.
+2. Preserved original tool identity instead of replacing valid calls with synthetic `exec true`.
+3. Added `read_skill` to the native skill allowlist and missing-argument taxonomy.
+4. Expanded missing-argument taxonomy for `process`, `Glob`, `web_fetch`, `browser`, and Tavily search.
+5. Added component regression tests for live-like valid envelopes and kept existing fail-closed tests for truly malformed calls.
+
+## Уроки
+
+1. If required fields are present in persisted tool-call JSON, do not classify the incident as model omission or message hygiene; inspect and fix the argument boundary.
+2. Telegram/Web tool error cleanup is not a root fix unless a test proves the original valid tool call can execute as that same tool.
+3. Hook tests must cover “dirty but valid runtime envelope” separately from “malformed missing required argument”.
+
+## Regression Test
+
+**Test File:** `tests/component/test_telegram_safe_llm_guard.sh`
+
+**Test Status:**
+
+- [x] Test created
+- [x] Test reproduces the class as a live-like envelope
+- [x] Fix applied
+- [x] Test passes

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -743,6 +743,116 @@ append_optional_number_field() {
     fi
 }
 
+canonicalize_known_tool_arguments_json() {
+    local tool_name="${1:-}"
+    local arguments_json="${2:-}"
+    local canonicalized=""
+
+    [[ -n "$tool_name" && -n "$arguments_json" ]] || return 1
+    case "$arguments_json" in
+        *'"_channel"'*|*'"_session_key"'*|*':null'*|*': null'*)
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    command -v python3 >/dev/null 2>&1 || return 1
+
+    canonicalized="$(
+        printf '%s' "$arguments_json" | python3 -c '
+import json
+import sys
+
+tool = sys.argv[1] if len(sys.argv) > 1 else ""
+raw = sys.stdin.read()
+
+try:
+    args = json.loads(raw)
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(args, dict):
+    raise SystemExit(1)
+
+requirements = {
+    "read_skill": ("string", "name"),
+    "memory_search": ("string", "query"),
+    "exec": ("string", "command"),
+    "cron": ("string", "action"),
+    "process": ("string", "action"),
+    "Glob": ("string", "pattern"),
+    "web_fetch": ("string", "url"),
+    "browser": ("string", "action"),
+    "create_skill": ("string", "name"),
+    "update_skill": ("string", "name"),
+    "patch_skill": ("all_strings", ("name", "instructions")),
+    "delete_skill": ("string", "name"),
+    "write_skill_files": ("name_and_files", None),
+    "mcp__tavily__tavily_search": ("string", "query"),
+}
+
+requirement = requirements.get(tool)
+if requirement is None:
+    raise SystemExit(1)
+
+def nonempty_string(value):
+    return isinstance(value, str) and bool(value.strip())
+
+kind, spec = requirement
+if kind == "string":
+    if not nonempty_string(args.get(spec)):
+        raise SystemExit(1)
+elif kind == "all_strings":
+    if not all(nonempty_string(args.get(key)) for key in spec):
+        raise SystemExit(1)
+elif kind == "name_and_files":
+    files = args.get("files")
+    if not nonempty_string(args.get("name")) or not isinstance(files, list):
+        raise SystemExit(1)
+    if not any(isinstance(item, dict) for item in files):
+        raise SystemExit(1)
+else:
+    raise SystemExit(1)
+
+changed = False
+
+def clean(value):
+    global changed
+    if isinstance(value, dict):
+        output = {}
+        for key, nested in value.items():
+            if key.startswith("_") or nested is None:
+                changed = True
+                continue
+            cleaned = clean(nested)
+            if cleaned is None:
+                changed = True
+                continue
+            output[key] = cleaned
+        return output
+    if isinstance(value, list):
+        output = []
+        for item in value:
+            cleaned = clean(item)
+            if cleaned is None:
+                changed = True
+                continue
+            output.append(cleaned)
+        return output
+    return value
+
+cleaned_args = clean(args)
+if not changed:
+    raise SystemExit(1)
+
+print(json.dumps(cleaned_args, ensure_ascii=False, separators=(",", ":")))
+        ' "$tool_name"
+    )" || return 1
+
+    [[ -n "$canonicalized" ]] || return 1
+    printf '%s' "$canonicalized"
+}
+
 append_field_to_object() {
     local object_json="$1"
     local field_fragment="$2"
@@ -3283,6 +3393,9 @@ tool_call_has_missing_required_arguments() {
     [[ -n "$arguments_json" ]] || arguments_json='{}'
 
     case "$tool_name" in
+        read_skill)
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "name"
+            ;;
         memory_search)
             ! json_string_field_present_and_nonempty_from_text "$arguments_json" "query"
             ;;
@@ -3290,6 +3403,18 @@ tool_call_has_missing_required_arguments() {
             ! json_string_field_present_and_nonempty_from_text "$arguments_json" "command"
             ;;
         cron)
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "action"
+            ;;
+        process)
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "action"
+            ;;
+        Glob)
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "pattern"
+            ;;
+        web_fetch)
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "url"
+            ;;
+        browser)
             ! json_string_field_present_and_nonempty_from_text "$arguments_json" "action"
             ;;
         create_skill)
@@ -3308,6 +3433,9 @@ tool_call_has_missing_required_arguments() {
         write_skill_files)
             ! json_string_field_present_and_nonempty_from_text "$arguments_json" "name" || \
             ! json_array_field_has_object_entries_from_text "$arguments_json" "files"
+            ;;
+        mcp__tavily__tavily_search)
+            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "query"
             ;;
         *)
             return 1
@@ -3354,7 +3482,7 @@ tool_name_is_allowlisted() {
 tool_name_is_skill_allowlisted() {
     local tool_name="${1:-}"
     case "$tool_name" in
-        create_skill|update_skill|patch_skill|delete_skill|write_skill_files|session_state|send_message|send_image)
+        read_skill|create_skill|update_skill|patch_skill|delete_skill|write_skill_files|session_state|send_message|send_image)
             return 0
             ;;
         *)
@@ -4037,6 +4165,15 @@ fi
 already_guarded_long_research=false
 if printf '%s' "$payload_flat" | grep -Fq 'Telegram-safe long-research guard'; then
     already_guarded_long_research=true
+fi
+
+if [[ "$event" == "BeforeToolCall" ]]; then
+    canonicalized_tool_arguments_json="$(canonicalize_known_tool_arguments_json "$tool_name" "${tool_arguments_json:-}" || true)"
+    if [[ -n "${canonicalized_tool_arguments_json:-}" ]]; then
+        write_audit_line "emit_modify event=$event reason=canonical_tool_arguments tool=${tool_name:-missing} telegram_safe=$is_telegram_safe_lane"
+        emit_before_tool_modified_payload "$tool_name" "$canonicalized_tool_arguments_json"
+        exit 0
+    fi
 fi
 
 if [[ "$event" == "MessageSending" ]]; then

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -2318,6 +2318,62 @@ EOF
         test_fail "BeforeToolCall guard must allow native update_skill, patch_skill, delete_skill, and write_skill_files passthrough for owner Telegram skill CRUD"
     fi
 
+    test_start "component_before_tool_guard_canonicalizes_live_read_skill_envelope_without_blocking"
+    local before_tool_read_skill_envelope_output
+    before_tool_read_skill_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:read-skill-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"read_skill","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984","surface":"telegram"},"_session_key":"session:read-skill-envelope","file_path":null,"name":"codex-update"}}}'
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.session_key == "session:read-skill-envelope"' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.tool == "read_skill"' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.tool_name == "read_skill"' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.arguments.name == "codex-update"' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.arguments | has("_channel") | not' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.arguments | has("_session_key") | not' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output" && \
+       jq -e '.data.arguments | has("file_path") | not' >/dev/null 2>&1 <<<"$before_tool_read_skill_envelope_output"; then
+        test_pass
+    else
+        test_fail "BeforeToolCall guard must normalize valid read_skill argument envelopes to the native tool instead of blocking or hiding them"
+    fi
+
+    test_start "component_before_tool_guard_canonicalizes_valid_runtime_tool_envelopes_to_original_tools"
+    local before_tool_memory_envelope_output before_tool_exec_envelope_output before_tool_cron_envelope_output before_tool_glob_envelope_output before_tool_fetch_envelope_output before_tool_browser_envelope_output
+    before_tool_memory_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:memory-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"memory_search","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:memory-envelope","limit":10,"query":"codex-update last announced version","filter":null}}}'
+    )"
+    before_tool_exec_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:exec-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"exec","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:exec-envelope","command":"pwd","timeout":20000,"working_dir":"/home/moltis/.moltis","reason":null}}}'
+    )"
+    before_tool_cron_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:cron-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"cron","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:cron-envelope","action":"list","limit":50,"id":null,"job":null}}}'
+    )"
+    before_tool_glob_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:glob-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"Glob","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:glob-envelope","path":"/home/moltis/.moltis","pattern":"**/codex-update/**","exclude":null}}}'
+    )"
+    before_tool_fetch_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:fetch-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"web_fetch","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:fetch-envelope","url":"https://docs.moltis.org/skill-tools.html","extract_mode":"text","max_chars":12000,"selector":null}}}'
+    )"
+    before_tool_browser_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:browser-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"browser","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:browser-envelope","action":"open","url":"https://example.com","session_id":null}}}'
+    )"
+    if jq -e '.action == "modify" and .data.tool == "memory_search" and .data.arguments.query == "codex-update last announced version" and .data.arguments.limit == 10 and (.data.arguments | has("_channel") | not) and (.data.arguments | has("filter") | not)' >/dev/null 2>&1 <<<"$before_tool_memory_envelope_output" && \
+       jq -e '.action == "modify" and .data.tool == "exec" and .data.arguments.command == "pwd" and .data.arguments.timeout == 20000 and .data.arguments.working_dir == "/home/moltis/.moltis" and (.data.arguments | has("_session_key") | not) and (.data.arguments | has("reason") | not)' >/dev/null 2>&1 <<<"$before_tool_exec_envelope_output" && \
+       jq -e '.action == "modify" and .data.tool == "cron" and .data.arguments.action == "list" and .data.arguments.limit == 50 and (.data.arguments | has("id") | not) and (.data.arguments | has("job") | not)' >/dev/null 2>&1 <<<"$before_tool_cron_envelope_output" && \
+       jq -e '.action == "modify" and .data.tool == "Glob" and .data.arguments.pattern == "**/codex-update/**" and .data.arguments.path == "/home/moltis/.moltis" and (.data.arguments | has("exclude") | not)' >/dev/null 2>&1 <<<"$before_tool_glob_envelope_output" && \
+       jq -e '.action == "modify" and .data.tool == "web_fetch" and .data.arguments.url == "https://docs.moltis.org/skill-tools.html" and .data.arguments.max_chars == 12000 and (.data.arguments | has("selector") | not)' >/dev/null 2>&1 <<<"$before_tool_fetch_envelope_output" && \
+       jq -e '.action == "modify" and .data.tool == "browser" and .data.arguments.action == "open" and .data.arguments.url == "https://example.com" and (.data.arguments | has("session_id") | not)' >/dev/null 2>&1 <<<"$before_tool_browser_envelope_output"; then
+        test_pass
+    else
+        test_fail "BeforeToolCall guard must fix valid live runtime envelopes at the argument boundary and preserve the original tool identity"
+    fi
+
     test_start "component_before_tool_guard_blocks_disallowed_browser_tool_in_safe_lane"
     local before_tool_browser_output
     before_tool_browser_output="$(


### PR DESCRIPTION
## Summary
- normalize valid Moltis BeforeToolCall argument envelopes before runner validation
- preserve original tool identity for dirty-but-valid calls instead of replacing them with synthetic exec/no-op
- allow native read_skill and expand missing-argument taxonomy for known tools
- document RCA and rebuild lessons index

## Verification
- bash -n scripts/telegram-safe-llm-guard.sh
- bash -n tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/static/test_config_validation.sh
- git diff --check