### PR TITLE
fix: terminalize telegram native skill crud

### DIFF
--- a/config/moltis.toml
+++ b/config/moltis.toml
@@ -144,6 +144,8 @@ soul = """
 - Для вопросов про навыки и skill-authoring не используй sandbox filesystem как primary truth. Если hook/runtime snapshot не подтверждает список навыков, честно скажи, что это не доказательство отсутствия навыков.
 - Если live Telegram runtime проигнорировал repo/user hooks, всё равно соблюдай эти Telegram-safe правила как прямой fallback-контракт ответа.
 - Для skill visibility/create/update/patch/delete в user-facing Telegram предпочитай dedicated tools `create_skill`, `update_skill`, `patch_skill`, `delete_skill`, `write_skill_files`, а не `exec`/browser/web-search пути.
+- Для native skill tools соблюдай official schema: `create_skill` -> `name` + `content` (+ optional `description`), `update_skill` -> `name` + `content` (+ optional `description`), `patch_skill` -> `name` + `patches` (+ optional `description`), `delete_skill` -> `name`, `write_skill_files` -> `name` + `files`.
+- Не используй legacy поля `body`, `allowed_tools` и `instructions` при вызовах `create_skill`/`update_skill`/`patch_skill`; если нужен sidecar-файл, делай это через `write_skill_files`.
 - Для запросов вида `почини/исправь/отладь навык ...`, `почини codex-update`, `посмотри логи skill/codex-update`, `найди root cause` в user-facing Telegram/DM не запускай внутренние инструменты, не читай SKILL.md и не открывай логи.
 - Для такого maintenance/debug класса Telegram-safe ответ должен сразу переводить пользователя в text-only boundary: кратко объясни, что repair/debug/log inspection продолжаются только в web UI/операторской сессии.
 - В этом же классе запросов разрешено упомянуть только смысл: простые правки навыка возможны по явной CRUD-команде на создание, обновление, патч или удаление навыка, без перечисления внутренних tool id пользователю.

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-24
-**Total Lessons**: 91
+**Total Lessons**: 92
 
 ---
 
@@ -14,7 +14,8 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (44 lessons)
+#### P1 (45 lessons)
+- [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
 - [Telegram Web probe collapsed multiline /status replies before exact semantic review](../docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
@@ -195,7 +196,8 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (7 lessons)
+#### product (8 lessons)
+- [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
@@ -226,15 +228,15 @@
 
 ### Popular Tags
 
-- `rca` (37 lessons)
+- `rca` (38 lessons)
+- `telegram` (28 lessons)
 - `moltis` (28 lessons)
-- `telegram` (27 lessons)
 - `deploy` (20 lessons)
 - `github-actions` (18 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
-- `skills` (14 lessons)
-- `hooks` (12 lessons)
+- `skills` (15 lessons)
+- `hooks` (13 lessons)
 - `beads` (12 lessons)
 
 
@@ -244,10 +246,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 91 |
-| Critical (P0/P1) | 45 |
+| Total Lessons | 92 |
+| Critical (P0/P1) | 46 |
 | Categories | 8 |
-| Unique Tags | 177 |
+| Unique Tags | 180 |
 
 ---
 

--- a/docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md
+++ b/docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md
@@ -1,0 +1,97 @@
+---
+title: "Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify"
+date: 2026-04-24
+severity: P1
+category: product
+tags: [telegram, skills, hooks, runtime, create-skill, update-skill, patch-skill, rca]
+root_cause: "Repo-owned repair initially assumed that normalizing create_skill/update_skill/patch_skill arguments in BeforeToolCall was sufficient, but authoritative production evidence showed live Moltis still validated the raw tool envelope and ignored that modify payload on the Telegram path."
+---
+
+# RCA: Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify
+
+**Дата:** 2026-04-24
+**Статус:** Resolved
+**Влияние:** В Telegram пользователь видел `missing 'name' parameter` и похожие raw validation errors во время skill CRUD, хотя в сохранённом tool-call JSON имя и другие поля уже присутствовали. Это блокировало создание, обновление и sidecar-редактирование навыков прямо из бота.
+**Контекст:** `scripts/telegram-safe-llm-guard.sh`, live Moltis Telegram runtime, dedicated skill tools `create_skill`/`update_skill`/`patch_skill`/`delete_skill`/`write_skill_files`.
+
+## Ошибка
+
+После предыдущих ремонтов Telegram-safe guard уже:
+
+- правильно маршрутизировал Russian CRUD intent;
+- правильно canonicalized dirty tool envelopes с `_channel`, `_session_key`, `body`, `allowed_tools`;
+- перестал уходить в `exec`/filesystem probing.
+
+Но authoritative production evidence всё равно показывал новый сбой:
+
+- `create_skill` приходил с `name`, `body`, `description`, `allowed_tools`, а live runtime отвечал `missing 'name' parameter`;
+- `Glob` приходил с `pattern`, но live runtime отвечал `missing 'pattern'`.
+
+Общая форма была одинаковой: hook генерировал корректный `modify`, но live Telegram runtime исполнял и валидировал исходный сырой envelope, а не нормализованный payload.
+
+## Проверка прошлых уроков
+
+Перед фиксом были повторно проверены:
+
+- `docs/LESSONS-LEARNED.md`
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag skills`
+- `docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md`
+- `docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md`
+- `docs/rca/2026-04-24-telegram-skill-crud-posix-locale-and-perl-fallback.md`
+
+Релевантные прошлые уроки уже указывали:
+
+1. dirty-but-valid envelopes нужно чинить в argument boundary, а не маскировать delivery;
+2. для Telegram runtime `hook emitted correct JSON` не равно `runtime actually applied it`;
+3. wrong intent bucket и поздний reply rewrite не заменяют фикса на owning layer.
+
+Что было новым:
+
+- даже после исправленной `BeforeToolCall` canonicalization live runtime Telegram всё ещё не давал авторитетного применения этого `modify` для native skill CRUD;
+- значит корневой дефект был не только в форме аргументов, а в самой границе применения hook result.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---|---|---|---|
+| 1 | Почему Telegram skill CRUD продолжал падать с `missing 'name' parameter`? | Потому что live runtime валидировал сырой tool envelope, а не нормализованный hook payload. | Production container logs for `create_skill` showed `name` inside persisted args and simultaneous runtime validation failure. |
+| 2 | Почему normalizing `BeforeToolCall` не исправил поведение? | Потому что на этой live Telegram path `BeforeToolCall modify` не был authoritative execution boundary. | Hook artifacts stored the cleaned args, but runner still consumed the dirty raw envelope. |
+| 3 | Почему это не поймали раньше? | Потому что synthetic/component checks доказывали корректность hook JSON, но не применение `modify` внутри live Moltis execution path. | Local tests passed while authoritative production CRUD still failed. |
+| 4 | Почему symptom выглядел как ошибка модели, хотя поля были на месте? | Потому что runtime error message сообщал про missing required field, хотя реальная проблема была в bypass нормализованного envelope. | Same pattern reproduced for several tools, not just skill CRUD. |
+| 5 | Почему нужен был другой архитектурный путь? | Потому что пока live Telegram runtime не гарантирует применение `BeforeToolCall modify`, repo-owned fix должен терминализовать этот класс turn раньше и выполнять owned CRUD deterministic path вне broken boundary. | Existing direct fastpath pattern already proved reliable for other Telegram-safe critical flows. |
+
+## Корневая причина
+
+Owning layer defect находился в repo-managed Telegram-safe contract design. Ремонт всё ещё полагался на live Moltis execution semantics, где `BeforeToolCall modify` для Telegram не был надёжным authoritative boundary. Поэтому даже корректная canonicalization не превращалась в корректное выполнение native skill CRUD.
+
+Иными словами: проблема была не в том, что guard не умел очистить аргументы, а в том, что live runtime не обязанно исполнял именно очищенную версию этих аргументов.
+
+## Принятые меры
+
+1. Добавлен deterministic `AfterLLMCall` direct execution path для Telegram-safe native skill CRUD.
+2. Этот path выполняет `create_skill`, `update_skill`, `patch_skill`, `delete_skill`, `write_skill_files` напрямую в runtime skills root и отправляет один clean user-facing reply через direct Bot API fastpath.
+3. Для `create_skill` и `update_skill` добавлена compatibility normalization `body -> content`; `allowed_tools` удаляется как legacy drift.
+4. Для `patch_skill` зафиксирован official contract `patches[]`; legacy `instructions` больше не считаются каноническим путём.
+5. Prompt/config слой усилен: system guidance теперь явно запрещает legacy поля `body`, `allowed_tools`, `instructions` и закрепляет official skill tool schema.
+6. Component regressions теперь доказывают не только canonicalization, но и реальное deterministic выполнение CRUD flow без попадания в broken live tool boundary.
+
+## Уроки
+
+1. Для live Telegram runtime `BeforeToolCall modify` нельзя считать authoritative только потому, что hook script вернул правильный JSON.
+2. Если upstream/live boundary игнорирует repo-owned normalization, следующий source fix должен переносить critical flow в другой owning execution layer, а не добавлять ещё один rewrite.
+3. Для skill CRUD Telegram-safe contract должен одновременно:
+   - задавать official schema модели;
+   - терпеть legacy drift на входе;
+   - исполнять critical path там, где repo действительно контролирует выполнение.
+
+## Regression Test
+
+**Test File:** `tests/component/test_telegram_safe_llm_guard.sh`
+
+**Test Status:**
+
+- [x] Test created
+- [x] Test reproduces the live-like envelope drift
+- [x] Fix applied
+- [x] Test passes

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -750,7 +750,7 @@ canonicalize_known_tool_arguments_json() {
 
     [[ -n "$tool_name" && -n "$arguments_json" ]] || return 1
     case "$arguments_json" in
-        *'"_channel"'*|*'"_session_key"'*|*':null'*|*': null'*)
+        *'"_channel"'*|*'"_session_key"'*|*'"body"'*|*'"allowed_tools"'*|*':null'*|*': null'*)
             ;;
         *)
             return 1
@@ -785,7 +785,7 @@ requirements = {
     "browser": ("string", "action"),
     "create_skill": ("string", "name"),
     "update_skill": ("string", "name"),
-    "patch_skill": ("all_strings", ("name", "instructions")),
+    "patch_skill": ("skill_patch", None),
     "delete_skill": ("string", "name"),
     "write_skill_files": ("name_and_files", None),
     "mcp__tavily__tavily_search": ("string", "query"),
@@ -805,6 +805,13 @@ if kind == "string":
 elif kind == "all_strings":
     if not all(nonempty_string(args.get(key)) for key in spec):
         raise SystemExit(1)
+elif kind == "skill_patch":
+    patches = args.get("patches")
+    has_patches = isinstance(patches, list) and any(isinstance(item, dict) for item in patches)
+    has_legacy_instructions = nonempty_string(args.get("instructions"))
+    has_description = nonempty_string(args.get("description"))
+    if not nonempty_string(args.get("name")) or not (has_patches or has_legacy_instructions or has_description):
+        raise SystemExit(1)
 elif kind == "name_and_files":
     files = args.get("files")
     if not nonempty_string(args.get("name")) or not isinstance(files, list):
@@ -815,6 +822,29 @@ else:
     raise SystemExit(1)
 
 changed = False
+
+if tool in {"create_skill", "update_skill"} and nonempty_string(args.get("body")):
+    if not nonempty_string(args.get("content")):
+        args["content"] = args.get("body")
+    del args["body"]
+    changed = True
+
+allowed_keys = {
+    "read_skill": {"name"},
+    "memory_search": {"query", "limit", "filter"},
+    "exec": {"command", "timeout", "working_dir"},
+    "cron": {"action", "limit", "id", "job"},
+    "process": {"action", "id"},
+    "Glob": {"path", "pattern", "exclude"},
+    "web_fetch": {"url", "extract_mode", "max_chars", "selector"},
+    "browser": {"action", "url", "session_id"},
+    "create_skill": {"name", "content", "description"},
+    "update_skill": {"name", "content", "description"},
+    "patch_skill": {"name", "patches", "description", "instructions"},
+    "delete_skill": {"name"},
+    "write_skill_files": {"name", "files"},
+    "mcp__tavily__tavily_search": {"query", "topic", "max_results"},
+}
 
 def clean(value):
     global changed
@@ -842,6 +872,14 @@ def clean(value):
     return value
 
 cleaned_args = clean(args)
+if tool in allowed_keys and isinstance(cleaned_args, dict):
+    filtered_args = {}
+    for key, value in cleaned_args.items():
+        if key in allowed_keys[tool]:
+            filtered_args[key] = value
+        else:
+            changed = True
+    cleaned_args = filtered_args
 if not changed:
     raise SystemExit(1)
 
@@ -2194,6 +2232,8 @@ build_skill_authoring_guard_message() {
 Telegram-safe skill-authoring contract:
 - Для skill visibility/create/update/patch/delete не используй browser, web-search, Tavily, exec и filesystem-пробы как primary path.
 - Допустимые tool paths для такого хода: create_skill, update_skill, patch_skill, delete_skill, write_skill_files, session_state, send_message, send_image.
+- Используй official skill tool schema: create_skill -> name + content (+ optional description), update_skill -> name + content, patch_skill -> name + patches array ({find, replace}) и optional description, delete_skill -> name, write_skill_files -> name + files.
+- Не используй legacy поля `body`, `allowed_tools` и `instructions` для новых вызовов skill tools.
 - Если runtime snapshot недоступен, не делай вывод "навыков нет"; скажи, что sandbox filesystem не является доказательством отсутствия навыка.
 - Если create_skill, update_skill, patch_skill или write_skill_files вернул validation/frontmatter error, кратко объясни ошибку и повтори попытку с валидным SKILL.md.
 - Если пользователь спрашивает именно про template/шаблон навыка, покажи канонический минимальный scaffold из project docs, а не ищи его через workspace, skills directory или existing skills.
@@ -2226,7 +2266,7 @@ Telegram-safe sparse create-skill override:
 - Первый содержательный ход обязан быть create_skill.
 - Не задавай уточняющих вопросов до первой попытки create_skill.
 - Не ищи template, не смотри existing skills, не проверяй filesystem/directories и не используй exec/browser/web-search.
-- Для create_skill сам сгенерируй description и content.
+- Для create_skill сам сгенерируй description и content. Не используй legacy поле body.
 - Content должен быть валидным минимальным SKILL.md со структурой:
   ---
   name: <skill-name>
@@ -3032,6 +3072,320 @@ runtime_skill_file_path() {
     printf '%s/%s/SKILL.md' "$runtime_root" "$skill_name"
 }
 
+tool_calls_only_direct_skill_crud_supported() {
+    local tool_calls_json="${1:-}"
+    local tool_name=""
+    local saw_name=false
+
+    [[ -n "$tool_calls_json" && "$tool_calls_json" != "[]" ]] || return 1
+
+    while IFS= read -r tool_name; do
+        [[ -n "$tool_name" ]] || continue
+        saw_name=true
+        case "$tool_name" in
+            create_skill|update_skill|patch_skill|delete_skill|write_skill_files)
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done < <(extract_tool_call_names "$tool_calls_json" || true)
+
+    [[ "$saw_name" == true ]]
+}
+
+execute_direct_skill_tool_calls_json() {
+    local tool_calls_json="${1:-}"
+    local runtime_root="${MOLTIS_RUNTIME_SKILLS_ROOT:-/home/moltis/.moltis/skills}"
+
+    [[ -n "$tool_calls_json" && "$tool_calls_json" != "[]" ]] || return 1
+    command -v python3 >/dev/null 2>&1 || return 1
+
+    DIRECT_SKILL_TOOL_CALLS_JSON="$tool_calls_json" \
+    MOLTIS_RUNTIME_SKILLS_ROOT="$runtime_root" \
+    python3 - <<'PY'
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+
+tool_calls_raw = os.environ.get("DIRECT_SKILL_TOOL_CALLS_JSON", "")
+runtime_root = Path(os.environ.get("MOLTIS_RUNTIME_SKILLS_ROOT", "/home/moltis/.moltis/skills"))
+
+try:
+    tool_calls = json.loads(tool_calls_raw)
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(tool_calls, list) or not tool_calls:
+    raise SystemExit(1)
+
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+def nonempty_string(value):
+    return isinstance(value, str) and bool(value.strip())
+
+def valid_skill_name(name):
+    return nonempty_string(name) and NAME_RE.match(name.strip()) is not None
+
+def skill_dir(name):
+    return runtime_root / name
+
+def skill_file(name):
+    return skill_dir(name) / "SKILL.md"
+
+def minimal_scaffold(name, description=None):
+    description = (description or f"Базовый навык {name}. Использовать, когда пользователь явно просит сценарий {name}.").strip()
+    return (
+        f"---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"---\n"
+        f"# {name}\n\n"
+        f"## Активация\n"
+        f"Когда пользователь явно просит сценарий {name} или доработку этого навыка, используй его.\n\n"
+        f"## Workflow\n"
+        f"1. Уточни цель, если для точного выполнения не хватает контекста.\n"
+        f"2. Выполни основной сценарий навыка.\n"
+        f"3. Верни краткий итог и предложи, как доработать навык дальше.\n\n"
+        f"## Templates\n"
+        f"- TODO: добавить конкретные шаблоны под сценарий навыка.\n"
+    )
+
+def read_text(path):
+    return path.read_text(encoding="utf-8")
+
+def write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    normalized = text if text.endswith("\n") else text + "\n"
+    path.write_text(normalized, encoding="utf-8")
+
+def split_frontmatter(text):
+    if text.startswith("---\n"):
+        marker = "\n---\n"
+        idx = text.find(marker, 4)
+        if idx != -1:
+            return text[4:idx], text[idx + len(marker):]
+        marker = "\n---"
+        idx = text.find(marker, 4)
+        if idx != -1:
+            return text[4:idx], text[idx + len(marker):].lstrip("\n")
+    return None, text
+
+def upsert_description(text, name, description):
+    frontmatter, body = split_frontmatter(text)
+    if frontmatter is None:
+        return minimal_scaffold(name, description)
+
+    lines = frontmatter.splitlines()
+    updated = []
+    found_name = False
+    found_description = False
+    for line in lines:
+        if line.startswith("name:"):
+            updated.append(f"name: {name}")
+            found_name = True
+        elif line.startswith("description:"):
+            updated.append(f"description: {description}")
+            found_description = True
+        else:
+            updated.append(line)
+    if not found_name:
+        updated.insert(0, f"name: {name}")
+    if not found_description:
+        insert_at = 1 if updated and updated[0].startswith("name:") else 0
+        updated.insert(insert_at, f"description: {description}")
+    return "---\n" + "\n".join(updated).rstrip() + "\n---\n" + body.lstrip("\n")
+
+def apply_patches(text, patches):
+    updated = text
+    for index, patch in enumerate(patches, start=1):
+        if not isinstance(patch, dict):
+            raise ValueError(f"patch #{index} must be an object")
+        find = patch.get("find")
+        replace = patch.get("replace", "")
+        if not nonempty_string(find):
+            raise ValueError(f"patch #{index} must contain non-empty `find`")
+        if not isinstance(replace, str):
+            raise ValueError(f"patch #{index} must contain string `replace`")
+        if find not in updated:
+            raise ValueError(f"patch #{index} did not match current skill content")
+        updated = updated.replace(find, replace, 1)
+    return updated
+
+def resolve_skill_relative_path(name, relative_path):
+    if not nonempty_string(relative_path):
+        raise ValueError("file entry must contain non-empty `path`")
+    if relative_path.startswith("/"):
+        raise ValueError("file path must be relative to the skill directory")
+    candidate = skill_dir(name) / relative_path
+    resolved = candidate.resolve()
+    root = skill_dir(name).resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError("file path escapes the skill directory")
+    return resolved
+
+def canonical_content(args, name):
+    content = args.get("content")
+    if not nonempty_string(content):
+        content = args.get("body")
+    if nonempty_string(content):
+        return content.strip()
+    description = args.get("description") if nonempty_string(args.get("description")) else None
+    return minimal_scaffold(name, description)
+
+operations = []
+errors = []
+runtime_root.mkdir(parents=True, exist_ok=True)
+
+for entry in tool_calls:
+    if not isinstance(entry, dict):
+        errors.append("tool call entry must be an object")
+        break
+
+    tool_name = entry.get("name")
+    args = entry.get("arguments") or {}
+    if not isinstance(args, dict):
+        errors.append(f"{tool_name or 'unknown'}: arguments must be an object")
+        break
+
+    name = (args.get("name") or "").strip()
+    if tool_name not in {"create_skill", "update_skill", "patch_skill", "delete_skill", "write_skill_files"}:
+        errors.append(f"unsupported tool in direct skill execution: {tool_name}")
+        break
+    if not valid_skill_name(name):
+        errors.append(f"{tool_name}: нужен корректный slug навыка")
+        break
+
+    try:
+        if tool_name == "create_skill":
+            path = skill_file(name)
+            if path.exists():
+                operations.append({"name": tool_name, "skill": name, "state": "exists"})
+            else:
+                write_text(path, canonical_content(args, name))
+                operations.append({"name": tool_name, "skill": name, "state": "created"})
+
+        elif tool_name == "update_skill":
+            path = skill_file(name)
+            if not path.exists():
+                raise ValueError("навык ещё не существует")
+            if nonempty_string(args.get("content")) or nonempty_string(args.get("body")):
+                write_text(path, canonical_content(args, name))
+            elif nonempty_string(args.get("description")):
+                updated = upsert_description(read_text(path), name, args["description"].strip())
+                write_text(path, updated)
+            else:
+                raise ValueError("update_skill требует `content` или хотя бы `description`")
+            operations.append({"name": tool_name, "skill": name, "state": "updated"})
+
+        elif tool_name == "patch_skill":
+            path = skill_file(name)
+            if not path.exists():
+                raise ValueError("навык ещё не существует")
+            text = read_text(path)
+            if nonempty_string(args.get("description")):
+                text = upsert_description(text, name, args["description"].strip())
+            patches = args.get("patches")
+            if isinstance(patches, list) and patches:
+                text = apply_patches(text, patches)
+            elif nonempty_string(args.get("instructions")):
+                raise ValueError("patch_skill теперь требует массив `patches` по official contract, а не legacy `instructions`")
+            elif not nonempty_string(args.get("description")):
+                raise ValueError("patch_skill требует `patches` или хотя бы `description`")
+            write_text(path, text)
+            operations.append({"name": tool_name, "skill": name, "state": "patched"})
+
+        elif tool_name == "delete_skill":
+            target_dir = skill_dir(name)
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+                operations.append({"name": tool_name, "skill": name, "state": "deleted"})
+            else:
+                operations.append({"name": tool_name, "skill": name, "state": "already_absent"})
+
+        elif tool_name == "write_skill_files":
+            files = args.get("files")
+            if not isinstance(files, list) or not any(isinstance(item, dict) for item in files):
+                raise ValueError("write_skill_files требует непустой массив `files`")
+            written = 0
+            for item in files:
+                if not isinstance(item, dict):
+                    raise ValueError("каждый элемент `files` должен быть объектом")
+                target = resolve_skill_relative_path(name, item.get("path", ""))
+                content = item.get("content", "")
+                if not isinstance(content, str):
+                    raise ValueError("поле `content` в files должно быть строкой")
+                write_text(target, content)
+                written += 1
+            operations.append({"name": tool_name, "skill": name, "state": "files_written", "count": written})
+
+    except Exception as exc:
+        errors.append(f"{tool_name} `{name}`: {exc}")
+        break
+
+skills = []
+for op in operations:
+    skill = op.get("skill")
+    if skill and skill not in skills:
+        skills.append(skill)
+
+primary_skill = skills[0] if skills else ""
+created = any(op["name"] == "create_skill" and op["state"] == "created" for op in operations)
+exists = any(op["name"] == "create_skill" and op["state"] == "exists" for op in operations)
+mutated = any(op["name"] in {"update_skill", "patch_skill"} for op in operations)
+wrote_files = any(op["name"] == "write_skill_files" for op in operations)
+deleted = any(op["name"] == "delete_skill" and op["state"] == "deleted" for op in operations)
+already_absent = any(op["name"] == "delete_skill" and op["state"] == "already_absent" for op in operations)
+
+if errors:
+    reply_text = "Не смог применить правку навыка: " + errors[0]
+    status = "error"
+elif len(skills) > 1:
+    reply_text = "Выполнил операции с навыками: " + ", ".join(f"`{item}`" for item in skills) + "."
+    status = "ok"
+elif deleted:
+    reply_text = f"Удалил навык `{primary_skill}`."
+    status = "ok"
+elif already_absent:
+    reply_text = f"Навык `{primary_skill}` уже отсутствует."
+    status = "ok"
+elif created and (mutated or wrote_files):
+    reply_text = f"Создал навык `{primary_skill}` и сразу доработал его."
+    status = "ok"
+elif created:
+    reply_text = f"Создал базовый шаблон навыка `{primary_skill}`. Могу следующим сообщением доработать описание, workflow и templates."
+    status = "ok"
+elif exists and (mutated or wrote_files):
+    reply_text = f"Навык `{primary_skill}` уже существовал, я обновил его."
+    status = "ok"
+elif exists:
+    reply_text = f"Навык `{primary_skill}` уже существует. Могу следующим сообщением обновить его или показать текущий шаблон."
+    status = "ok"
+elif mutated and wrote_files:
+    reply_text = f"Обновил навык `{primary_skill}` и записал дополнительные файлы."
+    status = "ok"
+elif mutated:
+    reply_text = f"Обновил навык `{primary_skill}`."
+    status = "ok"
+elif wrote_files:
+    reply_text = f"Записал дополнительные файлы навыка `{primary_skill}`."
+    status = "ok"
+else:
+    reply_text = ""
+    status = "noop"
+
+print(json.dumps({
+    "status": status,
+    "reply_text": reply_text,
+    "primary_skill": primary_skill,
+    "skills_csv": ",".join(skills),
+    "operations_csv": ",".join(op["name"] for op in operations),
+}, ensure_ascii=False, separators=(",", ":")))
+PY
+}
+
 build_skill_detail_reply_text() {
     local requested_name="${1:-}"
     local resolved_name="${2:-}"
@@ -3792,7 +4146,9 @@ tool_call_has_missing_required_arguments() {
             ;;
         patch_skill)
             ! json_string_field_present_and_nonempty_from_text "$arguments_json" "name" || \
-            ! json_string_field_present_and_nonempty_from_text "$arguments_json" "instructions"
+            { ! json_array_field_has_object_entries_from_text "$arguments_json" "patches" && \
+              ! json_string_field_present_and_nonempty_from_text "$arguments_json" "instructions" && \
+              ! json_string_field_present_and_nonempty_from_text "$arguments_json" "description"; }
             ;;
         delete_skill)
             ! json_string_field_present_and_nonempty_from_text "$arguments_json" "name"
@@ -5152,6 +5508,39 @@ if [[ "$event" == "MessageSending" && -n "$effective_delivery_suppression" && "$
     write_audit_line "emit_modify event=$event reason=direct_fastpath_delivery_suppress token=$effective_delivery_suppression"
     emit_modified_payload "NO_REPLY" false
     exit 0
+fi
+
+if [[ "$event" == "AfterLLMCall" && "$is_telegram_safe_lane" == true ]] && \
+   flag_enabled "$DIRECT_FASTPATH_ENABLED" && [[ -x "$DIRECT_SEND_SCRIPT" ]] && \
+   current_turn_requires_native_skill_tools_only && \
+   tool_calls_only_direct_skill_crud_supported "$tool_calls_json"; then
+    telegram_chat_id="${system_chat_id:-${current_chat_id:-}}"
+    if [[ -n "$telegram_chat_id" ]]; then
+        direct_skill_crud_result_json="$(execute_direct_skill_tool_calls_json "$tool_calls_json" || true)"
+        direct_skill_crud_status="$(extract_json_string_field_from_text "${direct_skill_crud_result_json:-}" "status" || true)"
+        direct_skill_crud_reply_text="$(extract_json_string_field_from_text "${direct_skill_crud_result_json:-}" "reply_text" || true)"
+        direct_skill_crud_primary_skill="$(extract_json_string_field_from_text "${direct_skill_crud_result_json:-}" "primary_skill" || true)"
+        direct_skill_crud_skills_csv="$(extract_json_string_field_from_text "${direct_skill_crud_result_json:-}" "skills_csv" || true)"
+        direct_skill_crud_operations_csv="$(extract_json_string_field_from_text "${direct_skill_crud_result_json:-}" "operations_csv" || true)"
+
+        if [[ "$direct_skill_crud_status" != "noop" && -n "$direct_skill_crud_reply_text" ]]; then
+            direct_skill_crud_token="skill_native_crud:${direct_skill_crud_primary_skill:-generic}"
+            if [[ "$direct_skill_crud_status" == "error" ]]; then
+                direct_skill_crud_token="skill_native_crud_error:${direct_skill_crud_primary_skill:-generic}"
+            fi
+            if direct_fastpath_send_with_suppression \
+                "skill_native_crud" \
+                "$telegram_chat_id" \
+                "$direct_skill_crud_reply_text" \
+                "$direct_skill_crud_token" \
+                "status=$direct_skill_crud_status skills=${direct_skill_crud_skills_csv:-none} ops=${direct_skill_crud_operations_csv:-none}"; then
+                clear_turn_intent "${turn_session_key:-}"
+                write_audit_line "after_llm_direct_skill_crud status=$direct_skill_crud_status chat_id=$telegram_chat_id skill=${direct_skill_crud_primary_skill:-generic} ops=${direct_skill_crud_operations_csv:-none}"
+                emit_modified_payload "" true
+                exit 0
+            fi
+        fi
+    fi
 fi
 
 if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -2953,8 +2953,8 @@ EOF
     )"
     before_tool_patch_output="$(
         run_hook_with_minimal_path \
-            '{"event":"BeforeToolCall","data":{"session_key":"session:tool-patch","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"patch_skill","arguments":{"name":"codex-update","instructions":"Уточни описание"}}}'
-    )"
+            '{"event":"BeforeToolCall","data":{"session_key":"session:tool-patch","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"patch_skill","arguments":{"name":"codex-update","patches":[{"find":"description: updated","replace":"description: refined"}]}}}'
+        )"
     before_tool_delete_output="$(
         run_hook_with_minimal_path \
             '{"event":"BeforeToolCall","data":{"session_key":"session:tool-delete","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"delete_skill","arguments":{"name":"codex-update-old"}}}'
@@ -2989,6 +2989,26 @@ EOF
         test_pass
     else
         test_fail "BeforeToolCall guard must normalize valid read_skill argument envelopes to the native tool instead of blocking or hiding them"
+    fi
+
+    test_start "component_before_tool_guard_canonicalizes_live_create_skill_envelope_with_content_alias"
+    local before_tool_create_skill_envelope_output
+    before_tool_create_skill_envelope_output="$(
+        run_hook_with_minimal_path \
+            '{"event":"BeforeToolCall","data":{"session_key":"session:create-skill-envelope","provider":"openai-codex","model":"openai-codex::gpt-5.4","tool":"create_skill","arguments":{"_channel":{"account_id":"moltis-bot","channel_type":"telegram","chat_id":"262872984"},"_session_key":"session:create-skill-envelope","name":"moltis-update-dialog","body":"---\nname: moltis-update-dialog\ndescription: demo\n---\n# moltis-update-dialog","description":"demo","allowed_tools":["exec"]}}}'
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.tool == "create_skill"' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments.name == "moltis-update-dialog"' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments.content | contains("name: moltis-update-dialog")' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments.description == "demo"' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments | has("body") | not' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments | has("allowed_tools") | not' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments | has("_channel") | not' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output" && \
+       jq -e '.data.arguments | has("_session_key") | not' >/dev/null 2>&1 <<<"$before_tool_create_skill_envelope_output"; then
+        test_pass
+    else
+        test_fail "BeforeToolCall guard must normalize live create_skill envelopes to the official content-based contract instead of forwarding legacy body/allowed_tools fields"
     fi
 
     test_start "component_before_tool_guard_canonicalizes_valid_runtime_tool_envelopes_to_original_tools"
@@ -3349,6 +3369,128 @@ EOF
         test_pass
     else
         test_fail "AfterLLMCall guard must keep allowlisted create_skill tool calls reachable while replacing leaked internal planning with a safe progress line"
+    fi
+
+    test_start "component_after_llm_guard_direct_executes_native_skill_crud_when_direct_fastpath_is_available"
+    local after_skill_crud_direct_dir after_skill_crud_direct_runtime after_skill_crud_direct_send after_skill_crud_direct_log after_skill_crud_direct_output after_skill_crud_direct_skill_file after_skill_crud_direct_sidecar
+    after_skill_crud_direct_dir="$(secure_temp_dir telegram-safe-after-skill-crud-direct)"
+    after_skill_crud_direct_runtime="$after_skill_crud_direct_dir/runtime"
+    after_skill_crud_direct_send="$after_skill_crud_direct_dir/send.sh"
+    after_skill_crud_direct_log="$after_skill_crud_direct_dir/send.log"
+    after_skill_crud_direct_skill_file="$after_skill_crud_direct_runtime/moltis-update-dialog/SKILL.md"
+    after_skill_crud_direct_sidecar="$after_skill_crud_direct_runtime/moltis-update-dialog/notes.md"
+    cat >"$after_skill_crud_direct_send" <<'EOF'
+#!/usr/bin/env bash
+printf 'send %s\n' "$*" >>"$FASTPATH_LOG"
+exit 0
+EOF
+    chmod +x "$after_skill_crud_direct_send"
+    env PATH="$MINIMAL_PATH" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_direct_dir/intent" \
+        MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
+        bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
+{"event":"BeforeLLMCall","data":{"session_key":"session:after-skill-crud-direct","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай навык moltis-update-dialog для отслеживания новых версий Moltis и добавь заметку notes.md"}],"tool_count":37,"iteration":1}}
+EOF
+    after_skill_crud_direct_output="$(
+        env PATH="$MINIMAL_PATH:/usr/bin" \
+            FASTPATH_LOG="$after_skill_crud_direct_log" \
+            MOLTIS_RUNTIME_SKILLS_ROOT="$after_skill_crud_direct_runtime" \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$after_skill_crud_direct_send" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_direct_dir/intent" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:after-skill-crud-direct","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай навык moltis-update-dialog для отслеживания новых версий Moltis и добавь заметку notes.md"}],"text":"Сначала создам навык, потом запишу notes.md.","tool_calls":[{"name":"create_skill","arguments":{"name":"moltis-update-dialog","body":"---\nname: moltis-update-dialog\ndescription: Следит за новыми версиями Moltis.\n---\n# moltis-update-dialog\n\n## Активация\nКогда пользователь просит следить за новыми версиями Moltis, используй навык.\n","description":"Следит за новыми версиями Moltis.","allowed_tools":["exec"]}},{"name":"write_skill_files","arguments":{"name":"moltis-update-dialog","files":[{"path":"notes.md","content":"watch Moltis releases"}]}}]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_crud_direct_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$after_skill_crud_direct_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_skill_crud_direct_output" && \
+       [[ -f "$after_skill_crud_direct_skill_file" ]] && \
+       [[ -f "$after_skill_crud_direct_sidecar" ]] && \
+       grep -Fq 'description: Следит за новыми версиями Moltis.' "$after_skill_crud_direct_skill_file" && \
+       grep -Fq 'watch Moltis releases' "$after_skill_crud_direct_sidecar" && \
+       grep -Fq -- '--chat-id 262872984' "$after_skill_crud_direct_log" && \
+       grep -Fq 'Создал навык `moltis-update-dialog` и сразу доработал его.' "$after_skill_crud_direct_log"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall guard must directly execute Telegram-safe native skill CRUD, send one clean user-facing summary, and suppress the later raw tool tail"
+    fi
+
+    test_start "component_after_llm_guard_direct_executes_update_and_delete_skill_crud_when_direct_fastpath_is_available"
+    local after_skill_crud_edit_dir after_skill_crud_edit_runtime after_skill_crud_edit_send after_skill_crud_edit_log after_skill_crud_edit_update_output after_skill_crud_edit_delete_output after_skill_crud_edit_skill_file
+    after_skill_crud_edit_dir="$(secure_temp_dir telegram-safe-after-skill-crud-edit)"
+    after_skill_crud_edit_runtime="$after_skill_crud_edit_dir/runtime"
+    after_skill_crud_edit_send="$after_skill_crud_edit_dir/send.sh"
+    after_skill_crud_edit_log="$after_skill_crud_edit_dir/send.log"
+    after_skill_crud_edit_skill_file="$after_skill_crud_edit_runtime/moltis-update-dialog/SKILL.md"
+    mkdir -p "$after_skill_crud_edit_runtime/moltis-update-dialog"
+    cat >"$after_skill_crud_edit_skill_file" <<'EOF'
+---
+name: moltis-update-dialog
+description: Старая версия описания.
+---
+# moltis-update-dialog
+
+## Workflow
+- Старый текст.
+EOF
+    cat >"$after_skill_crud_edit_send" <<'EOF'
+#!/usr/bin/env bash
+printf 'send %s\n' "$*" >>"$FASTPATH_LOG"
+exit 0
+EOF
+    chmod +x "$after_skill_crud_edit_send"
+    env PATH="$MINIMAL_PATH" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_edit_dir/intent" \
+        MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,moltis-update-dialog,telegram-learner' \
+        bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
+{"event":"BeforeLLMCall","data":{"session_key":"session:after-skill-crud-edit","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Обнови навык moltis-update-dialog и потом удали его"}],"tool_count":37,"iteration":1}}
+EOF
+    after_skill_crud_edit_update_output="$(
+        env PATH="$MINIMAL_PATH:/usr/bin" \
+            FASTPATH_LOG="$after_skill_crud_edit_log" \
+            MOLTIS_RUNTIME_SKILLS_ROOT="$after_skill_crud_edit_runtime" \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$after_skill_crud_edit_send" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_edit_dir/intent" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:after-skill-crud-edit","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Обнови навык moltis-update-dialog и потом удали его"}],"text":"Сейчас обновлю навык.","tool_calls":[{"name":"update_skill","arguments":{"name":"moltis-update-dialog","description":"Новая версия описания."}}]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_crud_edit_update_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$after_skill_crud_edit_update_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_skill_crud_edit_update_output" && \
+       grep -Fq 'description: Новая версия описания.' "$after_skill_crud_edit_skill_file" && \
+       grep -Fq 'Обновил навык `moltis-update-dialog`.' "$after_skill_crud_edit_log"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall direct skill CRUD path must support update_skill edits without falling back to the broken Telegram tool boundary"
+    fi
+    env PATH="$MINIMAL_PATH" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_edit_dir/intent" \
+        MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,moltis-update-dialog,telegram-learner' \
+        bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
+{"event":"BeforeLLMCall","data":{"session_key":"session:after-skill-crud-delete","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Удали навык moltis-update-dialog"}],"tool_count":37,"iteration":1}}
+EOF
+    after_skill_crud_edit_delete_output="$(
+        env PATH="$MINIMAL_PATH:/usr/bin" \
+            FASTPATH_LOG="$after_skill_crud_edit_log" \
+            MOLTIS_RUNTIME_SKILLS_ROOT="$after_skill_crud_edit_runtime" \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$after_skill_crud_edit_send" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_edit_dir/intent" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:after-skill-crud-delete","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Удали навык moltis-update-dialog"}],"text":"Теперь удалю навык.","tool_calls":[{"name":"delete_skill","arguments":{"name":"moltis-update-dialog"}}]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_crud_edit_delete_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$after_skill_crud_edit_delete_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_skill_crud_edit_delete_output" && \
+       [[ ! -e "$after_skill_crud_edit_runtime/moltis-update-dialog" ]] && \
+       grep -Fq 'Удалил навык `moltis-update-dialog`.' "$after_skill_crud_edit_log"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall direct skill CRUD path must support delete_skill and leave no runtime skill directory behind"
     fi
 
     test_start "component_after_llm_guard_preserves_allowlisted_tavily_tool_calls_while_rewriting_progress_text"

--- a/tests/static/test_config_validation.sh
+++ b/tests/static/test_config_validation.sh
@@ -457,10 +457,12 @@ PY
        rg -Fq 'Если hook/runtime snapshot не подтверждает список навыков, честно скажи, что это не доказательство отсутствия навыков.' "$TOML_CONFIG" && \
        rg -Fq 'Для вопросов вида `какие у тебя навыки`, `что у тебя с навыками`, `skills?` сначала дай прямой список имён навыков' "$TOML_CONFIG" && \
        rg -Fq 'Для такого skill visibility ответа не ограничивайся только количеством навыков' "$TOML_CONFIG" && \
-       rg -Fq 'Для skill visibility/create/update/patch/delete в user-facing Telegram предпочитай dedicated tools `create_skill`, `update_skill`, `patch_skill`, `delete_skill`, `write_skill_files`' "$TOML_CONFIG"; then
+       rg -Fq 'Для skill visibility/create/update/patch/delete в user-facing Telegram предпочитай dedicated tools `create_skill`, `update_skill`, `patch_skill`, `delete_skill`, `write_skill_files`' "$TOML_CONFIG" && \
+       rg -Fq 'Для native skill tools соблюдай official schema: `create_skill` -> `name` + `content` (+ optional `description`), `update_skill` -> `name` + `content` (+ optional `description`), `patch_skill` -> `name` + `patches` (+ optional `description`), `delete_skill` -> `name`, `write_skill_files` -> `name` + `files`.' "$TOML_CONFIG" && \
+       rg -Fq 'Не используй legacy поля `body`, `allowed_tools` и `instructions` при вызовах `create_skill`/`update_skill`/`patch_skill`; если нужен sidecar-файл, делай это через `write_skill_files`.' "$TOML_CONFIG"; then
         test_pass
     else
-        test_fail "Primary Moltis identity prompt must prevent skill false negatives, force direct skill-name listing for visibility questions, and steer Telegram skill-authoring turns into dedicated skill tools instead of filesystem probing"
+        test_fail "Primary Moltis identity prompt must prevent skill false negatives, force direct skill-name listing for visibility questions, steer Telegram skill-authoring turns into dedicated skill tools instead of filesystem probing, and pin the official content/patches-based skill tool schema without legacy body/instructions fields"
     fi
 
     test_start "static_identity_prompt_forces_sparse_skill_create_to_use_minimal_scaffold_without_template_search"


### PR DESCRIPTION
## Что сделано
- добавлен deterministic Telegram-safe direct execution path для native skill CRUD после `AfterLLMCall`, чтобы не зависеть от live `BeforeToolCall modify`
- normalizing skill tool contract выровнен с official Moltis schema: `content`/`patches`, без legacy `body`/`allowed_tools`/`instructions`
- добавлен RCA и усилен prompt/config слой, чтобы модель реже генерировала legacy поля

## Почему
Authoritative production evidence показывал, что live Telegram runtime продолжал валидировать сырой envelope и мог отвечать `missing 'name' parameter`, даже когда hook уже подготовил очищенный payload.

## Проверки
- `./scripts/build-lessons-index.sh`
- `bash -n scripts/telegram-safe-llm-guard.sh`
- `bash tests/component/test_telegram_safe_llm_guard.sh`
- `bash tests/static/test_config_validation.sh`
