### PR TITLE
Fix Telegram skill detail no-tool regression

### DIFF
--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -3736,7 +3736,13 @@ case "${persisted_turn_intent:-}" in
         ;;
 esac
 channel_account="$(extract_runtime_field_from_text "${latest_system_message:-}" "channel_account" || true)"
+if [[ -z "$channel_account" ]]; then
+    channel_account="$(extract_runtime_field_from_text "${messages_json:-$payload_flat}" "channel_account" || true)"
+fi
 system_chat_id="$(extract_runtime_field_from_text "${latest_system_message:-}" "channel_chat_id" || true)"
+if [[ -z "$system_chat_id" ]]; then
+    system_chat_id="$(extract_runtime_field_from_text "${messages_json:-$payload_flat}" "channel_chat_id" || true)"
+fi
 delivery_chat_id="$(extract_first_string to || true)"
 if [[ -z "$delivery_chat_id" ]]; then
     delivery_chat_id="$(extract_first_number to || true)"
@@ -4110,6 +4116,10 @@ if [[ "$current_turn_skill_detail_request" != true && "$looks_like_skill_turn" !
         current_turn_skill_detail_request=true
         looks_like_skill_turn=true
     fi
+fi
+if [[ "$current_turn_skill_detail_request" == true ]]; then
+    current_turn_codex_update_request=false
+    current_turn_codex_update_scheduler_request=false
 fi
 if [[ "$has_current_user_turn" != true && -n "$persisted_skill_create_state" && -n "$requested_skill_name" && -n "$requested_skill_name_re" ]] && \
    printf '%s' "${intent_text_flat} ${latest_user_message_flat} ${latest_assistant_message_flat} ${response_text_flat} ${payload_flat}" \

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -54,7 +54,7 @@ const headed = hasFlag("--headed");
 const debug = hasFlag("--debug");
 
 const ERROR_RE =
-  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|no models available|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'?(?:action|query|command)'?\s+parameter)/i;
+  /(traceback|exception|stack\s*trace|panic|internal server error|mcp tool error|validation errors for call\[|missing required argument|unexpected keyword argument|fetching (?:github\.com|https?:\/\/)|timed?\s*out|timeout|model[^\n]{0,120}not found|no authenticated providers|no models available|provider[^\n]{0,40}(unauth|unauthorized|auth(?:entication)?\s+failed)|missing\s+'?(?:action|query|command|name|pattern)'?(?:\s+parameter)?)/i;
 const SENSITIVE_RE = /\b(api[_ -]?key|token|password|secret)\b/i;
 
 let stage = "login";

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -1136,6 +1136,75 @@ EOF
         test_fail "Direct skill-detail fastpath must resolve the runtime skill, answer from SKILL.md, and leave only a same-turn delivery-suppression marker"
     fi
 
+    test_start "component_before_llm_guard_direct_fastpaths_live_codex_update_skill_detail_when_last_system_is_datetime"
+    local fastpath_skill_detail_live_tmp fastpath_skill_detail_live_send_script fastpath_skill_detail_live_log fastpath_skill_detail_live_stdout fastpath_skill_detail_live_stderr fastpath_skill_detail_live_status fastpath_skill_detail_live_intent_dir fastpath_skill_detail_live_suppress_file fastpath_skill_detail_live_runtime_root fastpath_skill_detail_live_fakebin
+    fastpath_skill_detail_live_tmp="$(secure_temp_dir telegram-safe-fastpath-skill-detail-live)"
+    fastpath_skill_detail_live_send_script="$fastpath_skill_detail_live_tmp/send.sh"
+    fastpath_skill_detail_live_log="$fastpath_skill_detail_live_tmp/send.log"
+    fastpath_skill_detail_live_intent_dir="$fastpath_skill_detail_live_tmp/intent"
+    fastpath_skill_detail_live_suppress_file="$fastpath_skill_detail_live_intent_dir/session_livecodexdetail.suppress"
+    fastpath_skill_detail_live_runtime_root="$fastpath_skill_detail_live_tmp/runtime-skills"
+    fastpath_skill_detail_live_fakebin="$fastpath_skill_detail_live_tmp/fakebin"
+    mkdir -p "$fastpath_skill_detail_live_runtime_root/codex-update" "$fastpath_skill_detail_live_fakebin"
+    cp "$PROJECT_ROOT/skills/codex-update/SKILL.md" "$fastpath_skill_detail_live_runtime_root/codex-update/SKILL.md"
+    cat >"$fastpath_skill_detail_live_fakebin/python3" <<'EOF'
+#!/usr/bin/env bash
+exit 127
+EOF
+    chmod +x "$fastpath_skill_detail_live_fakebin/python3"
+    cat >"$fastpath_skill_detail_live_send_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+chat_id=""
+text=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chat-id)
+            chat_id="${2:-}"
+            shift 2
+            ;;
+        --text)
+            text="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf 'chat_id=%s\ntext=%s\n' "$chat_id" "$text" >"$FASTPATH_LOG"
+printf '{"ok":true}\n'
+EOF
+    chmod +x "$fastpath_skill_detail_live_send_script"
+    fastpath_skill_detail_live_stdout="$fastpath_skill_detail_live_tmp/stdout.log"
+    fastpath_skill_detail_live_stderr="$fastpath_skill_detail_live_tmp/stderr.log"
+    set +e
+    env PATH="$fastpath_skill_detail_live_fakebin:$MINIMAL_PATH" \
+        FASTPATH_LOG="$fastpath_skill_detail_live_log" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+        MOLTIS_RUNTIME_SKILLS_ROOT="$fastpath_skill_detail_live_runtime_root" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$fastpath_skill_detail_live_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$fastpath_skill_detail_live_send_script" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
+        bash "$HOOK_HANDLER" >"$fastpath_skill_detail_live_stdout" 2>"$fastpath_skill_detail_live_stderr" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:livecodexdetail","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=4c3734b76ac1 | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"assistant","content":"Да. По сути уже разобрался: причина почти наверняка в том, что уведомление не дедуплицируется."},{"role":"system","content":"The current user datetime is 2026-04-23 18:09:48 MSK."},{"role":"user","content":"Открой навык codex-update и проверь, есть ли в нём дедупликация last_announced_version. Ничего не меняй, ответь кратко."}],"tool_count":55,"iteration":1}}
+EOF
+    fastpath_skill_detail_live_status=$?
+    set -e
+    if [[ "$fastpath_skill_detail_live_status" -eq 0 ]] && \
+       [[ ! -s "$fastpath_skill_detail_live_stdout" ]] && \
+       [[ ! -s "$fastpath_skill_detail_live_stderr" ]] && \
+       [[ -f "$fastpath_skill_detail_live_suppress_file" ]] && \
+       grep -Fq $'\tskill_detail:codex-update' "$fastpath_skill_detail_live_suppress_file" && \
+       grep -Fq 'chat_id=262872984' "$fastpath_skill_detail_live_log" && \
+       grep -Fq 'codex-update' "$fastpath_skill_detail_live_log" && \
+       grep -Fq 'новая стабильная версия Codex CLI' "$fastpath_skill_detail_live_log" && \
+       ! grep -Eq "read_skill|missing 'name'|Activity log|/home/moltis" "$fastpath_skill_detail_live_log"; then
+        test_pass
+    else
+        test_fail "Live-shaped codex-update skill-detail prompts must use direct text-only skill detail fastpath even when the latest system message is only datetime"
+    fi
+
     test_start "component_before_llm_guard_skill_detail_direct_fastpath_falls_back_to_modify_when_suppression_cannot_be_armed"
     local fastpath_skill_detail_armfail_tmp fastpath_skill_detail_armfail_send_script fastpath_skill_detail_armfail_log fastpath_skill_detail_armfail_stdout fastpath_skill_detail_armfail_stderr fastpath_skill_detail_armfail_status fastpath_skill_detail_armfail_intent_dir fastpath_skill_detail_armfail_runtime_root fastpath_skill_detail_armfail_fakebin fastpath_skill_detail_armfail_output
     fastpath_skill_detail_armfail_tmp="$(secure_temp_dir telegram-safe-fastpath-skill-detail-armfail)"

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -424,6 +424,40 @@ NODE
         test_fail "Unquoted missing command parameter replies must be rejected by reply-quality checks"
     fi
 
