### PR TITLE
fix: block BeforeLLMCall after Telegram direct fastpath

### DIFF
--- a/.moltis/hooks/telegram-safe-llm-guard/HOOK.md
+++ b/.moltis/hooks/telegram-safe-llm-guard/HOOK.md
@@ -20,6 +20,12 @@ telemetry-leaking behavior or filesystem-based skill false negatives.
 It also fail-closes skill/codex-update maintenance-debug turns (`почини`,
 `исправь`, `отладь`, logs/root-cause requests) into a deterministic text-only
 boundary instead of letting runtime tool chatter leak back into Telegram.
+For direct Bot API fastpaths, the owning delivery contract is:
+
+- send the user-visible reply directly through Bot API
+- block the subsequent `BeforeLLMCall` hook event instead of relying on
+  `modify` for typed message payloads
+- suppress the synthetic blocked tail in `MessageSending`
 
 Repository note:
 

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-23
-**Total Lessons**: 86
+**Total Lessons**: 87
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (42 lessons)
+#### P1 (43 lessons)
+- [Telegram direct fastpath had to block BeforeLLMCall instead of relying on modify](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [GitHub Actions bad logs from post-deploy image prune and calendar tag rejection](../docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md)
@@ -189,7 +190,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (6 lessons)
+#### product (7 lessons)
+- [Telegram direct fastpath had to block BeforeLLMCall instead of relying on modify](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
@@ -218,14 +220,14 @@
 
 - `rca` (33 lessons)
 - `moltis` (28 lessons)
-- `telegram` (22 lessons)
+- `telegram` (23 lessons)
 - `deploy` (20 lessons)
 - `github-actions` (18 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `skills` (13 lessons)
 - `beads` (12 lessons)
-- `hooks` (10 lessons)
+- `hooks` (11 lessons)
 
 
 ---
@@ -234,8 +236,8 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 86 |
-| Critical (P0/P1) | 43 |
+| Total Lessons | 87 |
+| Critical (P0/P1) | 44 |
 | Categories | 8 |
 | Unique Tags | 167 |
 

--- a/docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md
+++ b/docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md
@@ -1,0 +1,113 @@
+---
+title: "Telegram direct fastpath had to block BeforeLLMCall instead of relying on modify"
+date: 2026-04-23
+severity: P1
+category: product
+tags: [telegram, hooks, runtime, skill-detail, codex-update]
+root_cause: "After a successful Telegram direct fastpath send, the repo hook still tried to terminalize the turn with BeforeLLMCall modify payloads, but the live Moltis runtime explicitly ignored that path for typed messages; the reliable contract was to block the LLM pass and suppress the synthetic blocked tail."
+---
+
+# RCA: Telegram direct fastpath had to block BeforeLLMCall instead of relying on modify
+
+Date: 2026-04-23
+Status: Resolved in source, pending deploy/live re-verification
+Context: follow-up investigation for Telegram `skill_detail` / `codex-update` runtime leakage
+
+## Error
+
+User-facing Telegram turns still leaked fallback text like:
+
+- `Не могу проверить: read_skill в этой сессии сломан.`
+- repeated `missing 'command' / 'query' / 'action' parameter`
+
+even though the repo hook already:
+
+- generated the correct deterministic `skill_detail` answer,
+- sent it through the direct Bot API fastpath,
+- and returned a terminalizing `BeforeLLMCall` modify payload.
+
+The bug therefore survived after classifier and reply-text fixes.
+
+## Проверка прошлых уроков
+
+Checked first:
+
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag hooks`
+- `./scripts/query-lessons.sh --tag codex-update`
+- `docs/rca/2026-04-01-telegram-skill-visibility-and-create-hook-modify-bypass.md`
+- `docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md`
+
+Relevant prior lessons already covered two crucial facts:
+
+1. live Telegram routes cannot treat synthetic hook `modify` as production proof by itself;
+2. direct Bot API fastpaths remain the reliable repo-owned delivery contract for some Telegram turns.
+
+What was still missing:
+
+- the source contract after a successful direct fastpath still tried to end the turn via `BeforeLLMCall modify`;
+- we had not reduced that assumption to the stricter live-supported contract: `direct send -> block -> suppress blocked tail`.
+
+## Evidence
+
+Authoritative evidence gathered during the investigation:
+
+1. production hook capture for the failing `skill_detail` turn showed the correct direct fastpath reply text and `AfterLLMCall` suppression output;
+2. production Docker logs still showed the final bad reply delivered to chat;
+3. live binary strings from `/usr/local/bin/moltis` explicitly contained:
+   - `BeforeLLMCall ModifyPayload ignored (messages are typed)`
+   - `LLM call blocked by BeforeLLMCall hook`
+   - `hook blocked event`
+4. the direct send transport itself was healthy when invoked manually from both host and container.
+
+This ruled out:
+
+- stale deploy drift,
+- broken direct-send transport,
+- bad `skill_detail` text generation,
+- and classifier-only explanations.
+
+## 5 Whys
+
+| Level | Question | Answer | Evidence |
+|---|---|---|---|
+| 1 | Why did Telegram still show the bad fallback? | Because the runtime still executed the underlying LLM path after the direct fastpath answer. | production Telegram reply + `docker logs` |
+| 2 | Why was the underlying LLM path still alive? | Because the hook terminalized the turn with `BeforeLLMCall modify`, not with a hard block. | captured hook output |
+| 3 | Why was `modify` insufficient? | Because the live Moltis runtime explicitly ignores `BeforeLLMCall ModifyPayload` for typed messages. | binary string: `BeforeLLMCall ModifyPayload ignored (messages are typed)` |
+| 4 | Why did earlier tests not catch this root cause? | Because component tests only validated hook JSON shape, not the live runtime contract that consumes it. | green synthetic tests + red authoritative Telegram run |
+| 5 | Why did this become systemic? | Because the repo contract still encoded an outdated assumption: after direct send, `modify ""` was treated as terminal, even though the live runtime only guaranteed `block` for that boundary. | source design before fix + runtime evidence |
+
+## Root Cause
+
+The root cause was a delivery-contract mismatch in the repo-owned Telegram hook:
+
+- after a successful direct Bot API fastpath send, the hook still relied on `BeforeLLMCall modify` to silence the rest of the turn;
+- the live Moltis runtime did not honor that `modify` path for typed `BeforeLLMCall` payloads;
+- therefore the only reliable terminalization contract was to hard-block the LLM pass and let the existing `MessageSending` suppression hide the synthetic blocked tail.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - added explicit `emit_blocked_payload`;
+   - changed same-turn fastpath terminalization from `modify` to `block`;
+   - changed repeat direct-fastpath guard and codex terminal repeat guard from `modify` to `block`;
+   - changed direct `codex-update` fastpath terminalization from `modify` to `block`.
+2. `tests/component/test_telegram_safe_llm_guard.sh`
+   - updated direct-fastpath component expectations from `modify` payloads to `block`;
+   - kept suppression / late-tail rewrite assertions intact so the runtime tail contract stays covered end-to-end.
+3. `.moltis/hooks/telegram-safe-llm-guard/HOOK.md`
+   - documented the owning delivery contract as:
+     `direct send -> block BeforeLLMCall -> suppress blocked tail`.
+
+## Prevention
+
+1. For Telegram direct fastpaths, do not treat `modify` as terminal proof unless live runtime evidence shows it is applied.
+2. When the production binary exposes a stronger contract than synthetic tests, encode the stronger contract in source.
+3. Keep component tests focused on the real invariant:
+   the user-visible direct reply is sent once, the LLM pass is blocked, and all trailing blocked/runtime tails are suppressed.
+
+## Уроки
+
+1. In Moltis Telegram runtime, `hook generated the right JSON` is not the same thing as `runtime applied it`.
+2. For direct fastpaths, `block` is a delivery primitive, not just an error path.
+3. The reliable fix for Telegram leakage was architectural, not another layer of response filtering.

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -1787,15 +1787,13 @@ direct_fastpath_send_with_suppression() {
 emit_same_turn_fastpath_terminalization() {
     local token="${1:-}"
     local reason="${2:-direct_fastpath_terminalized}"
-    local same_turn_guard=""
-    local same_turn_user=""
-    local messages_json=""
 
-    same_turn_guard="$(build_same_turn_fastpath_guard_message)"
-    same_turn_user=$'Верни пустую строку. Не вызывай инструменты.'
-    messages_json="[$(build_message_json system "$same_turn_guard"),$(build_message_json user "$same_turn_user")]"
-    write_audit_line "before_modify reason=$reason token=${token:-none} iteration=${current_iteration:-missing}"
-    emit_before_llm_modified_payload "$messages_json" 0
+    # Live Moltis runtime reports that BeforeLLMCall modify payloads can be
+    # ignored because the message set is typed. After the user-visible reply is
+    # already delivered through the direct Bot API fastpath, the reliable
+    # contract is to block the LLM pass and suppress the synthetic blocked tail.
+    write_audit_line "before_block reason=$reason token=${token:-none} iteration=${current_iteration:-missing}"
+    emit_blocked_payload
 }
 
 persist_turn_intent() {
@@ -2213,26 +2211,6 @@ build_skill_maintenance_hard_override_message() {
 build_skill_detail_hard_override_message() {
     local reply_text="$1"
     build_text_only_hard_override_message "Telegram-safe skill-detail hard override" "$reply_text"
-}
-
-build_same_turn_fastpath_guard_message() {
-    cat <<'EOF'
-Telegram-safe same-turn fastpath guard:
-- A Telegram-safe direct fastpath already delivered the user-visible reply for this turn.
-- This repeated BeforeLLMCall entry is internal runtime churn, not a new user turn.
-- Do not call tools.
-- Return exactly an empty string and nothing else.
-EOF
-}
-
-build_codex_update_terminal_guard_message() {
-    cat <<'EOF'
-Telegram-safe codex-update terminal guard:
-- A deterministic codex-update reply has already been selected for this turn.
-- The runtime entered another internal pass only because a blocked tool follow-up was attempted after the hard override.
-- Do not call tools.
-- Return exactly an empty string and nothing else.
-EOF
 }
 
 read_codex_update_state_json() {
@@ -3742,6 +3720,10 @@ emit_before_llm_modified_payload() {
         "$(printf ',\"messages\":%s' "$messages_json")"
 }
 
+emit_blocked_payload() {
+    printf '{"action":"block"}\n'
+}
+
 log_guard_diagnostic() {
     local event_name="$1"
     local preview_source="$2"
@@ -4343,20 +4325,14 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     esac
 
     if [[ -n "$effective_delivery_suppression" && "$has_current_user_turn" == true && "$current_iteration" =~ ^[0-9]+$ ]] && (( current_iteration > 1 )); then
-        same_turn_guard="$(build_same_turn_fastpath_guard_message)"
-        same_turn_user=$'Верни пустую строку. Не вызывай инструменты.'
-        messages_json="[$(build_message_json system "$same_turn_guard"),$(build_message_json user "$same_turn_user")]"
-        write_audit_line "before_modify reason=direct_fastpath_repeat_guard token=$effective_delivery_suppression iteration=$current_iteration"
-        emit_before_llm_modified_payload "$messages_json" 0
+        write_audit_line "before_block reason=direct_fastpath_repeat_guard token=$effective_delivery_suppression iteration=$current_iteration"
+        emit_blocked_payload
         exit 0
     fi
 
     if [[ "$codex_update_terminal_repeat_guard" == true || ( -n "$persisted_terminal_marker" && ( "$persisted_codex_update_request" == true || "$current_turn_codex_update_request" == true || "$loaded_persisted_codex_update_request" == true ) ) ]]; then
-        same_turn_guard="$(build_codex_update_terminal_guard_message)"
-        same_turn_user=$'Верни пустую строку. Не вызывай инструменты.'
-        messages_json="[$(build_message_json system "$same_turn_guard"),$(build_message_json user "$same_turn_user")]"
-        write_audit_line "before_modify reason=codex_update_terminal_repeat_guard token=$persisted_terminal_marker iteration=$current_iteration"
-        emit_before_llm_modified_payload "$messages_json" 0
+        write_audit_line "before_block reason=codex_update_terminal_repeat_guard token=$persisted_terminal_marker iteration=$current_iteration"
+        emit_blocked_payload
         exit 0
     fi
 
@@ -4407,11 +4383,8 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
                     write_audit_line "codex_update_direct_fastpath_terminal_marker_fallback token=$codex_update_reply_mode"
                 fi
                 write_audit_line "codex_update_direct_fastpath_fallback_state_preserved mode=$codex_update_reply_mode"
-                same_turn_guard="$(build_codex_update_terminal_guard_message)"
-                same_turn_user=$'Верни пустую строку. Не вызывай инструменты.'
-                messages_json="[$(build_message_json system "$same_turn_guard"),$(build_message_json user "$same_turn_user")]"
-                write_audit_line "before_modify reason=codex_update_direct_fastpath_terminalized token=$codex_update_reply_mode iteration=$current_iteration"
-                emit_before_llm_modified_payload "$messages_json" 0
+                write_audit_line "before_block reason=codex_update_direct_fastpath_terminalized token=$codex_update_reply_mode iteration=$current_iteration"
+                emit_blocked_payload
                 exit 0
             fi
         fi

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -296,10 +296,7 @@ EOF
     set -e
     if [[ "$fastpath_status_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_status_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_status_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_status_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_status_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_status_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_status_stdout" && \
        [[ -f "$fastpath_status_suppress_file" ]] && \
        grep -Fq $'\tstatus' "$fastpath_status_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_status_log" && \
@@ -307,7 +304,7 @@ EOF
        grep -Fq 'openai-codex::gpt-5.4' "$fastpath_status_log"; then
         test_pass
     else
-        test_fail "Direct /status fastpath must stay handler-safe: send canonical text, return rc=0, and leave only a delivery-suppression marker instead of triggering hook-block"
+        test_fail "Direct /status fastpath must stay handler-safe: send canonical text, return rc=0, leave only a delivery-suppression marker, and hard-block the ignored runtime LLM pass"
     fi
 
     test_start "component_before_llm_guard_direct_fastpaths_codex_update_when_enabled"
@@ -359,10 +356,7 @@ EOF
     set -e
     if [[ "$fastpath_codex_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_codex_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_codex_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_codex_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 "$fastpath_codex_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_codex_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_codex_stdout" && \
        [[ -f "$fastpath_codex_session_suppress_file" ]] && \
        [[ -f "$fastpath_codex_chat_suppress_file" ]] && \
        grep -Fq $'\tcodex_update:scheduler' "$fastpath_codex_session_suppress_file" && \
@@ -426,10 +420,7 @@ EOF
     set -e
     if [[ "$array_codex_status" -eq 0 ]] && \
        [[ ! -s "$array_codex_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$array_codex_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$array_codex_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 "$array_codex_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$array_codex_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$array_codex_stdout" && \
        [[ -f "$array_codex_session_suppress_file" ]] && \
        [[ -f "$array_codex_chat_suppress_file" ]] && \
        grep -Fq $'\tcodex_update:scheduler' "$array_codex_session_suppress_file" && \
@@ -537,10 +528,7 @@ EOF
     )"
     if [[ "$fastpath_codex_recovery_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_codex_recovery_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_codex_recovery_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_codex_recovery_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 "$fastpath_codex_recovery_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_codex_recovery_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_codex_recovery_stdout" && \
        [[ "$fastpath_codex_recovery_intent_present_after_fastpath" == true ]] && \
        [[ "$fastpath_codex_recovery_terminal_present_after_fastpath" == true ]] && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$fastpath_codex_recovery_after_output" && \
@@ -609,10 +597,7 @@ EOF
     set -e
     if [[ "$mixed_status_codex_status" -eq 0 ]] && \
        [[ ! -s "$mixed_status_codex_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$mixed_status_codex_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$mixed_status_codex_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$mixed_status_codex_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$mixed_status_codex_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$mixed_status_codex_stdout" && \
        [[ -f "$mixed_status_codex_session_suppress" ]] && \
        [[ -f "$mixed_status_codex_chat_suppress" ]] && \
        grep -Fq $'\tstatus' "$mixed_status_codex_session_suppress" && \
@@ -702,15 +687,10 @@ EOF
     )"
     if [[ "$codex_direct_tail_status" -eq 0 ]] && \
        [[ ! -s "$codex_direct_tail_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$codex_direct_tail_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$codex_direct_tail_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 "$codex_direct_tail_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$codex_direct_tail_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$codex_direct_tail_stdout" && \
        [[ -f "$codex_direct_tail_session_suppress" ]] && \
        [[ -f "$codex_direct_tail_chat_suppress" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 <<<"$codex_direct_tail_repeat_before_output" && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_direct_tail_tool_output" && \
        jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$codex_direct_tail_tool_output" && \
        jq -e '.data.arguments.command | contains("direct fastpath already handled this reply")' >/dev/null 2>&1 <<<"$codex_direct_tail_tool_output" && \
@@ -840,9 +820,7 @@ EOF
        jq -e '.data.arguments.command | contains("codex-update turn already resolved by the hard override")' >/dev/null 2>&1 <<<"$codex_terminal_tool_output" && \
        [[ "$codex_terminal_marker_present_after_tool" == true ]] && \
        [[ "$codex_terminal_suppress_absent_after_tool" == true ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 <<<"$codex_terminal_repeat_before_output" && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_after_output" && \
        jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$codex_terminal_after_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$codex_terminal_after_output" && \
@@ -959,9 +937,9 @@ EOF
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_before_output" && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_tool_output" && \
        jq -e '.data.tool == "exec"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_tool_output" && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_repeat_before_output" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_repeat_before_output" && \
        [[ ! -s "$codex_terminal_marker_fail_stderr_log" ]] && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update terminal guard")' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_repeat_before_output"; then
+       jq -e '.data | not' >/dev/null 2>&1 <<<"$codex_terminal_marker_fail_repeat_before_output"; then
         test_pass
     else
         test_fail "Codex-update repeat guard must still terminalize the blocked follow-up even when the .terminal marker itself cannot be written, and it must stay silent on stderr"
@@ -1020,17 +998,14 @@ EOF
     set -e
     if [[ "$fastpath_visibility_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_visibility_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_visibility_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_visibility_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_visibility_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_visibility_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_visibility_stdout" && \
        [[ -f "$fastpath_visibility_suppress_file" ]] && \
        grep -Fq $'\tskill_visibility' "$fastpath_visibility_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_visibility_log" && \
        grep -Fq 'text=Навыки (3): codex-update, post-close-task-classifier, telegram-learner.' "$fastpath_visibility_log"; then
         test_pass
     else
-        test_fail "Direct skill-visibility fastpath must stay handler-safe: send the deterministic runtime list, return rc=0, and store only a delivery-suppression marker"
+        test_fail "Direct skill-visibility fastpath must stay handler-safe: send the deterministic runtime list, return rc=0, store only a delivery-suppression marker, and hard-block the ignored runtime LLM pass"
     fi
 
     test_start "component_before_llm_guard_direct_fastpaths_skill_template_via_bot_send_when_enabled"
@@ -1063,17 +1038,14 @@ EOF
     set -e
     if [[ "$fastpath_template_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_template_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_template_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_template_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_template_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_template_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_template_stdout" && \
        [[ -f "$fastpath_template_suppress_file" ]] && \
        grep -Fq $'\tskill_template' "$fastpath_template_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_template_log" && \
        grep -Fq 'text=Канонический минимальный шаблон навыка:' "$fastpath_template_log"; then
         test_pass
     else
-        test_fail "Direct skill-template fastpath must stay handler-safe: send the canonical scaffold, return rc=0, and leave only a delivery-suppression marker"
+        test_fail "Direct skill-template fastpath must stay handler-safe: send the canonical scaffold, return rc=0, leave only a delivery-suppression marker, and hard-block the ignored runtime LLM pass"
     fi
 
     test_start "component_before_llm_guard_direct_fastpaths_skill_detail_via_bot_send_when_enabled"
@@ -1133,10 +1105,7 @@ EOF
     set -e
     if [[ "$fastpath_skill_detail_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_skill_detail_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_skill_detail_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_skill_detail_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_skill_detail_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_skill_detail_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_skill_detail_stdout" && \
        [[ -f "$fastpath_skill_detail_suppress_file" ]] && \
        grep -Fq $'\tskill_detail:telegram-learner' "$fastpath_skill_detail_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_skill_detail_log" && \
@@ -1208,10 +1177,7 @@ EOF
     set -e
     if [[ "$fastpath_skill_detail_live_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_skill_detail_live_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_skill_detail_live_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_skill_detail_live_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_skill_detail_live_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_skill_detail_live_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_skill_detail_live_stdout" && \
        [[ -f "$fastpath_skill_detail_live_suppress_file" ]] && \
        grep -Fq $'\tskill_detail:codex-update' "$fastpath_skill_detail_live_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_skill_detail_live_log" && \
@@ -1334,10 +1300,7 @@ EOF
     set -e
     if [[ "$fastpath_skill_detail_history_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_skill_detail_history_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_skill_detail_history_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_skill_detail_history_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_skill_detail_history_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_skill_detail_history_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_skill_detail_history_stdout" && \
        [[ -f "$fastpath_skill_detail_history_suppress_file" ]] && \
        grep -Fq $'\tskill_detail:telegram-learner' "$fastpath_skill_detail_history_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_skill_detail_history_log" && \
@@ -1412,10 +1375,7 @@ EOF
     set -e
     if [[ "$fastpath_skill_detail_nolang_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_skill_detail_nolang_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_skill_detail_nolang_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_skill_detail_nolang_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_skill_detail_nolang_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_skill_detail_nolang_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_skill_detail_nolang_stdout" && \
        [[ -f "$fastpath_skill_detail_nolang_suppress_file" ]] && \
        grep -Fq $'\tskill_detail:telegram-learner' "$fastpath_skill_detail_nolang_suppress_file" && \
        grep -Fq 'chat_id=262872984' "$fastpath_skill_detail_nolang_log" && \
@@ -1463,15 +1423,13 @@ EOF
     set -e
     if [[ "$repeat_fastpath_status" -eq 0 ]] && \
        [[ ! -s "$repeat_fastpath_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 <"$repeat_fastpath_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <"$repeat_fastpath_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 <"$repeat_fastpath_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 <"$repeat_fastpath_stdout" && \
        [[ -f "$repeat_fastpath_session_marker" ]] && \
        [[ -f "$repeat_fastpath_chat_marker" ]] && \
        [[ ! -e "$repeat_fastpath_log" ]]; then
         test_pass
     else
-        test_fail "BeforeLLMCall guard must treat iteration>1 with an active direct-fastpath marker as same-turn runtime churn: keep suppression, avoid a duplicate direct-send, and return a no-op text-only override"
+        test_fail "BeforeLLMCall guard must treat iteration>1 with an active direct-fastpath marker as same-turn runtime churn: keep suppression, avoid a duplicate direct-send, and hard-block the repeated LLM pass"
     fi
 
     test_start "component_before_llm_guard_does_not_direct_fastpath_sparse_skill_create_anymore"
@@ -3539,17 +3497,14 @@ EOF
     set -e
     if [[ "$fastpath_maintenance_status" -eq 0 ]] && \
        [[ ! -s "$fastpath_maintenance_stderr" ]] && \
-       jq -e '.action == "modify"' >/dev/null 2>&1 "$fastpath_maintenance_stdout" && \
-       jq -e '.data.tool_count == 0' >/dev/null 2>&1 "$fastpath_maintenance_stdout" && \
-       jq -e '.data.messages[0].content | contains("Telegram-safe same-turn fastpath guard")' >/dev/null 2>&1 "$fastpath_maintenance_stdout" && \
-       jq -e '.data.messages[1].content == "Верни пустую строку. Не вызывай инструменты."' >/dev/null 2>&1 "$fastpath_maintenance_stdout" && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$fastpath_maintenance_stdout" && \
        [[ -f "$fastpath_maintenance_suppress_file" ]] && \
        grep -Fq $'\tmaintenance:codex_update' "$fastpath_maintenance_suppress_file" && \
        grep -Fq 'chat_id=262872999' "$fastpath_maintenance_log" && \
        grep -Fq 'text=В Telegram-safe режиме я не чиню и не отлаживаю `codex-update`' "$fastpath_maintenance_log"; then
         test_pass
     else
-        test_fail "Direct maintenance fastpath must send the deterministic codex-update boundary reply and store only a delivery-suppression marker"
+        test_fail "Direct maintenance fastpath must send the deterministic codex-update boundary reply, store only a delivery-suppression marker, and hard-block the ignored runtime LLM pass"
     fi
 
     test_start "component_message_sending_guard_rewrites_codex_update_maintenance_leak_into_boundary_reply"


### PR DESCRIPTION
## Summary
- switch Telegram direct fastpath terminalization from BeforeLLMCall modify to hook block
- keep same-turn suppression and late-tail rewrites intact for codex-update, skill-detail, status, template, visibility, and maintenance routes
- document the new runtime contract and add RCA plus lessons index update

## Why
Live Moltis runtime evidence showed that BeforeLLMCall modify payloads can be ignored for typed messages, so direct fastpaths could still leak late fallback replies even when the hook generated the correct modify payload.

## Testing
- bash -n scripts/telegram-safe-llm-guard.sh
- bash -n tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_safe_llm_guard.sh