### PR TITLE
fix: route codex-update frequency phrasing to scheduler

### DIFF
--- a/docs/rca/2026-04-24-telegram-codex-update-live-frequency-phrase-was-not-classified-as-scheduler.md
+++ b/docs/rca/2026-04-24-telegram-codex-update-live-frequency-phrase-was-not-classified-as-scheduler.md
@@ -1,0 +1,90 @@
+---
+title: "Telegram codex-update live frequency phrase was not classified as scheduler"
+date: 2026-04-24
+severity: P1
+category: product
+tags: [telegram, codex-update, scheduler, frequency, uat, rca]
+root_cause: "Both the Telegram-safe guard and the authoritative Telegram UAT wrapper only recognized explicit schedule words like cron/scheduler/расписание. A natural user phrasing like `Как часто обновляется навык codex-update?` missed the scheduler branch, fell through to generic codex-update handling, and the authoritative wrapper false-passed because it used the same narrow question classifier."
+---
+
+# RCA: Telegram codex-update live frequency phrase was not classified as scheduler
+
+Date: 2026-04-24
+Status: Fixed in source and covered by regression tests
+Context: live Telegram dialogue validation for `codex-update`
+
+## Error
+
+Во время user-like проверки вопрос:
+
+```text
+Как часто обновляется навык codex-update?
+```
+
+не попал в scheduler-ветку. В live Telegram бот отвечал generic skill-detail family:
+
+```text
+codex-update — показывает, есть ли новая стабильная версия Codex CLI...
+```
+
+При этом authoritative Telegram UAT тоже возвращал `passed`, хотя ответ был не по контракту.
+
+## Lessons Pre-check
+
+Перед фиксом были перечитаны:
+
+- `docs/rca/2026-04-24-telegram-codex-update-scheduler-question-drifted-into-skill-detail-and-uat-false-pass.md`
+- `docs/rules/abnormal-skill-helper-behavior-needs-root-cause-fix.md`
+
+Вывод из pre-check:
+
+1. intent matcher в Telegram-safe lane сам является частью user-facing контракта;
+2. authoritative UAT бесполезен, если использует ту же слепую taxономию, что и runtime;
+3. для scheduler-вопросов нужен не только negative leak detector, но и positive contract match.
+
+## Root Cause
+
+Корневая причина была двойной, но одинаковой по смыслу:
+
+1. `scripts/telegram-safe-llm-guard.sh` распознавал scheduler intent только по явным токенам вроде `cron`, `scheduler`, `расписание`, `каждые`, `автопроверка`.
+2. `scripts/telegram-e2e-on-demand.sh` использовал почти тот же narrow matcher для определения, что вопрос вообще относится к scheduler contract.
+
+Из-за этого phrasing `Как часто обновляется навык codex-update?`:
+
+- не считался scheduler-вопросом;
+- уходил в generic codex-update family;
+- не активировал authoritative scheduler-contract validation;
+- давал ложнозелёный live UAT.
+
+## Fixes Applied
+
+1. `scripts/telegram-safe-llm-guard.sh`
+   - scheduler matcher расширен под natural frequency phrasing:
+     - `как часто ... обновля...`
+     - `с какой периодичностью ...`
+   - deterministic scheduler reply теперь явно называет интервал:
+     - `каждые 6 часов`
+2. `scripts/telegram-e2e-on-demand.sh`
+   - authoritative scheduler question matcher синхронизирован с runtime matcher;
+   - positive scheduler contract усилен: safe reply теперь обязан содержать explicit frequency (`каждые 6 часов`) плюс runtime boundary.
+3. `tests/component/test_telegram_safe_llm_guard.sh`
+   - добавлен regression на exact live phrase:
+     - `Как часто обновляется навык codex-update?`
+4. `tests/component/test_telegram_remote_uat_contract.sh`
+   - добавлены positive и negative regression tests на ту же exact live phrase;
+   - обновлены safe scheduler fixtures под strengthened contract.
+
+## Verification
+
+Подтверждено локально:
+
+- `bash -n scripts/telegram-safe-llm-guard.sh`
+- `bash -n scripts/telegram-e2e-on-demand.sh`
+- `bash tests/component/test_telegram_safe_llm_guard.sh` -> `165/165`
+- `bash tests/component/test_telegram_remote_uat_contract.sh` -> `67/67`
+
+## Prevention
+
+1. Для Telegram user prompts нужно покрывать не только canonical phrasing (`по какому расписанию`), но и естественные frequency-формулировки (`как часто`, `с какой периодичностью`).
+2. Authoritative UAT не должен разделять с runtime один и тот же незамеченный blind spot без positive contract checks.
+3. Если route отвечает на вопрос о расписании, ответ должен содержать сам интервал, а не только абстрактное упоминание scheduler path.