+    test_start "component_telegram_web_probe_marks_missing_name_parameter_as_error_signature"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
+const badReplies = [
+  "read_skill в этой сессии возвращает missing 'name' даже при корректном вызове",
+  "read_skill снова вернул missing name"
+];
+for (const badReply of badReplies) {
+  if (!isReplyErrorSignature(badReply)) {
+    throw new Error(`expected missing name parameter to be rejected: ${badReply}`);
+  }
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Missing name parameter replies must be rejected by reply-quality checks"
+    fi
+
+    test_start "component_telegram_web_probe_marks_missing_pattern_parameter_as_error_signature"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { isReplyErrorSignature } = await import(process.env.NODE_SCRIPT);
+if (!isReplyErrorSignature("Glob снова вернул missing 'pattern' parameter")) {
+  throw new Error("expected missing pattern parameter to be rejected");
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Missing pattern parameter replies must be rejected by reply-quality checks"
+    fi
+
     test_start "component_telegram_web_probe_rejects_emoji_prefixed_internal_telemetry_replies"
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";


### PR DESCRIPTION
## Summary
- route live-shaped Telegram skill detail prompts through direct text-only fastpath when runtime metadata is not in the latest system message
- make explicit skill-detail intent override codex-update advisory intent for the same turn
- harden Telegram Web probe quality checks for missing name/pattern tool errors

## Tests
- bash -n scripts/telegram-safe-llm-guard.sh
- bash -n tests/component/test_telegram_safe_llm_guard.sh
- git diff --check
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_web_probe_correlation.sh
- bash tests/static/test_config_validation.sh