### PR TITLE
chore: bump tracked Moltis runtime to 20260423.01

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
   # MOLTIS - Main Application
   # ========================================================================
   moltis:
-    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260421.05}
+    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260423.01}
     container_name: moltis
     restart: unless-stopped
     stop_grace_period: 45s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ x-logging: &logging
 # ============================================================================
 services:
   moltis:
-    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260421.05}
+    image: ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260423.01}
     container_name: moltis
     restart: unless-stopped
     stop_grace_period: 45s

--- a/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
+++ b/docs/knowledge/LLM-REMOTE-MOLTIS-DOCKER-RUNBOOK.md
@@ -124,7 +124,7 @@ Additional invariant:
 Do not skip this.
 
 ```bash
-docker pull ghcr.io/moltis-org/moltis:20260421.05
+docker pull ghcr.io/moltis-org/moltis:20260423.01
 ```
 
 If the feature targets another version, replace the tag, but still pull it explicitly.
@@ -138,7 +138,7 @@ First stop it with an extended grace window, then remove it, then create the new
 cd /opt/moltinger-active
 docker stop --time 45 moltis || true
 docker rm -f moltis || true
-MOLTIS_VERSION=20260421.05 docker compose -p moltinger -f docker-compose.prod.yml up -d --no-deps moltis
+MOLTIS_VERSION=20260423.01 docker compose -p moltinger -f docker-compose.prod.yml up -d --no-deps moltis
 ```
 
 Then verify immediately:
@@ -151,8 +151,8 @@ docker inspect -f '{{.State.Health.Status}}' moltis
 
 Expected:
 
-- image shows `ghcr.io/moltis-org/moltis:20260421.05`
-- binary shows `moltis 20260421.05`
+- image shows `ghcr.io/moltis-org/moltis:20260423.01`
+- binary shows `moltis 20260423.01`
 - health becomes `healthy`
 
 ## 7. Verify OAuth persistence before trying re-auth

--- a/docs/runbooks/moltis-backup-safe-update.md
+++ b/docs/runbooks/moltis-backup-safe-update.md
@@ -31,7 +31,7 @@ Operational policy in this repository:
 - Do not replay production deploy steps manually from a feature branch after workflow branch guards block promotion.
 - Use `.github/workflows/feature-diagnostics.yml` for read-only branch evidence, then promote to `main` before production rollout.
 - Do not pin a GitHub release tag unless the matching GHCR container tag is actually published.
-- Do not keep a leading `v` in tracked GHCR tags (use `20260421.05`, not `v20260421.05`).
+- Do not keep a leading `v` in tracked GHCR tags (use `20260423.01`, not `v20260423.01`).
 - Do not pull or restart a new Moltis image without a fresh pre-update backup.
 - Do not continue rollout if restore-check fails for that fresh backup.
 - Do not treat "previous image exists" as sufficient rollback evidence by itself.

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -30,7 +30,7 @@ make version-check
 Production Moltis updates are git-based and backup-safe only.
 
 The tracked version must point to a published GHCR container tag, not only to a GitHub release tag.
-Use GHCR tag format without a leading `v` (for example `20260421.05`, not `v20260421.05`).
+Use GHCR tag format without a leading `v` (for example `20260423.01`, not `v20260423.01`).
 
 Allowed:
 

--- a/scripts/moltis-version.sh
+++ b/scripts/moltis-version.sh
@@ -157,7 +157,7 @@ assert_explicit_release_tag() {
     fi
 
     if [[ "$version" == v* ]]; then
-        echo "Tracked Moltis version must use GHCR tag format without leading 'v' (example: 20260421.05)" >&2
+        echo "Tracked Moltis version must use GHCR tag format without leading 'v' (example: 20260423.01)" >&2
         return 1
     fi
 

--- a/tests/component/test_moltis_version_helper.sh
+++ b/tests/component/test_moltis_version_helper.sh
@@ -53,14 +53,14 @@ run_component_moltis_version_helper_tests() {
     local tagged_main tagged_prod tagged_version tagged_image
     tagged_main="${project_dir}/docker-compose.yml"
     tagged_prod="${project_dir}/docker-compose.prod.yml"
-    write_compose_fixture "$tagged_main" 'ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260421.05}'
-    write_compose_fixture "$tagged_prod" 'ghcr.io/moltis-org/moltis:20260421.05'
+    write_compose_fixture "$tagged_main" 'ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-20260423.01}'
+    write_compose_fixture "$tagged_prod" 'ghcr.io/moltis-org/moltis:20260423.01'
 
     tagged_version="$("$helper_copy" version)"
     tagged_image="$("$helper_copy" image)"
 
-    if [[ "$tagged_version" == "20260421.05" ]] && \
-       [[ "$tagged_image" == "ghcr.io/moltis-org/moltis:20260421.05" ]] && \
+    if [[ "$tagged_version" == "20260423.01" ]] && \
+       [[ "$tagged_image" == "ghcr.io/moltis-org/moltis:20260423.01" ]] && \
        "$helper_copy" assert-tracked >/dev/null 2>&1; then
         test_pass
     else
@@ -71,14 +71,14 @@ run_component_moltis_version_helper_tests() {
     local quoted_main quoted_prod quoted_version quoted_image
     quoted_main="${project_dir}/docker-compose.yml"
     quoted_prod="${project_dir}/docker-compose.prod.yml"
-    write_compose_fixture "$quoted_main" '"ghcr.io/moltis-org/moltis:${MOLTIS_VERSION-20260421.05}" # pinned via default'
-    write_compose_fixture "$quoted_prod" "'ghcr.io/moltis-org/moltis:20260421.05' # explicit prod image"
+    write_compose_fixture "$quoted_main" '"ghcr.io/moltis-org/moltis:${MOLTIS_VERSION-20260423.01}" # pinned via default'
+    write_compose_fixture "$quoted_prod" "'ghcr.io/moltis-org/moltis:20260423.01' # explicit prod image"
 
     quoted_version="$("$helper_copy" version)"
     quoted_image="$("$helper_copy" image)"
 
-    if [[ "$quoted_version" == "20260421.05" ]] && \
-       [[ "$quoted_image" == "ghcr.io/moltis-org/moltis:20260421.05" ]]; then
+    if [[ "$quoted_version" == "20260423.01" ]] && \
+       [[ "$quoted_image" == "ghcr.io/moltis-org/moltis:20260423.01" ]]; then
         test_pass
     else
         test_fail "Helper should normalize quoted compose image lines, comments, and ${MOLTIS_VERSION-...} defaults"
@@ -95,7 +95,7 @@ run_component_moltis_version_helper_tests() {
 
     test_start "component_moltis_version_helper_compares_calendar_release_tags"
     local compare_result
-    compare_result="$("$helper_copy" compare '20260421.04' '20260421.05')"
+    compare_result="$("$helper_copy" compare '20260421.05' '20260423.01')"
     if [[ "$compare_result" == "-1" ]]; then
         test_pass
     else
@@ -140,7 +140,7 @@ run_component_moltis_version_helper_tests() {
     mismatch_main="${project_dir}/docker-compose.yml"
     mismatch_prod="${project_dir}/docker-compose.prod.yml"
     write_compose_fixture "$mismatch_main" 'ghcr.io/moltis-org/moltis:${MOLTIS_VERSION:-latest}'
-    write_compose_fixture "$mismatch_prod" 'ghcr.io/moltis-org/moltis:20260421.05'
+    write_compose_fixture "$mismatch_prod" 'ghcr.io/moltis-org/moltis:20260423.01'
 
     if "$helper_copy" version >/dev/null 2>&1; then
         test_fail "Helper must fail when dev/prod compose contracts disagree"


### PR DESCRIPTION
## Summary
- bump tracked Moltis image from `20260421.05` to official latest `20260423.01`
- sync version-helper fixtures and operator docs to the new tracked GHCR tag
- keep this PR narrowly scoped so post-deploy Telegram UAT can isolate runtime/image impact

## Why
Production Telegram UAT is still failing after PR #208 even though the repo-owned hook now reaches the boundary (`BeforeLLMCall -> {"action":"block"}`). Production is still pinned to `ghcr.io/moltis-org/moltis:20260421.05`, while the official latest Moltis release is `20260423.01`.

Official upstream evidence:
- release: https://github.com/moltis-org/moltis/releases/tag/20260423.01
- compare: https://github.com/moltis-org/moltis/compare/20260421.05...20260423.01
- relevant upstream fix in that window: `ef94841` `fix(skills): repair embedded bundled skill discovery in release builds`

This PR is the next repo-owned discriminating step before concluding the remaining failure is an upstream/runtime hook-contract gap.

## Validation
- `bash tests/component/test_moltis_version_helper.sh`
- `bash tests/static/test_config_validation.sh`
- `bash tests/component/test_telegram_remote_uat_contract.sh`
- `bash tests/component/test_telegram_web_probe_correlation.sh`
- `bash tests/component/test_telegram_safe_llm_guard.sh`

## Follow-up after merge
- deploy `main`
- verify live runtime image attestation is exactly `ghcr.io/moltis-org/moltis:20260423.01`
- rerun authoritative Telegram Web UAT on the failing prompts
- only then decide whether the remaining issue is closed, needs another repo fix, or must be escalated upstream
