### PR TITLE
Fix Telegram sparse create persisted recovery

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-24
-**Total Lessons**: 93
+**Total Lessons**: 94
 
 ---
 
@@ -14,8 +14,9 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (46 lessons)
+#### P1 (47 lessons)
 - [Telegram sparse skill create could still go silent because empty LLM turns had no repo-owned recovery](../docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md)
+- [Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent](../docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md)
 - [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
 - [Telegram Web probe collapsed multiline /status replies before exact semantic review](../docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
@@ -197,8 +198,9 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (9 lessons)
+#### product (10 lessons)
 - [Telegram sparse skill create could still go silent because empty LLM turns had no repo-owned recovery](../docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md)
+- [Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent](../docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md)
 - [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
@@ -230,16 +232,16 @@
 
 ### Popular Tags
 
-- `rca` (39 lessons)
-- `telegram` (29 lessons)
+- `rca` (40 lessons)
+- `telegram` (30 lessons)
 - `moltis` (28 lessons)
 - `deploy` (20 lessons)
 - `github-actions` (18 lessons)
-- `skills` (16 lessons)
+- `skills` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
-- `hooks` (14 lessons)
-- `beads` (12 lessons)
+- `hooks` (15 lessons)
+- `runtime` (12 lessons)
 
 
 ---
@@ -248,10 +250,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 93 |
-| Critical (P0/P1) | 47 |
+| Total Lessons | 94 |
+| Critical (P0/P1) | 48 |
 | Categories | 8 |
-| Unique Tags | 181 |
+| Unique Tags | 182 |
 
 ---
 

--- a/docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md
+++ b/docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md
@@ -1,0 +1,109 @@
+---
+title: "Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent"
+date: 2026-04-24
+severity: P1
+category: product
+tags: [telegram, skills, hooks, runtime, create-skill, sparse-create, persisted-intent, rca]
+root_cause: "The repo had already added an AfterLLMCall recovery for sparse Telegram skill create, but that recovery still reconstructed its target name from the current AfterLLMCall payload. Live Telegram runs can omit the user message entirely on that phase, so the turn still ended silent unless CRUD mode and target name were persisted and rehydrated from repo-owned state."
+---
+
+# RCA: Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent
+
+**Дата:** 2026-04-24
+**Статус:** Resolved
+**Влияние:** После предыдущего ремонта Telegram skill create всё ещё мог завершиться `bot_no_response`: пользователь отправлял валидный запрос на создание навыка, но live `AfterLLMCall` приходил без user message, имя навыка повторно не извлекалось, навык не создавался, ответ не уходил.
+**Контекст:** `scripts/telegram-safe-llm-guard.sh`, authoritative Telegram Remote UAT, production logs for live sparse create, persisted turn intent contract `skill_native_crud`.
+
+## Ошибка
+
+Предыдущий fix уже закрыл один дефект:
+
+- пустой `AfterLLMCall` больше не считался допустимым silent turn;
+- guard умел синтезировать minimal `create_skill`;
+- архитектурно recovery жил в owning `AfterLLMCall` layer, а не в старом `BeforeLLMCall` shortcut.
+
+Но authoritative production/UAT показали ещё один live-only разрыв:
+
+- на `BeforeLLMCall` пользовательский текст и имя нового навыка были видны;
+- на позднем `AfterLLMCall` live payload иногда содержал только system messages;
+- recovery branch продолжал опираться на `requested_skill_name`, повторно извлекаемый из текущего payload;
+- из-за этого ветка `sparse create recovery` не срабатывала, хотя persisted intent уже доказывал, что turn относится к native skill CRUD и это именно `create`.
+
+Итог: user intent был корректно классифицирован, но recovery не имел достаточного repo-owned состояния, чтобы завершить turn без повторного чтения исчезнувшего user message.
+
+## Проверка прошлых уроков
+
+Перед фиксом были повторно проверены:
+
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag skills`
+- `docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md`
+- `docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md`
+- `docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md`
+
+Релевантные уже закреплённые уроки:
+
+1. Telegram-safe critical path нельзя считать починенным, пока live runtime не доказан authoritative UAT, а не только локальным component coverage.
+2. Для Telegram runtime `hook emitted correct JSON` и `runtime supplied the same payload shape on the next phase` — разные утверждения.
+3. Если owning layer уже взял под контроль critical turn, recovery должен опираться на repo-owned state, а не на повторное везение с upstream payload shape.
+
+Что было новым:
+
+- предыдущий sparse-create fix предполагал, что live `AfterLLMCall` всё ещё несёт user message, хотя authoritative production path это опроверг;
+- persisted contract `skill_native_crud` был слишком бедным: он сохранял класс turn, но не сохранял достаточно данных для late recovery;
+- отдельно вскрылся вторичный drift: persisted native CRUD turn не должен уходить в чистый Tavily/search path, если live модель снова свернула в чужой tool family.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---|---|---|---|
+| 1 | Почему после прошлого sparse-create fix Telegram всё ещё иногда не отвечал? | Потому что live `AfterLLMCall` мог прийти без user message, и recovery не мог повторно извлечь имя навыка. | Authoritative UAT run `24870123224` ended with `bot_no_response`; production logs showed `has_text=false`, `tool_calls_count=0`, `silent=true`, and no created skill file for the requested slug. |
+| 2 | Почему recovery не взял имя навыка из уже сохранённого состояния? | Потому что persisted turn intent хранил только общий маркер `skill_native_crud`, без режима и target slug. | `scripts/telegram-safe-llm-guard.sh` before fix restored only coarse turn intent; sparse recovery still depended on current `requested_skill_name`. |
+| 3 | Почему это не поймали локально раньше? | Потому что локальный regression fixture для `AfterLLMCall` всё ещё содержал user message и тем самым скрывал live payload drift. | Local test passed before live UAT; updated regression that removes user message from `AfterLLMCall` failed until persisted CRUD hydration was added. |
+| 4 | Почему простой reply suppression не решал проблему? | Потому что defect был не в грязном тексте, а в отсутствии достаточного repo-owned execution context для owned recovery branch. | No duplicate/leak message was sent; the turn simply ended silent without creating the skill. |
+| 5 | Какой source fix нужен был на самом деле? | Нужно было расширить persisted CRUD intent до режима и target name, гидрировать его на поздних фазах и использовать как authoritative fallback context; для чистого Tavily drift на persisted CRUD turn нужно fail-close, а не разрешать уводить turn в search tools. | New fix persists `skill_native_crud:create:<slug>`-style intent, restores name/mode on `AfterLLMCall`, and strips pure Tavily tool calls for persisted CRUD turns. |
+
+## Корневая причина
+
+Owning layer defect был в неполном persisted-state contract для Telegram-safe skill CRUD.
+
+Репозиторий уже перенёс sparse create recovery в deterministic `AfterLLMCall` layer, но сохранил скрытое предположение: будто текущий `AfterLLMCall` всегда позволит заново вычислить target skill name из live payload. В production это неверно. Когда upstream payload терял user message, repo-owned recovery фактически оставался без собственных данных для завершения create-turn.
+
+Иными словами: проблема была уже не в отсутствии recovery как такового, а в том, что recovery всё ещё зависел от неавторитетного upstream payload shape вместо repo-owned persisted CRUD context.
+
+## Принятые меры
+
+1. Persisted native CRUD turn intent расширен до backward-compatible форм:
+   - `skill_native_crud`
+   - `skill_native_crud:create:<name>`
+   - `skill_native_crud:update:<name>`
+   - `skill_native_crud:delete:<name>`
+2. Добавлена гидрация persisted CRUD state на поздних hook phases:
+   - восстанавливаются `mode`, `target skill name`, `sparse create` flag;
+   - если текущий payload не содержит user message, recovery всё равно видит нужный slug.
+3. Sparse create `AfterLLMCall` recovery теперь использует effective context:
+   - `current sparse create OR persisted sparse create`
+   - `current requested skill name OR persisted CRUD target`.
+4. Для persisted native CRUD turn добавлен fail-closed branch против pure Tavily/search drift:
+   - чистые Tavily tool calls не допускаются внутри Telegram-safe skill CRUD turn;
+   - пользователю возвращается deterministic объяснение, а не ложный browser/search path.
+5. Component regression обновлён под реальный live payload:
+   - `AfterLLMCall` fixture больше не содержит user message;
+   - test доказывает, что skill реально создаётся и direct reply уходит даже при таком payload.
+
+## Уроки
+
+1. Persisted intent для Telegram-safe critical flow должен хранить не только класс turn, но и минимальный execution context, необходимый для late recovery.
+2. Если live runtime может менять payload shape между hook phases, recovery нельзя строить на повторном парсинге тех же user fields из следующей фазы.
+3. Для native skill CRUD persisted context должен защищать не только от silent hole, но и от дрейфа в нерелевантные search/browser tools.
+
+## Regression Test
+
+**Test File:** `tests/component/test_telegram_safe_llm_guard.sh`
+
+**Test Status:**
+
+- [x] Test created
+- [x] Test reproduces live `AfterLLMCall` without user message
+- [x] Fix applied
+- [x] Test passes

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -2092,6 +2092,66 @@ clear_turn_intent() {
     rm -f "$intent_file" 2>/dev/null || true
 }
 
+format_skill_native_crud_turn_intent() {
+    local crud_mode="${1:-generic}"
+    local skill_name="${2:-}"
+
+    case "$crud_mode" in
+        create|update|delete|generic)
+            ;;
+        *)
+            crud_mode="generic"
+            ;;
+    esac
+
+    if [[ -n "$skill_name" ]]; then
+        printf 'skill_native_crud:%s:%s' "$crud_mode" "$skill_name"
+        return 0
+    fi
+
+    if [[ "$crud_mode" != "generic" ]]; then
+        printf 'skill_native_crud:%s' "$crud_mode"
+        return 0
+    fi
+
+    printf 'skill_native_crud'
+}
+
+hydrate_persisted_skill_native_crud_state() {
+    local intent_name="${1:-}"
+
+    persisted_skill_native_crud_request=false
+    persisted_sparse_skill_create_request=false
+    persisted_skill_native_crud_mode=""
+    persisted_skill_native_crud_name=""
+
+    case "${intent_name:-}" in
+        skill_native_crud)
+            persisted_skill_native_crud_request=true
+            persisted_skill_native_crud_mode="generic"
+            ;;
+        skill_native_crud:*)
+            persisted_skill_native_crud_request=true
+            if [[ "$intent_name" =~ ^skill_native_crud:([a-z]+):([A-Za-z0-9._-]+)$ ]]; then
+                persisted_skill_native_crud_mode="${BASH_REMATCH[1]}"
+                persisted_skill_native_crud_name="${BASH_REMATCH[2]}"
+            elif [[ "$intent_name" =~ ^skill_native_crud:([a-z]+)$ ]]; then
+                persisted_skill_native_crud_mode="${BASH_REMATCH[1]}"
+            else
+                persisted_skill_native_crud_mode="generic"
+            fi
+            ;;
+    esac
+
+    if [[ "$persisted_skill_native_crud_request" == true && -z "$persisted_skill_native_crud_mode" ]]; then
+        persisted_skill_native_crud_mode="generic"
+    fi
+
+    if [[ "$persisted_skill_native_crud_mode" == "create" ]]; then
+        persisted_sparse_skill_create_request=true
+    fi
+}
+
 discover_runtime_skill_names_csv() {
     local csv_override="${MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES:-}"
     local runtime_root="${MOLTIS_RUNTIME_SKILLS_ROOT:-/home/moltis/.moltis/skills}"
@@ -4235,7 +4295,7 @@ current_turn_requires_native_skill_tools_only() {
         return 1
     fi
 
-    if [[ "${current_turn_skill_mutation_request:-false}" == true || "${looks_like_sparse_skill_create_request:-false}" == true || "${persisted_skill_native_crud_request:-false}" == true || "${persisted_turn_intent:-}" == "skill_native_crud" ]]; then
+    if [[ "${current_turn_skill_mutation_request:-false}" == true || "${looks_like_sparse_skill_create_request:-false}" == true || "${persisted_skill_native_crud_request:-false}" == true ]]; then
         return 0
     fi
 
@@ -4348,6 +4408,22 @@ tool_calls_only_tavily_allowlisted() {
     if current_turn_requires_native_skill_tools_only; then
         return 1
     fi
+
+    while IFS= read -r tool_name; do
+        [[ -n "$tool_name" ]] || continue
+        saw_name=true
+        if ! tool_name_is_tavily_allowlisted "$tool_name"; then
+            return 1
+        fi
+    done < <(extract_tool_call_names "$tool_calls_json" || true)
+
+    $saw_name
+}
+
+tool_calls_only_tavily_allowlisted_unchecked() {
+    local tool_calls_json="${1:-}"
+    local saw_name=false
+    local tool_name=""
 
     while IFS= read -r tool_name; do
         [[ -n "$tool_name" ]] || continue
@@ -4909,10 +4985,6 @@ requested_skill_reference_name="$(extract_referenced_skill_candidate "${latest_u
 skill_runtime_snapshot_csv="$(discover_runtime_skill_names_csv || true)"
 resolved_skill_name="$(resolve_runtime_skill_name_from_text "${latest_user_message:-${user_message:-}}" "$skill_runtime_snapshot_csv" || true)"
 requested_skill_name="$(extract_requested_skill_name "${latest_user_message:-${user_message:-}}" || true)"
-requested_skill_name_re=""
-if [[ -n "$requested_skill_name" ]]; then
-    requested_skill_name_re="$(printf '%s' "$requested_skill_name" | sed 's/[][(){}.^$?+*|\\/]/\\&/g')"
-fi
 legacy_skill_create_intent=false
 persisted_skill_create_state=""
 persisted_skill_create_name=""
@@ -4942,7 +5014,6 @@ persisted_codex_update_scheduler_request=false
 persisted_codex_update_context_request=false
 persisted_codex_update_maintenance_request=false
 persisted_generic_maintenance_request=false
-persisted_skill_native_crud_request=false
 case "${persisted_turn_intent:-}" in
     codex_update)
         persisted_codex_update_request=true
@@ -4961,10 +5032,8 @@ case "${persisted_turn_intent:-}" in
     maintenance_generic)
         persisted_generic_maintenance_request=true
         ;;
-    skill_native_crud)
-        persisted_skill_native_crud_request=true
-        ;;
 esac
+hydrate_persisted_skill_native_crud_state "${persisted_turn_intent:-}"
 if [[ -z "$resolved_skill_name" && -n "$persisted_skill_detail_name" ]]; then
     resolved_skill_name="$persisted_skill_detail_name"
 fi
@@ -4973,6 +5042,13 @@ if [[ -z "$resolved_skill_name" && -n "$persisted_skill_maintenance_name" && "$p
 fi
 if [[ -z "$requested_skill_reference_name" && -n "$resolved_skill_name" ]]; then
     requested_skill_reference_name="$resolved_skill_name"
+fi
+if [[ -z "$requested_skill_name" && -n "$persisted_skill_native_crud_name" ]]; then
+    requested_skill_name="$persisted_skill_native_crud_name"
+fi
+requested_skill_name_re=""
+if [[ -n "$requested_skill_name" ]]; then
+    requested_skill_name_re="$(printf '%s' "$requested_skill_name" | sed 's/[][(){}.^$?+*|\\/]/\\&/g')"
 fi
 if [[ "$codex_update_subject_request" != true ]] && printf '%s' "$intent_text_flat" | grep -Eiq '(codex([[:space:]]+cli)?|codex-update)'; then
     codex_update_subject_request=true
@@ -5219,7 +5295,19 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     elif [[ "$current_turn_skill_maintenance_request" == true ]]; then
         next_turn_intent="skill_maintenance:${resolved_skill_name:-${requested_skill_reference_name:-generic}}"
     elif [[ "$current_turn_skill_mutation_request" == true || "$looks_like_sparse_skill_create_request" == true ]]; then
-        next_turn_intent="skill_native_crud"
+        next_skill_native_crud_mode="generic"
+        next_skill_native_crud_name="${requested_skill_name:-${resolved_skill_name:-${requested_skill_reference_name:-}}}"
+
+        if [[ "$looks_like_sparse_skill_create_request" == true ]]; then
+            next_skill_native_crud_mode="create"
+            next_skill_native_crud_name="${requested_skill_name:-}"
+        elif printf '%s' "$intent_text_flat" | grep -Eiq '(^|[^[:alnum:]_])(удали(ть|м)?|delete|remove)([^[:alnum:]_]|$)'; then
+            next_skill_native_crud_mode="delete"
+        elif printf '%s' "$intent_text_flat" | grep -Eiq '(^|[^[:alnum:]_])(обнов(и|им|ить)|измени(ть|м)|редактир(уй|овать|уйте)?|патч(ь|ить)|перепиш(и|ем|ите|у)|update|patch|edit|rewrite)([^[:alnum:]_]|$)'; then
+            next_skill_native_crud_mode="update"
+        fi
+
+        next_turn_intent="$(format_skill_native_crud_turn_intent "$next_skill_native_crud_mode" "$next_skill_native_crud_name")"
     elif [[ "$current_turn_codex_update_request" == true ]]; then
         next_turn_intent="$(codex_update_intent_name_for_mode "$(determine_codex_update_reply_mode "$current_turn_codex_update_context_request" "$current_turn_codex_update_scheduler_request")")"
     elif [[ "$current_turn_skill_detail_request" == true && -n "${resolved_skill_name:-}" ]]; then
@@ -5248,7 +5336,6 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
     persisted_codex_update_context_request=false
     persisted_codex_update_maintenance_request=false
     persisted_generic_maintenance_request=false
-    persisted_skill_native_crud_request=false
     case "${persisted_turn_intent:-}" in
         codex_update)
             persisted_codex_update_request=true
@@ -5267,10 +5354,8 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         maintenance_generic)
             persisted_generic_maintenance_request=true
             ;;
-        skill_native_crud)
-            persisted_skill_native_crud_request=true
-            ;;
     esac
+    hydrate_persisted_skill_native_crud_state "${persisted_turn_intent:-}"
 
     if [[ -n "$effective_delivery_suppression" && "$has_current_user_turn" == true && "$current_iteration" =~ ^[0-9]+$ ]] && (( current_iteration > 1 )); then
         write_audit_line "before_block reason=direct_fastpath_repeat_guard token=$effective_delivery_suppression iteration=$current_iteration"
@@ -5564,14 +5649,20 @@ if [[ "$event" == "MessageSending" && -n "$effective_delivery_suppression" && "$
     exit 0
 fi
 
+effective_sparse_skill_create_request=false
+if [[ "$current_turn_sparse_skill_create_request" == true || "$persisted_sparse_skill_create_request" == true ]]; then
+    effective_sparse_skill_create_request=true
+fi
+sparse_skill_create_target_name="${requested_skill_name:-${persisted_skill_native_crud_name:-}}"
+
 if [[ "$event" == "AfterLLMCall" && "$is_telegram_safe_lane" == true ]] && \
    flag_enabled "$DIRECT_FASTPATH_ENABLED" && [[ -x "$DIRECT_SEND_SCRIPT" ]] && \
    current_turn_requires_native_skill_tools_only && \
-   [[ "$current_turn_sparse_skill_create_request" == true ]] && \
+   [[ "$effective_sparse_skill_create_request" == true ]] && \
    [[ "$tool_calls_present" != true ]] && \
-   [[ -n "${requested_skill_name:-}" ]] && \
+   [[ -n "${sparse_skill_create_target_name:-}" ]] && \
    [[ -z "${response_text_flat:-}" ]]; then
-    sparse_skill_create_fallback_tool_calls_json="$(build_sparse_skill_create_fallback_tool_calls_json "${requested_skill_name:-}" || true)"
+    sparse_skill_create_fallback_tool_calls_json="$(build_sparse_skill_create_fallback_tool_calls_json "${sparse_skill_create_target_name:-}" || true)"
     if attempt_direct_skill_crud_after_llm_fastpath "${sparse_skill_create_fallback_tool_calls_json:-}" "sparse_create_empty_turn"; then
         exit 0
     fi
@@ -5714,6 +5805,13 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
 fi
 
 if [[ "$event" == "AfterLLMCall" && "$tool_calls_allowlisted_only" == true && ( "$tool_calls_present" == true || "$has_delivery_internal_telemetry" == true || "$has_after_llm_tool_intent" == true || "$has_user_visible_internal_planning" == true || "$has_skill_path_false_negative" == true ) ]]; then
+    if [[ "$is_telegram_safe_lane" == true ]] && current_turn_requires_native_skill_tools_only && tool_calls_only_tavily_allowlisted_unchecked "$tool_calls_json"; then
+        fallback_text='В Telegram-safe режиме я не запускаю инструменты browser/search внутри skill CRUD turn. Продолжим через skill-tools или web UI без Tavily-поиска.'
+        write_audit_line "emit_modify event=$event reason=skill_native_crud_tavily_fail_closed tool_calls_present=$tool_calls_present"
+        emit_modified_payload "$fallback_text" true
+        exit 0
+    fi
+
     fallback_text='Выполняю запрос через встроенные инструменты без показа внутренних логов. После завершения вернусь с итогом.'
     if tool_calls_only_skill_allowlisted "$tool_calls_json"; then
         fallback_text='Выполняю запрос по навыкам через встроенные инструменты без filesystem-проб. После завершения вернусь с итогом.'

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -209,7 +209,7 @@ EOF
        jq -e '.data.messages[1].content | contains("Telegram-safe skill-authoring contract")' >/dev/null 2>&1 <<<"$maintenance_to_create_output" && \
        jq -e '.data.messages[2].content | contains("Telegram-safe sparse create-skill override")' >/dev/null 2>&1 <<<"$maintenance_to_create_output" && \
        jq -e '([.data.messages[].content] | join("\n")) | contains("не чиню и не отлаживаю") | not' >/dev/null 2>&1 <<<"$maintenance_to_create_output" && \
-       [[ "$maintenance_to_create_intent" == *$'\tskill_native_crud\t'* ]]; then
+       ([[ "$maintenance_to_create_intent" == *$'\tskill_native_crud\t'* ]] || [[ "$maintenance_to_create_intent" == *$'\tskill_native_crud:'* ]]); then
         test_pass
     else
         test_fail "BeforeLLMCall guard must replace stale maintenance intent with the native skill CRUD lane when the latest user turn is a plain create-skill request"
@@ -2764,7 +2764,7 @@ EOF
        jq -e '.data.messages[1].content | contains("Telegram-safe skill-authoring contract")' >/dev/null 2>&1 <<<"$stale_visibility_create_output" && \
        jq -e '.data.messages[2].content | contains("Telegram-safe sparse create-skill override")' >/dev/null 2>&1 <<<"$stale_visibility_create_output" && \
        [[ ! -f "$stale_visibility_create_file" ]] && \
-       [[ "$stale_visibility_create_intent" == *$'\tskill_native_crud\t'* ]]; then
+       ([[ "$stale_visibility_create_intent" == *$'\tskill_native_crud\t'* ]] || [[ "$stale_visibility_create_intent" == *$'\tskill_native_crud:'* ]]); then
         test_pass
     else
         test_fail "BeforeLLMCall guard must keep create follow-ups on the native tool lane, clear stale visibility intent, and persist only the current native CRUD lane without scaffold writes"
@@ -3481,8 +3481,8 @@ EOF
         test_fail "AfterLLMCall guard must directly execute Telegram-safe native skill CRUD, send one clean user-facing summary, and suppress the later raw tool tail"
     fi
 
-    test_start "component_after_llm_guard_recovers_sparse_skill_create_when_llm_returns_empty_turn"
-    local after_sparse_create_empty_dir after_sparse_create_empty_runtime after_sparse_create_empty_send after_sparse_create_empty_log after_sparse_create_empty_output after_sparse_create_empty_skill_file
+    test_start "component_after_llm_guard_recovers_sparse_skill_create_when_live_after_llm_payload_omits_user_message"
+    local after_sparse_create_empty_dir after_sparse_create_empty_runtime after_sparse_create_empty_send after_sparse_create_empty_log after_sparse_create_empty_output after_sparse_create_empty_skill_file after_sparse_create_empty_before_intent
     after_sparse_create_empty_dir="$(secure_temp_dir telegram-safe-after-sparse-create-empty)"
     after_sparse_create_empty_runtime="$after_sparse_create_empty_dir/runtime"
     after_sparse_create_empty_send="$after_sparse_create_empty_dir/send.sh"
@@ -3500,6 +3500,7 @@ EOF
         bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
 {"event":"BeforeLLMCall","data":{"session_key":"session:after-sparse-create-empty","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай новый навык moltis-version-watch-20260424 для автоматического отслеживания новой версии Moltis."}],"tool_count":37,"iteration":1}}
 EOF
+    after_sparse_create_empty_before_intent="$(cat "$after_sparse_create_empty_dir/intent/session_after-sparse-create-empty.intent" 2>/dev/null || true)"
     after_sparse_create_empty_output="$(
         env PATH="$MINIMAL_PATH:/usr/bin" \
             FASTPATH_LOG="$after_sparse_create_empty_log" \
@@ -3508,18 +3509,19 @@ EOF
             MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$after_sparse_create_empty_send" \
             MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_sparse_create_empty_dir/intent" \
             bash "$HOOK_SCRIPT" <<'EOF'
-{"event":"AfterLLMCall","data":{"session_key":"session:after-sparse-create-empty","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай новый навык moltis-version-watch-20260424 для автоматического отслеживания новой версии Moltis."}],"text":"","tool_calls":[]}}
+{"event":"AfterLLMCall","data":{"session_key":"session:after-sparse-create-empty","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"system","content":"The current user datetime is 2026-04-24 06:07:59 MSK."}],"text":"","tool_calls":[]}}
 EOF
     )"
     if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_sparse_create_empty_output" && \
        jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$after_sparse_create_empty_output" && \
        jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_sparse_create_empty_output" && \
        [[ -f "$after_sparse_create_empty_skill_file" ]] && \
+       [[ "$after_sparse_create_empty_before_intent" == *$'\tskill_native_crud:create:moltis-version-watch-20260424\t'* ]] && \
        grep -Fq 'name: moltis-version-watch-20260424' "$after_sparse_create_empty_skill_file" && \
        grep -Fq 'Создал базовый шаблон навыка `moltis-version-watch-20260424`.' "$after_sparse_create_empty_log"; then
         test_pass
     else
-        test_fail "AfterLLMCall guard must recover sparse Telegram skill creation when the model returns an empty turn, so valid create requests do not end in a silent hole"
+        test_fail "AfterLLMCall guard must recover sparse Telegram skill creation even when the live-shaped AfterLLMCall payload omits the user message, so valid create requests do not end in a silent hole"
     fi
 
     test_start "component_after_llm_guard_direct_executes_update_and_delete_skill_crud_when_direct_fastpath_is_available"


### PR DESCRIPTION
## Summary
- persist native Telegram skill CRUD intent with mode and target name for late recovery
- recover sparse create even when live AfterLLMCall omits the user message
- fail closed when a persisted native CRUD turn drifts into pure Tavily/search tools

## Validation
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_remote_uat_contract.sh
- git diff --check