### PR TITLE
Fix Telegram UTF-8 matcher runtime portability

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-24
-**Total Lessons**: 89
+**Total Lessons**: 90
 
 ---
 
@@ -60,7 +60,8 @@
 - [Topology refresh misclassified permission boundary as a held lock](../docs/rca/2026-03-09-topology-lock-permission-boundary.md)
 - [Self-inflicted GitOps drift from deployment audit markers](../docs/rca/2026-03-08-gitops-audit-markers-self-drift.md)
 
-#### P2 (28 lessons)
+#### P2 (29 lessons)
+- [Telegram UTF-8 matchers depended on Encode.pm that the live container did not ship](../docs/rca/2026-04-24-telegram-utf8-matchers-depended-on-encode-pm.md)
 - [Telegram intent routing broke under POSIX locale and broken-perl fallback](../docs/rca/2026-04-24-telegram-skill-crud-posix-locale-and-perl-fallback.md)
 - [Worktree plan helper treated the default branch as a similar slug candidate](../docs/rca/2026-04-15-worktree-plan-helper-treated-default-branch-as-similar-slug-candidate.md)
 - [Worktree governance left raw create and cleanup reconciliation gaps](../docs/rca/2026-04-15-worktree-governance-left-raw-create-and-cleanup-reconciliation-gaps.md)
@@ -205,7 +206,8 @@
 #### security (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### shell (7 lessons)
+#### shell (8 lessons)
+- [Telegram UTF-8 matchers depended on Encode.pm that the live container did not ship](../docs/rca/2026-04-24-telegram-utf8-matchers-depended-on-encode-pm.md)
 - [Telegram intent routing broke under POSIX locale and broken-perl fallback](../docs/rca/2026-04-24-telegram-skill-crud-posix-locale-and-perl-fallback.md)
 - [Beads wrapper delegated into a sibling worktree wrapper and left stale JSONL export](../docs/rca/2026-03-20-beads-wrapper-path-pollution-caused-stale-jsonl-export.md)
 - [GitOps repair workflow failed before execution because inline heredoc was not parse-safe in GitHub Actions](../docs/rca/2026-03-13-gitops-repair-heredoc-parse-failure.md)
@@ -222,16 +224,16 @@
 
 ### Popular Tags
 
-- `rca` (35 lessons)
+- `rca` (36 lessons)
 - `moltis` (28 lessons)
