### PR TITLE
Fix Telegram sparse create history contamination

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-24
-**Total Lessons**: 95
+**Total Lessons**: 96
 
 ---
 
@@ -14,10 +14,11 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (48 lessons)
+#### P1 (49 lessons)
 - [Telegram skill CRUD fastpath depended on JSON field order when extracting tool call names](../docs/rca/2026-04-24-telegram-tool-call-name-extraction-depended-on-json-field-order.md)
 - [Telegram sparse skill create could still go silent because empty LLM turns had no repo-owned recovery](../docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md)
 - [Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent](../docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md)
+- [Telegram sparse skill create replayed stale create-skill failure from contaminated history](../docs/rca/2026-04-24-telegram-sparse-create-history-replayed-stale-failure.md)
 - [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
 - [Telegram Web probe collapsed multiline /status replies before exact semantic review](../docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
@@ -199,10 +200,11 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (11 lessons)
+#### product (12 lessons)
 - [Telegram skill CRUD fastpath depended on JSON field order when extracting tool call names](../docs/rca/2026-04-24-telegram-tool-call-name-extraction-depended-on-json-field-order.md)
 - [Telegram sparse skill create could still go silent because empty LLM turns had no repo-owned recovery](../docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md)
 - [Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent](../docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md)
+- [Telegram sparse skill create replayed stale create-skill failure from contaminated history](../docs/rca/2026-04-24-telegram-sparse-create-history-replayed-stale-failure.md)
 - [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
@@ -234,16 +236,16 @@
 
 ### Popular Tags
 
-- `rca` (41 lessons)
-- `telegram` (31 lessons)
+- `rca` (42 lessons)
+- `telegram` (32 lessons)
 - `moltis` (28 lessons)
 - `deploy` (20 lessons)
-- `skills` (18 lessons)
+- `skills` (19 lessons)
 - `github-actions` (18 lessons)
-- `hooks` (16 lessons)
+- `hooks` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
-- `runtime` (13 lessons)
+- `runtime` (14 lessons)
 
 
 ---
@@ -252,10 +254,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 95 |
-| Critical (P0/P1) | 49 |
+| Total Lessons | 96 |
+| Critical (P0/P1) | 50 |
 | Categories | 8 |
-| Unique Tags | 185 |
+| Unique Tags | 187 |
 
 ---
 

--- a/docs/rca/2026-04-24-telegram-sparse-create-history-replayed-stale-failure.md
+++ b/docs/rca/2026-04-24-telegram-sparse-create-history-replayed-stale-failure.md
@@ -1,0 +1,106 @@
+---
+title: "Telegram sparse skill create replayed stale create-skill failure from contaminated history"
+date: 2026-04-24
+severity: P1
+category: product
+tags: [telegram, skills, hooks, runtime, create-skill, sparse-create, history, contamination, rca]
+root_cause: "BeforeLLMCall still passed contaminated session history into sparse Telegram create turns. When old assistant messages already claimed `create_skill` was broken, the model simply repeated that stale failure instead of starting a fresh native CRUD attempt."
+---
+
+# RCA: Telegram sparse skill create replayed stale create-skill failure from contaminated history
+
+**Дата:** 2026-04-24  
+**Статус:** Resolved  
+**Влияние:** После merge/deploy предыдущего Telegram skill-CRUD фикса пользователь всё ещё мог получить ложный ответ вида `Не могу создать ... create_skill сломан ... missing 'name'` на полностью валидный новый запрос создания навыка. Навык не создавался, потому что модель не делала ни одного tool call и просто повторяла старую failure-реплику из истории сессии.  
+**Контекст:** `scripts/telegram-safe-llm-guard.sh`, authoritative Telegram Remote UAT for production create-skill flow, hook capture bundle inside live container.
+
+## Ошибка
+
+На production был повторно прогнан authoritative Telegram UAT exact prompt:
+
+`Создай новый навык moltis-version-watch-20260424-tele-a1 для автоматического отслеживания новой версии Moltis.`
+
+UAT завершился `failed`, но не из-за отсутствия reply. Reply был, однако он был неверным и содержал старую ложную диагностику:
+
+`Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове.`
+
+Production logs показали, что в этом ходе:
+
+- `BeforeLLMCall` стартовал как обычный safe Telegram create turn;
+- `AfterLLMCall` завершился с `tool_calls_count=0`;
+- итоговый текст был именно старым failure-ответом;
+- Telegram реально отправил этот текст пользователю.
+
+То есть проблема была не в поздней доставке и не в скрытом tool error: модель вообще не вошла в fresh native CRUD path.
+
+## Проверка прошлых уроков
+
+Перед фиксом были повторно проверены:
+
+- `docs/LESSONS-LEARNED.md`
+- `docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md`
+- `docs/rca/2026-04-24-telegram-tool-call-name-extraction-depended-on-json-field-order.md`
+- `docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md`
+- live hook capture и production logs для exact failing run
+
+Что уже было известно из прошлых уроков:
+
+1. `AfterLLMCall`/`MessageSending modify` нельзя считать authoritative proof сами по себе; нужен source fix раньше по critical path.
+2. Sparse create-turn обязан входить в native skill CRUD lane, а не в browser/search/maintenance path.
+3. Live Telegram payload shape может отличаться от локальных fixture и это надо подтверждать authoritative UAT.
+
+Что было новым в этом инциденте:
+
+1. Даже после исправления persisted CRUD intent новый sparse create-turn всё ещё мог быть заражён старой assistant history.
+2. Проблема была уже не в пустом `AfterLLMCall`, а в том, что модель до него видела старые failure-traces и принимала их за актуальный контекст текущей попытки.
+3. Репозиторий ещё не имел repo-owned guard, который бы принудительно очищал contaminated sparse-create history до нового create-turn.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---|---|---|---|
+| 1 | Почему новый Telegram create request снова вернул старый текст про `create_skill` и `missing 'name'`? | Потому что модель увидела в history старые assistant failure messages и повторила их вместо нового tool path. | Authoritative UAT run `24872155539` observed the exact stale failure text as the matched reply. |
+| 2 | Почему модель вообще видела эти старые failure messages в fresh sparse create-turn? | Потому что `BeforeLLMCall` для sparse create только prepend'ил guards, но не вычищал contaminated session history. | Live capture `20260424T042635Z-712.output.json` showed `message_count=165` and still contained prior assistant lines about `create_skill` returning `missing 'name'`. |
+| 3 | Почему это стало критично именно для create-turn? | Потому что sparse create relies on a fresh first native CRUD attempt; stale assistant refusal in the same history changes the model prior and nudges it to answer textually instead of calling `create_skill`. | Live `AfterLLMCall` payload `20260424T042642Z-1203.payload.json` had `tool_calls=[]` and already contained the stale refusal text. |
+| 4 | Почему поздняя `AfterLLMCall modify` перепись не спасла пользователя? | Потому что в этом path live runtime всё ещё завершал run исходным текстом модели, а не modified replacement. | Capture showed `AfterLLMCall output` already tried to rewrite to Telegram-safe generic text, but production run still completed with the stale failure message. |
+| 5 | Какой repo-owned fix действительно устраняет корень причины? | Нужно очищать sparse create-turn history ещё в `BeforeLLMCall`, если там уже есть stale create-failure traces, и передавать модели только current user request плюс свежие skill guards. | New regression test reproduces that exact contamination shape; after fix the modified payload contains only guard systems and the latest user create request. |
+
+## Корневая причина
+
+Корневая причина была в incomplete `BeforeLLMCall` contract для Telegram sparse create-turn.
+
+Guard уже умел:
+
+- классифицировать sparse create;
+- запрещать лишние tool families;
+- добавлять skill-authoring instructions.
+
+Но он всё ещё предполагал, что достаточно просто prepend'ить эти guards к существующему `messages_json`. Это предположение оказалось ложным: если в той же сессии уже накопились старые assistant/tool traces о поломанном `create_skill`, модель воспринимала их как актуальное состояние текущей попытки и повторяла старый отказ вместо fresh native CRUD start.
+
+Иными словами: проблема была не в отсутствии инструкций, а в том, что current sparse create-turn не был изолирован от исторического мусора, который уже противоречил этим инструкциям.
+
+## Принятые меры
+
+1. Для sparse create-turn добавлен explicit contamination detector по raw `messages_json`.
+2. Если история содержит stale create-failure markers (`create_skill`, `missing 'name'`, `не смог создать`, `сломан`, `broken`), `BeforeLLMCall` теперь сбрасывает history до минимального current-turn контекста:
+   - свежие Telegram skill guards;
+   - последний user create request.
+3. Добавлен regression test `component_before_llm_guard_resets_sparse_create_history_after_stale_create_failure`.
+4. Полный suite `bash tests/component/test_telegram_safe_llm_guard.sh` повторно прогнан и прошёл `167/167`.
+
+## Уроки
+
+1. Для Telegram-safe create/update/delete flows недостаточно добавить правильные guards; нужно ещё изолировать текущий turn от stale assistant/tool history, если она уже противоречит current contract.
+2. Если live capture показывает `tool_calls=0` и устаревший отказ в ответе, сначала нужно проверять contaminated `BeforeLLMCall` history, а не лечить только `AfterLLMCall` output rewriting.
+3. Sparse create-turn — это отдельный high-risk режим: ему нужен minimal current-turn context, иначе старая незавершённая create/debug история легко перезапишет намерение модели.
+
+## Regression Test
+
+**Test File:** `tests/component/test_telegram_safe_llm_guard.sh`
+
+**Test Status:**
+
+- [x] Test created
+- [x] Test reproduces stale create failure contamination in sparse Telegram create history
+- [x] Fix applied
+- [x] Test passes

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -3253,6 +3253,27 @@ PY
     return 1
 }
 
+sparse_skill_create_history_has_stale_failure() {
+    local messages_json="${1:-}"
+    local messages_flat=""
+
+    [[ -n "$messages_json" ]] || return 1
+
+    messages_flat="$(flatten_text_for_match "$messages_json")"
+    [[ -n "$messages_flat" ]] || return 1
+
+    printf '%s' "$messages_flat" | grep -Eiq "create_skill.{0,200}missing[[:space:]]+name|missing[[:space:]]+name.{0,200}create_skill|не[[:space:]]+(смог|могу).{0,200}созда|не[[:space:]]+создал(ся|ась|ись)?|create_skill.{0,120}(сломан|broken)|(сломан|broken).{0,120}create_skill|инструмент.{0,120}(сломан|broken)"
+}
+
+build_sparse_skill_create_reset_messages_json() {
+    local _messages_json="${1:-}"
+    local latest_user_content="${2:-}"
+
+    [[ -n "$latest_user_content" ]] || return 1
+
+    printf '[%s]' "$(build_message_json user "$latest_user_content")"
+}
+
 create_runtime_skill_scaffold() {
     local skill_name="${1:-}"
     local runtime_root="${MOLTIS_RUNTIME_SKILLS_ROOT:-/home/moltis/.moltis/skills}"
@@ -5723,6 +5744,10 @@ if [[ "$event" == "BeforeLLMCall" ]]; then
         if [[ "$looks_like_skill_turn" == true ]]; then
             skill_snapshot_csv="$(discover_runtime_skill_names_csv || true)"
             if [[ "$looks_like_sparse_skill_create_request" == true ]]; then
+                if sparse_skill_create_history_has_stale_failure "$messages_json"; then
+                    messages_json="$(build_sparse_skill_create_reset_messages_json "$messages_json" "${latest_user_message:-${user_message:-}}" || printf '%s' "$messages_json")"
+                    write_audit_line "before_modify reason=sparse_create_history_reset tool_count=${tool_count:-preserve} latest_skill=${requested_skill_name:-missing}"
+                fi
                 messages_json="$(prepend_message_to_array "$messages_json" system "$(build_sparse_skill_create_guard_message)")"
             fi
             messages_json="$(prepend_message_to_array "$messages_json" system "$(build_skill_authoring_guard_message)")"

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -2770,6 +2770,29 @@ EOF
         test_fail "BeforeLLMCall guard must keep create follow-ups on the native tool lane, clear stale visibility intent, and persist only the current native CRUD lane without scaffold writes"
     fi
 
+    test_start "component_before_llm_guard_resets_sparse_create_history_after_stale_create_failure"
+    local stale_create_failure_output
+    stale_create_failure_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"BeforeLLMCall","data":{"session_key":"session:create-history-regression","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=00cde7cf989d | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай новый навык codex-update-old-failed"},{"role":"assistant","content":"Не смог создать: `create_skill` в этой сессии тоже сломан и вернул `missing 'name'` при корректном вызове."},{"role":"user","content":"Создай новый навык moltis-version-watch-20260424-tele-a1 для автоматического отслеживания новой версии Moltis."}],"tool_count":37,"iteration":1}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '.data.tool_count == 37' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '.data.messages | length == 4' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '.data.messages[0].content | contains("Telegram-safe skill runtime note")' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '.data.messages[1].content | contains("Telegram-safe skill-authoring contract")' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '.data.messages[2].content | contains("Telegram-safe sparse create-skill override")' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '.data.messages[3].content == "Создай новый навык moltis-version-watch-20260424-tele-a1 для автоматического отслеживания новой версии Moltis."' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '[.data.messages[].content] | any(contains("codex-update-old-failed")) | not' >/dev/null 2>&1 <<<"$stale_create_failure_output" && \
+       jq -e '[.data.messages[].content] | any(contains("missing '\''name'\''")) | not' >/dev/null 2>&1 <<<"$stale_create_failure_output"; then
+        test_pass
+    else
+        test_fail "BeforeLLMCall guard must reset sparse create history when stale create_skill failure traces would contaminate the next native CRUD attempt"
+    fi
+
     test_start "component_message_sending_guard_drops_legacy_skill_create_intent_rewrite"
     local skill_create_intent_dir skill_create_intent_output
     skill_create_intent_dir="$(secure_temp_dir telegram-safe-skill-create-intent)"


### PR DESCRIPTION
## Что исправлено
- сброс contaminated history для Telegram sparse create-turn, если в ней уже есть старые failure traces `create_skill` / `missing 'name'`
- добавлен regression test на exact паттерн production capture
- добавлен RCA и пересобран lessons index

## Проверка
- `bash -n scripts/telegram-safe-llm-guard.sh`
- `bash tests/component/test_telegram_safe_llm_guard.sh`

## Контекст
- live UAT ранее показал, что новый create-turn видел старую assistant failure history и повторял её без tool calls
- source fix внесён в owning `BeforeLLMCall` layer, а не в post-hoc suppression