--- a/scripts/telegram-e2e-on-demand.sh
+++ b/scripts/telegram-e2e-on-demand.sh
@@ -800,7 +800,7 @@ message_is_codex_update_scheduler_query() {
     return 1
   fi
 
-  text_matches_extended_regex "$normalized" '(крон(а|у|ом)?|cron|scheduler|schedule|расписан|расписанию|регулярн|автопровер|автоматич|watcher|монитор|периодич|daemon|демон|каждые)'
+  text_matches_extended_regex "$normalized" '(крон(а|у|ом)?|cron|scheduler|schedule|расписан|расписанию|регулярн|автопровер|автоматич|watcher|монитор|периодич|daemon|демон|каждые|((как|насколько).{0,12}часто.{0,80}(обновля|проверя|срабатыва|запуска|монитор))|((с[[:space:]]+какой|какова).{0,12}(периодичност|частот).{0,80}(обновля|проверя|срабатыва|запуска|монитор)))'
 }
 
 message_is_codex_update_context_query() {
@@ -918,7 +918,7 @@ reply_has_codex_update_scheduler_memory_false_negative() {
 }
 
 reply_matches_codex_update_scheduler_contract() {
-  local normalized has_scheduler_scope=false has_runtime_boundary=false
+  local normalized has_scheduler_scope=false has_frequency=false has_runtime_boundary=false
   normalized="$(normalize_message_text "${1:-}" | tr '[:upper:]' '[:lower:]')"
   [[ -n "$normalized" ]] || return 1
 
@@ -926,11 +926,15 @@ reply_matches_codex_update_scheduler_contract() {
     has_scheduler_scope=true
   fi
 
+  if printf '%s' "$normalized" | grep -Eiq '(каждые 6 часов|раз в 6 часов|с интервалом 6 часов)'; then
+    has_frequency=true
+  fi
+
   if printf '%s' "$normalized" | grep -Eiq '(не подтверждаю по памяти|не доказывает, что live cron сейчас|подтверждено быть не может без runtime check|нужен( отдельный)? операторск(ий|ого)/runtime check|нужен runtime check|для точного статуса нужен операторский/runtime check|без runtime check|не могу подтвердить без runtime check)'; then
     has_runtime_boundary=true
   fi
 
-  [[ "$has_scheduler_scope" == true && "$has_runtime_boundary" == true ]]
+  [[ "$has_scheduler_scope" == true && "$has_frequency" == true && "$has_runtime_boundary" == true ]]
 }
 
 reply_matches_codex_update_context_contract() {

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -2506,7 +2506,7 @@ build_codex_update_scheduler_reply_text() {
         state_run_date="$(format_iso_date_short "$state_run_at" || true)"
     fi
 
-    reply_text='По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI.'
+    reply_text='По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов.'
     if [[ -n "$state_run_date" ]]; then
         reply_text="${reply_text} В сохранённом состоянии последняя проверка была ${state_run_date}, но это само по себе не доказывает, что live cron сейчас включён."
     else
@@ -2775,7 +2775,7 @@ text_looks_like_codex_update_scheduler_request() {
 
     [[ -n "$source_text" ]] || return 1
 
-    text_matches_extended_regex "$source_text" '(крон(а|у|ом)?|cron|scheduler|schedule|расписан|расписанию|регулярн|автопровер|автоматич|watcher|монитор|периодич|daemon|демон|каждые)'
+    text_matches_extended_regex "$source_text" '(крон(а|у|ом)?|cron|scheduler|schedule|расписан|расписанию|регулярн|автопровер|автоматич|watcher|монитор|периодич|daemon|демон|каждые|((как|насколько).{0,12}часто.{0,80}(обновля|проверя|срабатыва|запуска|монитор))|((с[[:space:]]+какой|какова).{0,12}(периодичност|частот).{0,80}(обновля|проверя|срабатыва|запуска|монитор)))'
 }
 
 text_looks_like_codex_update_release_request() {

--- a/tests/component/test_telegram_remote_uat_contract.sh
+++ b/tests/component/test_telegram_remote_uat_contract.sh
@@ -879,7 +879,7 @@ if [[ "$mode" == "codex_update_scheduler_safe_negative_runtime_check_pass" ]]; t
   "ok": true,
   "status": "pass",
   "stage": "wait_reply",
-  "reply_text": "Нет. По сохранённому контексту наличие такого крона подтверждено не было и подтверждено быть не может без runtime check. Для такого вывода нужен отдельный операторский/runtime check.",
+  "reply_text": "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов. Но по сохранённому контексту наличие такого крона подтверждено не было и подтверждено быть не может без runtime check. Для такого вывода нужен отдельный операторский/runtime check.",
   "reply_mid": 42,
   "sent_mid": 41,
   "checks": {
@@ -1007,7 +1007,7 @@ if [[ "$mode" == "codex_update_scheduler_contract_safe_pass" ]]; then
   "ok": true,
   "status": "pass",
   "stage": "wait_reply",
-  "reply_text": "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search.",
+  "reply_text": "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search.",
   "reply_mid": 42,
   "sent_mid": 41,
   "checks": {
@@ -2294,6 +2294,19 @@ run_component_telegram_remote_uat_contract_tests() {
         test_fail "Authoritative wrapper must classify the exact schedule phrasing as the codex-update scheduler contract"
     fi
 
+    test_start "component_telegram_remote_uat_allows_live_frequency_phrase_for_codex_update_scheduler_contract"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_contract_safe_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "Как часто обновляется навык codex-update?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-safe-live-frequency-phrase.json" \
+        >/dev/null 2>&1
+    then
+        test_pass
+    else
+        test_fail "Authoritative wrapper must classify the exact live frequency phrasing as the codex-update scheduler contract"
+    fi
+
     test_start "component_telegram_remote_uat_fails_codex_update_scheduler_question_when_reply_falls_into_skill_detail_summary"
     if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_skill_detail_false_positive_pass \
         "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
@@ -2309,6 +2322,24 @@ run_component_telegram_remote_uat_contract_tests() {
             test_pass
         else
             test_fail "Wrapper must classify codex-update scheduler questions that degrade into skill-detail wording as a scheduler contract mismatch"
+        fi
+    fi
+
+    test_start "component_telegram_remote_uat_fails_live_frequency_phrase_when_reply_falls_into_skill_detail_summary"
+    if TELEGRAM_WEB_STUB_MODE=codex_update_scheduler_skill_detail_false_positive_pass \
+        "$TEST_TMPDIR/telegram-e2e-on-demand.sh" \
+        --mode authoritative \
+        --message "Как часто обновляется навык codex-update?" \
+        --output "$TEST_TMPDIR/result-codex-update-scheduler-skill-detail-live-frequency.json" \
+        >/dev/null 2>&1
+    then
+        test_fail "Authoritative wrapper must fail when the exact live frequency phrasing gets a generic codex-update skill-detail reply"
+    else
+        if jq -e '.failure.code == "semantic_codex_update_scheduler_contract_mismatch" and .run.stage == "semantic_review"' "$TEST_TMPDIR/result-codex-update-scheduler-skill-detail-live-frequency.json" >/dev/null 2>&1
+        then
+            test_pass
+        else
+            test_fail "Wrapper must classify the exact live frequency phrasing that degrades into skill-detail wording as a scheduler contract mismatch"
         fi
     fi
 

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -966,11 +966,76 @@ EOF
        grep -Fq $'\tcodex_update:scheduler' "$codex_schedule_phrase_session_suppress" && \
        grep -Fq $'\tcodex_update:scheduler' "$codex_schedule_phrase_chat_suppress" && \
        grep -Fq 'scheduler path для регулярной проверки обновлений Codex CLI' "$codex_schedule_phrase_log" && \
+       grep -Fq 'каждые 6 часов' "$codex_schedule_phrase_log" && \
        grep -Fq 'операторский/runtime check' "$codex_schedule_phrase_log" && \
        ! grep -Fq 'После исправлений схема такая' "$codex_schedule_phrase_log"; then
         test_pass
     else
         test_fail "An explicit schedule phrasing for codex-update must stay on the scheduler contract instead of drifting into the context reply"
+    fi
+
+    test_start "component_message_received_direct_fastpath_routes_live_frequency_phrase_to_codex_update_scheduler_contract"
+    local codex_frequency_phrase_tmp codex_frequency_phrase_send_script codex_frequency_phrase_log codex_frequency_phrase_stdout codex_frequency_phrase_stderr
+    local codex_frequency_phrase_status codex_frequency_phrase_intent_dir codex_frequency_phrase_session_suppress codex_frequency_phrase_chat_suppress
+    codex_frequency_phrase_tmp="$(secure_temp_dir telegram-safe-codex-frequency-phrase)"
+    codex_frequency_phrase_send_script="$codex_frequency_phrase_tmp/send.sh"
+    codex_frequency_phrase_log="$codex_frequency_phrase_tmp/send.log"
+    codex_frequency_phrase_intent_dir="$codex_frequency_phrase_tmp/intent"
+    codex_frequency_phrase_session_suppress="$codex_frequency_phrase_intent_dir/session_codexfrequencyphrase.suppress"
+    codex_frequency_phrase_chat_suppress="$codex_frequency_phrase_intent_dir/chat-262872985.suppress"
+    cat >"$codex_frequency_phrase_send_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+chat_id=""
+text=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --chat-id)
+            chat_id="${2:-}"
+            shift 2
+            ;;
+        --text)
+            text="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf 'chat_id=%s\ntext=%s\n' "$chat_id" "$text" >"$FASTPATH_LOG"
+printf '{"ok":true}\n'
+EOF
+    chmod +x "$codex_frequency_phrase_send_script"
+    codex_frequency_phrase_stdout="$codex_frequency_phrase_tmp/stdout.log"
+    codex_frequency_phrase_stderr="$codex_frequency_phrase_tmp/stderr.log"
+    set +e
+    env PATH="$MINIMAL_PATH" \
+        FASTPATH_LOG="$codex_frequency_phrase_log" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$codex_frequency_phrase_intent_dir" \
+        MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$codex_frequency_phrase_send_script" \
+        MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_SCRIPT="$HOOK_SCRIPT" \
+        bash "$HOOK_HANDLER" >"$codex_frequency_phrase_stdout" 2>"$codex_frequency_phrase_stderr" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:codexfrequencyphrase","provider":"openai-codex","model":"gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872985 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Как часто обновляется навык codex-update?"}],"tool_count":37,"iteration":1}}
+EOF
+    codex_frequency_phrase_status=$?
+    set -e
+    if [[ "$codex_frequency_phrase_status" -eq 0 ]] && \
+       [[ ! -s "$codex_frequency_phrase_stderr" ]] && \
+       jq -e '.action == "block"' >/dev/null 2>&1 "$codex_frequency_phrase_stdout" && \
+       [[ -f "$codex_frequency_phrase_session_suppress" ]] && \
+       [[ -f "$codex_frequency_phrase_chat_suppress" ]] && \
+       grep -Fq $'\tcodex_update:scheduler' "$codex_frequency_phrase_session_suppress" && \
+       grep -Fq $'\tcodex_update:scheduler' "$codex_frequency_phrase_chat_suppress" && \
+       grep -Fq 'scheduler path для регулярной проверки обновлений Codex CLI' "$codex_frequency_phrase_log" && \
+       grep -Fq 'каждые 6 часов' "$codex_frequency_phrase_log" && \
+       grep -Fq 'операторский/runtime check' "$codex_frequency_phrase_log" && \
+       ! grep -Fq 'После исправлений схема такая' "$codex_frequency_phrase_log"; then
+        test_pass
+    else
+        test_fail "The exact live frequency phrasing for codex-update must route to the scheduler contract instead of generic skill-detail or release wording"
     fi
 
     test_start "component_codex_update_direct_fastpath_handles_array_message_content_from_live_payload"
@@ -1319,7 +1384,7 @@ EOF
     codex_terminal_marker="$codex_terminal_intent_dir/session_codex-terminal.terminal"
     codex_terminal_session_suppress="$codex_terminal_intent_dir/session_codex-terminal.suppress"
     codex_terminal_chat_suppress="$codex_terminal_intent_dir/chat-262872984.suppress"
-    codex_terminal_reply_text='По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search.'
+    codex_terminal_reply_text='По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search.'
     codex_terminal_before_output="$(
         env PATH="$MINIMAL_PATH" \
             MOLTIS_CODEX_UPDATE_RELEASE_JSON='{"tag_name":"0.118.0","published_at":"2026-04-01T12:00:00Z"}' \
@@ -2400,7 +2465,7 @@ EOF
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$clean_codex_update_scheduler_output" && \
-       jq -e '.data.text == "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search."' >/dev/null 2>&1 <<<"$clean_codex_update_scheduler_output" && \
+       jq -e '.data.text == "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search."' >/dev/null 2>&1 <<<"$clean_codex_update_scheduler_output" && \
        jq -e '.data.account_id == "moltis-bot"' >/dev/null 2>&1 <<<"$clean_codex_update_scheduler_output" && \
        jq -e '.data.to == "262872984"' >/dev/null 2>&1 <<<"$clean_codex_update_scheduler_output" && \
        jq -e '.data.reply_to_message_id == 1295' >/dev/null 2>&1 <<<"$clean_codex_update_scheduler_output"; then
@@ -2438,7 +2503,7 @@ EOF
     if [[ "$dirty_codex_update_scheduler_status" -eq 0 ]] && \
        [[ ! -s "$dirty_codex_update_scheduler_stderr" ]] && \
        jq -e '.action == "modify"' >/dev/null 2>&1 <"$dirty_codex_update_scheduler_stdout" && \
-       jq -e '.data.text == "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search."' >/dev/null 2>&1 <"$dirty_codex_update_scheduler_stdout" && \
+       jq -e '.data.text == "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search."' >/dev/null 2>&1 <"$dirty_codex_update_scheduler_stdout" && \
        jq -e '.data.reply_to_message_id == 1296' >/dev/null 2>&1 <"$dirty_codex_update_scheduler_stdout" && \
        [[ ! -s "$dirty_codex_update_scheduler_log" ]]; then
         test_pass
@@ -3810,7 +3875,7 @@ EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_llm_codex_update_scheduler_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_llm_codex_update_scheduler_output" && \
-       jq -e '.data.text == "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search."' >/dev/null 2>&1 <<<"$after_llm_codex_update_scheduler_output"; then
+       jq -e '.data.text == "По проектному контракту у codex-update есть отдельный scheduler path для регулярной проверки обновлений Codex CLI каждые 6 часов. Но в Telegram-safe чате я не подтверждаю по памяти, что live cron сейчас действительно включён. Для точного статуса нужен операторский/runtime check, а не memory search."' >/dev/null 2>&1 <<<"$after_llm_codex_update_scheduler_output"; then
         test_pass
     else
         test_fail "AfterLLMCall guard must rewrite a clean codex-update scheduler false negative into the canonical deterministic reply"
@@ -4429,6 +4494,7 @@ EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
        jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
+       jq -e '.data.text | contains("каждые 6 часов")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
        jq -e '.data.text | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
        jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$codex_update_scheduler_after_output" && \
@@ -4470,6 +4536,7 @@ EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
        jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
+       jq -e '.data.text | contains("каждые 6 часов")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
        jq -e '.data.text | contains("не подтверждаю по памяти")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
        jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
        jq -e '.data.reply_to_message_id == 964' >/dev/null 2>&1 <<<"$codex_update_scheduler_message_output" && \
@@ -4493,6 +4560,7 @@ EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$codex_update_stale_context_output" && \
        jq -e '.data.text | contains("scheduler path для регулярной проверки обновлений Codex CLI")' >/dev/null 2>&1 <<<"$codex_update_stale_context_output" && \
+       jq -e '.data.text | contains("каждые 6 часов")' >/dev/null 2>&1 <<<"$codex_update_stale_context_output" && \
        jq -e '.data.text | contains("операторский/runtime check")' >/dev/null 2>&1 <<<"$codex_update_stale_context_output" && \
        jq -e '.data.reply_to_message_id == 966' >/dev/null 2>&1 <<<"$codex_update_stale_context_output" && \
        jq -e '.data.text | test("После исправлений схема такая|last_alert_fingerprint|suppressed") | not' >/dev/null 2>&1 <<<"$codex_update_stale_context_output"; then


### PR DESCRIPTION
## Summary\n- classify natural codex-update frequency phrasing as scheduler intent in Telegram-safe runtime\n- strengthen authoritative scheduler contract to require an explicit interval\n- add regressions for the exact live phrase `Как часто обновляется навык codex-update?` and document the RCA\n\n## Validation\n- bash -n scripts/telegram-safe-llm-guard.sh\n- bash -n scripts/telegram-e2e-on-demand.sh\n- bash tests/component/test_telegram_safe_llm_guard.sh\n- bash tests/component/test_telegram_remote_uat_contract.sh