-- `telegram` (25 lessons)
+- `telegram` (26 lessons)
 - `deploy` (20 lessons)
 - `github-actions` (18 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
 - `skills` (14 lessons)
+- `hooks` (12 lessons)
 - `beads` (12 lessons)
-- `hooks` (11 lessons)
 
 
 ---
@@ -240,10 +242,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 89 |
+| Total Lessons | 90 |
 | Critical (P0/P1) | 45 |
 | Categories | 8 |
-| Unique Tags | 173 |
+| Unique Tags | 175 |
 
 ---
 

--- a/docs/rca/2026-04-24-telegram-utf8-matchers-depended-on-encode-pm.md
+++ b/docs/rca/2026-04-24-telegram-utf8-matchers-depended-on-encode-pm.md
@@ -1,0 +1,137 @@
+---
+title: "Telegram UTF-8 matchers depended on Encode.pm that the live container did not ship"
+date: 2026-04-24
+severity: P2
+category: shell
+tags: [telegram, hooks, shell, perl, utf8, encode, codex-update, rca]
+root_cause: "Repo-owned Telegram-safe UTF-8 regex helpers depended on Perl Encode.pm, but the live Moltis container shipped perl without that module, so the exact codex-update context questions silently fell back to POSIX-unsafe matching and were classified into the wrong intent bucket."
+---
+
+# RCA: Telegram UTF-8 matchers depended on Encode.pm that the live container did not ship
+
+**Дата:** 2026-04-24
+**Статус:** In Progress
+**Влияние:** После merge/deploy PR `#215` exact Telegram questions про историю дублей `codex-update` всё ещё отвечали release summary вместо context contract, хотя локальные POSIX tests уже были зелёными.
+**Контекст:** repair-lane `fix/telegram-safe-unicode-runtime-no-encode`, `scripts/telegram-safe-llm-guard.sh`, `scripts/telegram-e2e-on-demand.sh`
+
+## Context
+
+| Field | Value |
+|-------|-------|
+| Timestamp | 2026-04-24T03:00:00+03:00 |
+| PWD | `/Users/rl/coding/moltinger/moltinger-main-fix-telegram-safe-unicode-runtime-no-encode` |
+| Shell | `zsh` |
+| Git Branch | `fix/telegram-safe-unicode-runtime-no-encode` |
+| Git Status | modified guard + UAT wrapper + component tests + RCA |
+| Docker Version | production evidence collected from `docker exec moltis ...` |
+| Disk Usage | not material |
+| Memory | not material |
+| Error Type | shell |
+
+## Error Classification (Chain-of-Thought)
+
+| Field | Value |
+|-------|-------|
+| Error Type | code/config |
+| Confidence | high |
+| Context Quality | sufficient |
+
+### Hypotheses
+
+| # | Hypothesis | Confidence |
+|---|------------|------------|
+| H1 | Live container still ran an old hook version after deploy | 15% |
+| H2 | New UTF-8 matcher logic still relied on a Perl module missing from production, so runtime silently fell back to POSIX-unsafe matching | 80% |
+| H3 | Telegram Web authoritative probe was again misclassifying a correct reply | 5% |
+
+## Ошибка
+
+После deploy PR `#215` authoritative Telegram UAT на exact prompt `Почему раньше ты присылал три одинаковых сообщения подряд про обновление Codex CLI?` всё ещё падал с `semantic_codex_update_context_contract_mismatch`.
+
+Production evidence showed:
+
+1. audit log on live container still classified the exact question as `direct_fastpath kind=codex_update ... mode=release`;
+2. captured `MessageReceived` payload contained the exact Russian user text, so the input itself was correct;
+3. manual replay of that payload inside the production container crashed with `Can't locate Encode.pm in @INC`;
+4. the container had `/usr/bin/perl`, but not the `Encode.pm` module;
+5. local tests were green because the host perl did ship `Encode.pm`.
+
+То есть проблема уже не была в формулировке intent patterns и не в Telegram probe. Проблема была в том, что repo-owned UTF-8 matcher helper использовал host-only Perl dependency.
+
+## Проверка прошлых уроков
+
+**Проверенные источники:**
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag hooks`
+- `./scripts/query-lessons.sh --tag shell`
+
+**Релевантные прошлые RCA/уроки:**
+1. `2026-04-24-telegram-skill-crud-posix-locale-and-perl-fallback` — уже зафиксировал, что Telegram-safe routing нельзя опирать на locale-sensitive shell matching и что `command -v perl` не равен “perl рабочий”.
+2. `2026-04-02-telegram-skill-detail-fell-back-to-tool-error-leak` — уже предупреждал, что для Telegram-safe сценариев нельзя считать host-only зависимости допустимыми, если контейнерный runtime их не гарантирует.
+3. `2026-04-23-telegram-direct-fastpath-before-llm-must-block` — уже отделял `hook сгенерировал правильный JSON` от `runtime реально прошёл нужную ветку`; здесь тот же принцип проявился на matcher helper.
+
+**Что могло быть упущено без этой сверки:**
+- можно было бы ошибочно считать, что PR `#215` “почти починил” проблему, и лечить оставшийся симптом новыми reply-rewrite эвристиками;
+- можно было бы продолжить верить локальному POSIX replay вместо проверки container/runtime execution path.
+
+**Что в текущем инциденте действительно новое:**
+- новый matcher path сам был Unicode-aware только на хосте, потому что зависел от `Encode.pm`, отсутствующего в live container.
+
+## Анализ 5 Почему (with Evidence)
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---------|--------|-------|----------|
+| 1 | Почему exact `codex-update` history question после deploy всё ещё уходил в release summary? | Потому что live audit по-прежнему классифицировал turn как `mode=release`, а не `mode=context`. | production audit: `direct_fastpath kind=codex_update ... mode=release` |
+| 2 | Почему live runtime не использовал уже добавленный UTF-8 matcher как ожидалось? | Потому что helper вызывал `perl -MEncode=...`, а в контейнере этого модуля не было. | manual payload replay in container: `Can't locate Encode.pm in @INC` |
+| 3 | Почему это не было видно по локальным тестам до merge? | Потому что локальный perl на хосте модуль `Encode.pm` имел, поэтому matcher branch проходил и тесты были зелёными. | local suite `160/160` green before this follow-up; production-only replay failed |
+| 4 | Почему failure снова деградировал именно в wrong intent bucket, а не в явный hard crash? | Потому что helper path silently fell back from Perl matcher to plain `grep -Eiq`, а под `LC_CTYPE=POSIX` этот fallback не держит Russian uppercase/context semantics. | live symptom returned after deploy; prior RCA and local reproduction showed POSIX fallback misclassifies the same question |
+| 5 | Почему это системная, а не единичная ошибка? | Потому что repo-owned Telegram-safe helper был написан с неявной предпосылкой “perl ships Encode.pm”, хотя production contract этого не гарантирует. | both `telegram-safe-llm-guard.sh` and `telegram-e2e-on-demand.sh` used the same `-MEncode=` dependency |
+
+## Корневая причина
+
+Repo-owned Telegram-safe UTF-8 regex helpers were implemented with a non-portable Perl dependency (`Encode.pm`). The live Moltis container had perl installed but did not ship that module, so the helper failed and silently fell back to POSIX-unsafe shell matching. As a result, exact Russian `codex-update` context/history questions were again classified into the wrong intent bucket even though the higher-level routing logic had already been fixed in the previous PR.
+
+### Root Cause Validation
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| □ Actionable? | yes | Исправляется в repo-owned shell helpers and regression tests |
+| □ Systemic? | yes | Один и тот же helper path used by live guard and authoritative UAT wrapper |
+| □ Preventable? | yes | Нужен module-free UTF-8 decode path and explicit regression coverage for host-only Perl deps |
+
+## Принятые меры
+
+1. **Немедленное исправление:** в `scripts/telegram-safe-llm-guard.sh` и `scripts/telegram-e2e-on-demand.sh` заменён `Encode.pm`-based decode на built-in `utf8::decode`, не требующий внешнего Perl модуля.
+2. **Предотвращение:** добавлены regression tests, которые:
+   - проверяют отсутствие `Encode.pm` dependency в guard и UAT wrapper;
+   - воспроизводят exact live `codex-update` context question через подменный `perl`, который специально заваливает любой вызов с `Encode`.
+3. **Документация:** создан этот RCA; `docs/LESSONS-LEARNED.md` будет пересобран после добавления файла.
+
+## Связанные обновления
+
+- [ ] Новый файл правила создан (docs/rules/ или .claude/skills/)
+- [ ] Краткая ссылка добавлена в CLAUDE.md (1-2 строки)
+- [ ] Новые навыки созданы
+- [x] Тесты добавлены
+- [ ] Чеклисты обновлены
+
+## Уроки
+
+- Для Telegram-safe shell helpers недостаточно требования “perl есть”; нужен контракт “используем только built-in perl surface, гарантированную в live container”.
+- Если локальный POSIX regression зелёный, но authoritative production UAT всё ещё красный, следующим источником истины должен быть container replay exact payload-а, а не ещё одна эвристика переписывания ответа.
+- Shared helper logic нужно проверять не только на корректность текста/intent, но и на отсутствие host-only module dependencies.
+
+## Regression Test (Optional - for code errors only)
+
+**Test File:** `tests/component/test_telegram_safe_llm_guard.sh`, `tests/component/test_telegram_remote_uat_contract.sh`
+
+**Test Status:**
+- [x] Test created
+- [x] Test reproduces the live container dependency gap
+- [x] Fix applied
+- [x] Test passes
+
+---
+
+*Создано вручную по live container evidence и component regression tests*

--- a/scripts/telegram-e2e-on-demand.sh
+++ b/scripts/telegram-e2e-on-demand.sh
@@ -250,7 +250,7 @@ text_matches_extended_regex() {
 
   if command -v perl >/dev/null 2>&1; then
     TEXT_MATCH_TEXT="$text" TEXT_MATCH_PATTERN="$pattern" \
-      perl -CSDA -MEncode=decode,FB_CROAK -e '
+      perl -CSDA -e '
         use strict;
         use warnings;
         use utf8;
@@ -259,13 +259,10 @@ text_matches_extended_regex() {
         my $raw_pattern = $ENV{TEXT_MATCH_PATTERN} // q();
         exit 2 unless length $raw_pattern;
 
-        my ($text, $pattern) = eval {
-          (
-            decode("UTF-8", $raw_text, FB_CROAK),
-            decode("UTF-8", $raw_pattern, FB_CROAK),
-          );
-        };
-        exit 2 if $@;
+        my $text = $raw_text;
+        my $pattern = $raw_pattern;
+        exit 2 unless utf8::decode($text);
+        exit 2 unless utf8::decode($pattern);
 
         my $matched = eval {
           my $re = qr{$pattern}iu;

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -1044,7 +1044,7 @@ text_matches_extended_regex() {
 
     if command -v perl >/dev/null 2>&1; then
         TEXT_MATCH_TEXT="$text" TEXT_MATCH_PATTERN="$pattern" \
-            perl -CSDA -MEncode=decode,FB_CROAK -e '
+            perl -CSDA -e '
                 use strict;
                 use warnings;
                 use utf8;
@@ -1053,13 +1053,10 @@ text_matches_extended_regex() {
                 my $raw_pattern = $ENV{TEXT_MATCH_PATTERN} // q();
                 exit 2 unless length $raw_pattern;
 
-                my ($text, $pattern) = eval {
-                    (
-                        decode("UTF-8", $raw_text, FB_CROAK),
-                        decode("UTF-8", $raw_pattern, FB_CROAK),
-                    );
-                };
-                exit 2 if $@;
+                my $text = $raw_text;
+                my $pattern = $raw_pattern;
+                exit 2 unless utf8::decode($text);
+                exit 2 unless utf8::decode($pattern);
 
                 my $matched = eval {
                     my $re = qr{$pattern}iu;

--- a/tests/component/test_telegram_remote_uat_contract.sh
+++ b/tests/component/test_telegram_remote_uat_contract.sh
@@ -2879,6 +2879,13 @@ run_component_telegram_remote_uat_contract_tests() {
         test_fail "Deploy workflow must keep the Telegram Web scheduler disabled by default"
     fi
 
+    test_start "component_telegram_remote_uat_perl_utf8_matchers_do_not_depend_on_encode_pm"
+    if ! grep -Fq -- '-MEncode=' "$WRAPPER_SCRIPT" && ! grep -Fq 'use Encode' "$WRAPPER_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Authoritative Telegram UAT wrapper must not depend on Encode.pm because the live Moltis container does not ship that module"
+    fi
+
     generate_report
 }
 

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -30,6 +30,12 @@ run_hook_bundle_with_minimal_path() {
     printf '%s\n' "$input_json" | env PATH="$MINIMAL_PATH" MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" bash "$HOOK_HANDLER"
 }
 
+run_hook_with_custom_path() {
+    local custom_path="$1"
+    local input_json="$2"
+    printf '%s\n' "$input_json" | env PATH="$custom_path" bash "$HOOK_SCRIPT"
+}
+
 run_component_telegram_safe_llm_guard_tests() {
     start_timer
 
@@ -4527,6 +4533,45 @@ EOF
         test_pass
     else
         test_fail "Perl-based Telegram-safe fastpaths must not depend on open.pm because the live Moltis container does not ship that module"
+    fi
+
+    test_start "component_perl_utf8_matchers_do_not_depend_on_encode_pm"
+    if ! grep -Fq -- '-MEncode=' "$HOOK_SCRIPT" && ! grep -Fq 'use Encode' "$HOOK_SCRIPT"; then
+        test_pass
+    else
+        test_fail "Telegram-safe UTF-8 matcher helpers must not depend on Encode.pm because the live Moltis container does not ship that module"
+    fi
+
+    test_start "component_before_llm_guard_codex_update_context_survives_perl_without_encode_pm"
+    local perl_guard_tmpdir
+    perl_guard_tmpdir="$(mktemp -d)"
+    cat > "$perl_guard_tmpdir/perl" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+    if [[ "$arg" == *Encode* ]]; then
+        echo "Encode.pm is unavailable in this test wrapper" >&2
+        exit 97
+    fi
+done
+exec /usr/bin/perl "$@"
+EOF
+    chmod +x "$perl_guard_tmpdir/perl"
+    local before_llm_no_encode_wrapper_output
+    before_llm_no_encode_wrapper_output="$(
+        LANG= \
+        LC_ALL=C \
+        LC_CTYPE=POSIX \
+        run_hook_with_custom_path "$perl_guard_tmpdir:/usr/bin:/bin" \
+            '{"event":"BeforeLLMCall","session_key":"session:no-encode-wrapper","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=prod | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Почему раньше ты присылал три одинаковых сообщения подряд про обновление Codex CLI?"}],"tool_count":37,"iteration":1}'
+    )"
+    rm -rf "$perl_guard_tmpdir"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_llm_no_encode_wrapper_output" && \
+       jq -e '.data.tool_count == 0' >/dev/null 2>&1 <<<"$before_llm_no_encode_wrapper_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe codex-update hard override")' >/dev/null 2>&1 <<<"$before_llm_no_encode_wrapper_output" && \
+       jq -e '.data.messages[0].content | contains("После исправлений схема такая")' >/dev/null 2>&1 <<<"$before_llm_no_encode_wrapper_output"; then
+        test_pass
+    else
+        test_fail "The exact live codex-update context route must stay functional even when perl wrappers reject any Encode.pm dependency"
     fi
 
     test_start "component_telegram_safe_llm_guard_is_noop_for_non_telegram_safe_models"


### PR DESCRIPTION
## Summary
- remove `Encode.pm` dependency from Telegram-safe UTF-8 regex helpers in the live guard and authoritative UAT wrapper
- add regression coverage for the live codex-update context question under a perl wrapper that rejects `Encode`
- record the new production-only root cause in RCA and rebuild lessons learned

## Testing
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_remote_uat_contract.sh
