### PR TITLE
fix: preserve multiline /status text in Telegram Web probe

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -14,9 +14,9 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (43 lessons)
-- [Telegram shell-hook block contract and MessageSending assumptions were false](../docs/rca/2026-04-23-telegram-shell-hook-block-contract-and-message-sending-assumptions-were-false.md)
-- [Telegram direct fastpath had to block BeforeLLMCall instead of relying on modify](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
+#### P1 (44 lessons)
+- [Telegram Web probe collapsed multiline /status replies before exact semantic review](../docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md)
+- [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [GitHub Actions bad logs from post-deploy image prune and calendar tag rejection](../docs/rca/2026-04-20-github-actions-bad-logs-from-post-deploy-image-prune-and-calendar-tag-rejection.md)
@@ -161,7 +161,8 @@
 - [2026-03-03-rca-comprehensive-test](../docs/rca/2026-03-03-rca-comprehensive-test.md)
 - [2026-03-03-git-branch-confusion](../docs/rca/2026-03-03-git-branch-confusion.md)
 
-#### process (28 lessons)
+#### process (29 lessons)
+- [Telegram Web probe collapsed multiline /status replies before exact semantic review](../docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md)
 - [Worktree Phase A returned before local Beads runtime was ready and plain bd worktree list still depended on cwd](../docs/rca/2026-04-15-worktree-phase-a-readiness-and-canonical-worktree-list-routing.md)
 - [Worktree governance left raw create and cleanup reconciliation gaps](../docs/rca/2026-04-15-worktree-governance-left-raw-create-and-cleanup-reconciliation-gaps.md)
 - [Worktree governance helpers trusted contextual Beads state instead of canonical ownership/runtime evidence](../docs/rca/2026-04-15-worktree-governance-helpers-trusted-contextual-beads-state.md)
@@ -192,7 +193,7 @@
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
 #### product (7 lessons)
-- [Telegram direct fastpath had to block BeforeLLMCall instead of relying on modify](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
+- [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
 - [Telegram codex-update live runtime ignored in-band hook modify despite correct guard output](../docs/rca/2026-04-14-telegram-codex-update-live-runtime-ignored-inband-modify.md)
@@ -219,9 +220,9 @@
 
 ### Popular Tags
 
-- `rca` (33 lessons)
+- `rca` (34 lessons)
 - `moltis` (28 lessons)
-- `telegram` (23 lessons)
+- `telegram` (24 lessons)
 - `deploy` (20 lessons)
 - `github-actions` (18 lessons)
 - `gitops` (16 lessons)
@@ -237,10 +238,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 87 |
-| Critical (P0/P1) | 44 |
+| Total Lessons | 88 |
+| Critical (P0/P1) | 45 |
 | Categories | 8 |
-| Unique Tags | 167 |
+| Unique Tags | 171 |
 
 ---
 

--- a/docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md
+++ b/docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md
@@ -1,0 +1,103 @@
+---
+title: "Telegram Web probe collapsed multiline /status replies before exact semantic review"
+date: 2026-04-23
+severity: P1
+category: process
+tags: [telegram, uat, telegram-web, probe, status, safe-text, multiline, rca]
+root_cause: "The authoritative Telegram Web probe normalized all whitespace in captured bubble text, so multiline user-visible replies were flattened into one line before remote UAT compared them against the exact five-line /status contract."
+---
+
+# RCA: Telegram Web probe collapsed multiline /status replies before exact semantic review
+
+**Дата:** 2026-04-23
+**Статус:** Resolved
+**Влияние:** post-deploy authoritative Telegram `/status` UAT ложно падал с `semantic_status_mismatch`, хотя live reply был атрибутируемым и содержательно корректным
+**Контекст:** follow-up после merge/deploy Telegram ingress terminalization fix; live smoke для `/status` стал единственным remaining blocker перед cleanup
+
+## Ошибка
+
+После успешных merge и deploy authoritative Telegram Web UAT для `/status` вернул:
+
+- observed reply: `Статус: Online Канал: Telegram (@moltinger_bot) Модель: openai-codex::gpt-5.4 Провайдер: openai-codex Режим: safe-text`
+- expected reply: exact five-line safe-text contract with embedded `\n`
+
+Симптом выглядел как runtime formatting drift, но локальный анализ показал, что exact mismatch возникал уже внутри repo-owned authoritative probe pipeline.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+- `docs/LESSONS-LEARNED.md`
+- `docs/rules/moltis-user-facing-telegram-browser-heavy-paths-must-degrade-gracefully.md`
+- `docs/rca/2026-03-28-moltis-operator-browser-session-isolation-and-telegram-send-attribution-drift.md`
+- `docs/rca/2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run.md`
+
+**Релевантные прошлые RCA/уроки:**
+1. `2026-03-28-moltis-operator-browser-session-isolation-and-telegram-send-attribution-drift` — authoritative Telegram Web layer already owned attribution and reply-shape correctness, so new drift had to be diagnosed there first.
+2. `2026-04-14-telegram-codex-update-direct-fastpath-raced-underlying-run` — user-facing Telegram verdicts must be validated against the actual terminal reply contract, not just against a superficially clean intermediate artifact.
+
+**Что могло быть упущено без этой сверки:**
+- можно было бы ошибочно чинить live runtime send path, хотя повреждение происходило в UAT probe;
+- можно было бы снова “лечить” deploy/session state вместо repo-owned verification layer.
+
+**Что в текущем инциденте действительно новое:**
+- this failure was not about attribution timing or second replies; it was a data-shape bug where the probe destroyed multiline formatting before exact semantic comparison.
+
+## Анализ 5 Почему (with Evidence)
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему live `/status` UAT упал с `semantic_status_mismatch`? | Потому что observed reply оказался одной строкой с пробелами вместо exact five-line reply. | Artifact `telegram-e2e-result.json` from authoritative run `24856960937` |
+| 2 | Почему observed reply стал одной строкой? | Потому что probe normalised captured bubble text through whitespace collapse before exposing `reply_text`. | `scripts/telegram-web-user-probe.mjs`, `normalizeMessageText()` and `collectMessages()` |
+| 3 | Почему exact semantic review не отличил raw user-visible text от normalized correlation text? | Потому что `reply_text` reused the same normalized field that correlation helpers use for matching/interim detection. | `scripts/telegram-web-user-probe.mjs: normalizeProbeMessage(), successPayload()` |
+| 4 | Почему это не было поймано раньше тестами? | Потому что probe tests covered correlation and stability behavior, but did not assert preservation of raw multiline reply text for exact downstream contracts. | `tests/component/test_telegram_web_probe_correlation.sh` before fix |
+| 5 | Почему это важно системно? | Потому что authoritative UAT is the repo-owned decision boundary before merge/cleanup; if it mutates user-visible text, operator decisions become false-negative. | `scripts/telegram-e2e-on-demand.sh` exact `/status` compare + cleanup gate usage in workflow |
+
+## Корневая причина
+
+Repo-owned authoritative Telegram Web probe смешал два разных представления текста в одно поле:
+
+- normalized correlation text for matching, filtering, and heuristics;
+- raw user-visible reply text for exact semantic contracts.
+
+Из-за этого probe сам разрушал newline-sensitive `/status` contract before remote UAT wrapper compared it to the canonical five-line safe-text reply.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| □ Actionable? | yes | Fix lives in repo-owned probe/wrapper tests |
+| □ Systemic? | yes | Any exact multiline Telegram contract could false-fail the same way |
+| □ Preventable? | yes | Preserve raw text separately and add regression tests |
+
+## Принятые меры
+
+1. **Немедленное исправление:** `scripts/telegram-web-user-probe.mjs` now preserves multiline `raw_text` for message bubbles and emits raw `reply_text`, while normalized text remains internal to correlation/heuristics.
+2. **Предотвращение:** added regression coverage proving raw multiline `/status` survives probe normalization boundaries.
+3. **Документация:** this RCA was added and `docs/LESSONS-LEARNED.md` was regenerated.
+
+## Связанные обновления
+
+- [ ] Новый файл правила создан (docs/rules/ или .claude/skills/)
+- [ ] Краткая ссылка добавлена в CLAUDE.md (1-2 строки)
+- [ ] Новые навыки созданы
+- [x] Тесты добавлены
+- [ ] Чеклисты обновлены
+
+## Уроки
+
+1. Authoritative probes must preserve raw user-visible payloads separately from normalized matcher text.
+2. If a downstream contract is exact and multiline-sensitive, the probe layer must never collapse whitespace before emitting the comparable field.
+3. Telegram UAT regressions should be tested not only for attribution and leak filtering, but also for fidelity of the user-visible reply shape.
+
+## Regression Test (Optional - for code errors only)
+
+**Test File:** `tests/component/test_telegram_web_probe_correlation.sh`
+
+**Test Status:**
+- [x] Test created
+- [x] Fix applied
+- [x] Test passes
+
+---
+
+*Создано по протоколу RCA-5-Whys.*

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -62,12 +62,20 @@ let retriesUsed = 0;
 let chatOpenVerified = false;
 let lastChatOpenCheck = null;
 
-function normalizeMessageText(value) {
+function preserveMessageText(value) {
   return String(value || "")
+    .replace(/\r\n?/g, "\n")
     .replace(/[\u200e\u200f]/g, " ")
     .replace(/[\uE000-\uF8FF]/g, " ")
-    .replace(/\s+/g, " ")
-    .replace(/(?:\s+\d{1,2}:\d{2}(?:\s*(?:AM|PM))?)+$/gi, "")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/(?:\n?\s*\d{1,2}:\d{2}(?:\s*(?:AM|PM))?)+$/gi, "")
+    .trim();
+}
+
+function normalizeMessageText(value) {
+  return preserveMessageText(value)
+    .replace(/\n+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -111,10 +119,12 @@ function safeMid(value) {
 }
 
 function normalizeProbeMessage(message) {
+  const rawText = preserveMessageText(message?.raw_text ?? message?.text);
   return {
     mid: safeMid(message?.mid),
     direction: String(message?.direction || "unknown"),
-    text: normalizeMessageText(message?.text),
+    raw_text: rawText,
+    text: normalizeMessageText(rawText),
   };
 }
 
@@ -490,7 +500,7 @@ function successPayload({ targetValue, sentText, sentMessage, replyMessage, corr
     target: targetValue,
     sent_text: sentText,
     sent_mid: sentMessage.mid,
-    reply_text: replyMessage.text,
+    reply_text: replyMessage.raw_text || replyMessage.text,
     reply_mid: replyMessage.mid,
     checks,
     failures,
@@ -603,7 +613,7 @@ async function collectMessages(page) {
           bubble.querySelector(".translatable-message") ||
           bubble.querySelector(".bubble-content") ||
           bubble;
-        const text = (textNode.textContent || "").replace(/\s+/g, " ").trim();
+        const text = textNode.innerText || textNode.textContent || "";
         if (!text) continue;
         const midRaw = bubble.closest("[data-mid]")?.getAttribute("data-mid");
         const mid = midRaw ? Number(midRaw) : null;
@@ -827,7 +837,7 @@ async function collectSendDebugSnapshot(page, probeText, minMidExclusive = 0) {
           bubble.querySelector(".translatable-message") ||
           bubble.querySelector(".bubble-content") ||
           bubble;
-        const text = (textNode.textContent || "").replace(/\s+/g, " ").trim();
+        const text = textNode.innerText || textNode.textContent || "";
         const midRaw = bubble.closest("[data-mid]")?.getAttribute("data-mid");
         let direction = "unknown";
         if (className.includes(" is-in ")) direction = "in";

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -106,6 +106,31 @@ NODE
         test_fail "Attributed reply should be the first incoming message after the sent probe"
     fi
 
+    test_start "component_telegram_web_probe_preserves_multiline_raw_reply_text"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { findAttributedReply } = await import(process.env.NODE_SCRIPT);
+const rawReply = "Статус: Online\nКанал: Telegram (@moltinger_bot)\nМодель: openai-codex::gpt-5.4\nПровайдер: openai-codex\nРежим: safe-text";
+const reply = findAttributedReply([
+  { mid: 41, direction: "out", text: "/status" },
+  { mid: 42, direction: "in", text: rawReply }
+], 41);
+if (!reply) {
+  throw new Error("expected attributed reply");
+}
+if (reply.raw_text !== rawReply) {
+  throw new Error(`expected raw multiline reply to be preserved, got ${JSON.stringify(reply)}`);
+}
+if (reply.text !== "Статус: Online Канал: Telegram (@moltinger_bot) Модель: openai-codex::gpt-5.4 Провайдер: openai-codex Режим: safe-text") {
+  throw new Error(`expected normalized reply text for correlation helpers, got ${JSON.stringify(reply)}`);
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Probe must preserve raw multiline reply text while keeping normalized text for correlation logic"
+    fi
+
     test_start "component_telegram_web_probe_waits_for_stable_final_reply_before_passing"
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";


### PR DESCRIPTION
## Summary
- preserve raw multiline Telegram bubble text in the authoritative web probe
- keep normalized text only for correlation and leak-detection heuristics
- add regression coverage for multiline /status and document the helper RCA

## Validation
- node --check scripts/telegram-web-user-probe.mjs
- bash tests/component/test_telegram_web_probe_correlation.sh
- bash tests/component/test_telegram_remote_uat_contract.sh
- bash scripts/build-lessons-index.sh
- git diff --check