### PR TITLE
Stabilize Telegram Web probe baseline before quiet window

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-24
-**Total Lessons**: 96
+**Total Lessons**: 97
 
 ---
 
@@ -228,6 +228,9 @@
 - [Child worktree reconciliation renames authoritative feature worktree](../docs/rca/2026-03-08-topology-child-worktree-identity-drift.md)
 - [Команда false завершилась с кодом 1](../docs/rca/2026-03-07-false-command-exit-code.md)
 
+#### telegram (1 lessons)
+- [Telegram Web probe treated hydrated historical chat bubbles as fresh pre-send invalid activity](../docs/rca/2026-04-24-telegram-web-probe-baseline-hydration-false-invalid-activity.md)
+
 #### tooling (3 lessons)
 - [Worktree plan helper treated the default branch as a similar slug candidate](../docs/rca/2026-04-15-worktree-plan-helper-treated-default-branch-as-similar-slug-candidate.md)
 - [Worktree cleanup helper treated derived branch-only path as a path/branch conflict](../docs/rca/2026-04-15-worktree-cleanup-helper-treated-derived-branch-path-as-conflict.md)
@@ -237,7 +240,7 @@
 ### Popular Tags
 
 - `rca` (42 lessons)
-- `telegram` (32 lessons)
+- `telegram` (33 lessons)
 - `moltis` (28 lessons)
 - `deploy` (20 lessons)
 - `skills` (19 lessons)
@@ -254,10 +257,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 96 |
+| Total Lessons | 97 |
 | Critical (P0/P1) | 50 |
-| Categories | 8 |
-| Unique Tags | 187 |
+| Categories | 9 |
+| Unique Tags | 190 |
 
 ---
 

--- a/docs/rca/2026-04-24-telegram-web-probe-baseline-hydration-false-invalid-activity.md
+++ b/docs/rca/2026-04-24-telegram-web-probe-baseline-hydration-false-invalid-activity.md
@@ -1,0 +1,90 @@
+---
+title: "Telegram Web probe treated hydrated historical chat bubbles as fresh pre-send invalid activity"
+date: 2026-04-24
+status: resolved
+severity: medium
+category: telegram
+tags: [telegram, uat, playwright, probe, false-negative, hydration]
+root_cause: "The authoritative Telegram Web probe established its pre-send baseline before the visible chat DOM had finished hydrating, so an old leaked assistant bubble appeared after baseline capture and was misclassified as fresh invalid incoming activity."
+---
+
+# RCA: Telegram Web probe treated hydrated historical chat bubbles as fresh pre-send invalid activity
+
+## Summary
+
+Authoritative Telegram Web UAT for skill-creation turns failed with `pre_send_invalid_activity` even after the production runtime fix had already been deployed. The probe kept reporting the same historical leaked message:
+
+`Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове.`
+
+The underlying runtime was no longer proven broken by that point. The failing boundary was the repo-owned authoritative probe itself: it captured a pre-send baseline too early, before Telegram Web had finished hydrating the visible chat snapshot after opening the dialog.
+
+## Impact
+
+- Post-deploy authoritative UAT produced a false negative and blocked further user-imitation testing.
+- Operators were pushed toward `clear or reconcile the chat/session noise` even though the same stale bubble was being rediscovered from already-existing history.
+- The repair lane for Telegram skill creation could not be cleanly verified end-to-end until the probe contract was corrected.
+
+## Evidence
+
+- Authoritative runs `24872927003`, `24873093295`, and `24873203337` all failed with `pre_send_invalid_activity`.
+- The offending bubble kept the same `mid=221721` across reruns, which is inconsistent with a newly generated live reply and consistent with historical message hydration.
+- Review-safe and restricted-debug artifacts both showed:
+  - `failure.code = pre_send_invalid_activity`
+  - `baseline_max_message_id = 221721`
+  - `last_pre_send_activity.messages[0].mid = 221721`
+- `scripts/telegram-web-user-probe.mjs` previously did:
+  1. `openTargetChat(...)`
+  2. immediate `collectMessages(...)`
+  3. use that first snapshot as `baselineMaxMid`
+  4. enter `waitForQuietWindow(...)`
+  5. fail on any invalid incoming seen after that baseline
+
+## Why It Happened
+
+| Why | Answer | Evidence |
+| --- | --- | --- |
+| 1 | Why did authoritative UAT fail before sending the new probe message? | Because `pre_send_invalid_activity` fired during quiet-window evaluation. | `scripts/telegram-web-user-probe.mjs` |
+| 2 | Why did quiet-window evaluation think there was fresh invalid incoming activity? | Because a leaked assistant bubble appeared after the initial baseline snapshot and was therefore treated as `newMessages`. | `waitForQuietWindowWithCollector(...)` in `scripts/telegram-web-user-probe.mjs` |
+| 3 | Why could an old bubble appear after baseline capture? | Telegram Web had not finished hydrating the visible chat DOM immediately after `openTargetChat(...)`. | repeated runs with the exact same `mid=221721` |
+| 4 | Why did the probe not absorb that hydration before starting the quiet-window guard? | There was no dedicated visible-baseline stabilization step between `openTargetChat(...)` and `waitForQuietWindow(...)`. | `scripts/telegram-web-user-probe.mjs` before fix |
+| 5 | Why is this a source-contract defect rather than operator noise? | Because the authoritative repo-owned probe defined the decision boundary and misclassified already-existing history as fresh recent invalid activity. | repeated authoritative failures after runtime fix deploy |
+
+## Root Cause
+
+The repo-owned authoritative Telegram Web probe captured its pre-send baseline before the visible chat snapshot had stabilized. Historical bubbles that were merely hydrated into the DOM after chat-open were then reclassified as fresh `newMessages`, and invalid ones triggered `pre_send_invalid_activity` before the probe could send the new operator message.
+
+## Fix
+
+1. Added a visible-baseline stabilization phase in `scripts/telegram-web-user-probe.mjs` before quiet-window guarding:
+   - `stabilizeVisibleBaselineWithCollector(...)`
+   - new defaults:
+     - `TELEGRAM_WEB_BASELINE_STABILIZE_MS=1200`
+     - `TELEGRAM_WEB_BASELINE_STABILIZE_MAX_WAIT_MS=4000`
+2. The authoritative flow now:
+   - opens the target chat
+   - waits for the visible bubble snapshot to stop changing
+   - uses that stabilized max `mid` as the real pre-send baseline
+   - only then runs `waitForQuietWindow(...)`
+3. Added regression coverage in `tests/component/test_telegram_web_probe_correlation.sh` for the exact historical hydration pattern:
+   - stale invalid bubble appears only after initial empty snapshot
+   - stabilized baseline absorbs it
+   - quiet-window no longer treats it as fresh pre-send invalid activity
+
+## Validation
+
+- `node --check scripts/telegram-web-user-probe.mjs`
+- `bash tests/component/test_telegram_web_probe_correlation.sh`
+
+## Уроки
+
+1. В authoritative browser-based UAT нельзя считать первый видимый chat snapshot истинным baseline сразу после открытия чата; сначала нужен явный stabilization step для DOM hydration.
+2. Если один и тот же `mid` воспроизводится в `pre_send_invalid_activity` на нескольких прогонах, это сильный сигнал ложного probe-boundary fail, а не обязательного live runtime regression.
+3. Repo-owned UAT boundary должен различать active incoming noise и historical chat hydration, иначе post-deploy verification превращается в ложный блокер.
+
+## Follow-ups
+
+1. Re-run authoritative Telegram Web UAT after deploy on the same skill-creation prompt to verify that the false `pre_send_invalid_activity` is gone.
+2. Continue the planned user-imitation dialog sequence for:
+   - `codex-update`
+   - duplicate-notification explanation
+   - create/update/delete of a new Moltis version-watch skill

--- a/scripts/telegram-web-user-probe.mjs
+++ b/scripts/telegram-web-user-probe.mjs
@@ -18,6 +18,8 @@ const DEFAULT_TIMEOUT_SEC = Number(process.env.TELEGRAM_WEB_TIMEOUT_SECONDS || 4
 const DEFAULT_MIN_REPLY_LEN = Number(process.env.TELEGRAM_WEB_MIN_REPLY_LEN || 2);
 const DEFAULT_COMPOSER_RETRIES = Number(process.env.TELEGRAM_WEB_COMPOSER_RETRIES || 2);
 const DEFAULT_QUIET_WINDOW_MS = Number(process.env.TELEGRAM_WEB_QUIET_WINDOW_MS || 3000);
+const DEFAULT_BASELINE_STABILIZE_MS = Number(process.env.TELEGRAM_WEB_BASELINE_STABILIZE_MS || 1200);
+const DEFAULT_BASELINE_STABILIZE_MAX_WAIT_MS = Number(process.env.TELEGRAM_WEB_BASELINE_STABILIZE_MAX_WAIT_MS || 4000);
 const DEFAULT_REPLY_SETTLE_MS = Number(process.env.TELEGRAM_WEB_REPLY_SETTLE_MS || 5000);
 const DEFAULT_MIN_REPLY_OBSERVATION_MS = Number(process.env.TELEGRAM_WEB_MIN_REPLY_OBSERVATION_MS || 15000);
 const INTERNAL_TELEMETRY_RE =
@@ -48,6 +50,14 @@ const timeoutSec = Number(getArg("--timeout", String(DEFAULT_TIMEOUT_SEC)));
 const minReplyLen = Number(getArg("--min-reply-len", String(DEFAULT_MIN_REPLY_LEN)));
 const composerRetries = Math.max(0, Number(getArg("--composer-retries", String(DEFAULT_COMPOSER_RETRIES))) || 0);
 const quietWindowMs = Math.max(500, Number(getArg("--quiet-window-ms", String(DEFAULT_QUIET_WINDOW_MS))) || 0);
+const baselineStabilizeMs = Math.max(
+  250,
+  Number(getArg("--baseline-stabilize-ms", String(DEFAULT_BASELINE_STABILIZE_MS))) || 0
+);
+const baselineStabilizeMaxWaitMs = Math.max(
+  baselineStabilizeMs,
+  Number(getArg("--baseline-stabilize-max-wait-ms", String(DEFAULT_BASELINE_STABILIZE_MAX_WAIT_MS))) || 0
+);
 const replySettleMs = Math.max(1000, Number(getArg("--reply-settle-ms", String(DEFAULT_REPLY_SETTLE_MS))) || 0);
 const minReplyObservationMs = Math.max(0, Number(getArg("--min-reply-observation-ms", String(DEFAULT_MIN_REPLY_OBSERVATION_MS))) || 0);
 const headed = hasFlag("--headed");
@@ -144,6 +154,14 @@ function maxObservedMid(messages) {
     const mid = safeMid(message?.mid);
     return mid > max ? mid : max;
   }, 0);
+}
+
+function visibleMessagesFingerprint(messages, limit = 16) {
+  return (Array.isArray(messages) ? messages : [])
+    .map(normalizeProbeMessage)
+    .slice(-limit)
+    .map(messageFingerprint)
+    .join("|");
 }
 
 export function findOutgoingProbeMessage(messages, probeText, minMidExclusive = 0) {
@@ -683,6 +701,61 @@ async function waitForQuietWindow(page, quietMs, maxWaitMs, baselineMaxMid) {
   });
 }
 
+export async function stabilizeVisibleBaselineWithCollector({
+  collectMessagesFn,
+  sleepFn,
+  settleMs,
+  maxWaitMs,
+  baselineMaxMid = 0,
+}) {
+  const startedAt = Date.now();
+  let lastFingerprint = null;
+  let lastChangeAt = null;
+  let latestMessages = [];
+  let latestBaselineMaxMid = baselineMaxMid;
+
+  while (Date.now() - startedAt < maxWaitMs) {
+    const messages = await collectMessagesFn();
+    const fingerprint = visibleMessagesFingerprint(messages);
+    const observedBaselineMaxMid = Math.max(baselineMaxMid, maxObservedMid(messages));
+
+    if (fingerprint !== lastFingerprint || observedBaselineMaxMid !== latestBaselineMaxMid) {
+      latestMessages = (Array.isArray(messages) ? messages : []).map(normalizeProbeMessage);
+      latestBaselineMaxMid = observedBaselineMaxMid;
+      lastFingerprint = fingerprint;
+      lastChangeAt = Date.now();
+    }
+
+    if (lastChangeAt !== null && Date.now() - lastChangeAt >= settleMs) {
+      return {
+        ok: true,
+        settleWaitMs: Date.now() - startedAt,
+        baselineMaxMid: latestBaselineMaxMid,
+        messages: latestMessages,
+      };
+    }
+
+    await sleepFn(Math.min(750, Math.max(150, Math.floor(settleMs / 3))));
+  }
+
+  return {
+    ok: false,
+    settleWaitMs: Date.now() - startedAt,
+    baselineMaxMid: latestBaselineMaxMid,
+    messages: latestMessages,
+  };
+}
+
+async function stabilizeVisibleBaseline(page, settleMs, maxWaitMs, baselineMaxMid) {
+  return stabilizeVisibleBaselineWithCollector({
+    collectMessagesFn: () => collectMessages(page),
+    sleepFn: (ms) => page.waitForTimeout(ms),
+    settleMs,
+    maxWaitMs,
+    baselineMaxMid,
+  });
+}
+
 export async function waitForReplySettleWithCollector({
   collectMessagesFn,
   sleepFn,
@@ -1043,13 +1116,20 @@ async function main() {
 
     const initialMessages = await collectMessages(page);
     const initialBaselineMaxMid = maxObservedMid(initialMessages);
+    const stabilizedBaseline = await stabilizeVisibleBaseline(
+      page,
+      baselineStabilizeMs,
+      baselineStabilizeMaxWaitMs,
+      initialBaselineMaxMid
+    );
+    const stabilizedBaselineMaxMid = Math.max(initialBaselineMaxMid, stabilizedBaseline.baselineMaxMid || 0);
 
     stage = "quiet_window";
     const quietWindow = await waitForQuietWindow(
       page,
       quietWindowMs,
       Math.min(timeoutSec * 1000, Math.max(quietWindowMs * 4, 12_000)),
-      initialBaselineMaxMid
+      stabilizedBaselineMaxMid
     );
 
     if (!quietWindow.ok) {

--- a/tests/component/test_telegram_web_probe_correlation.sh
+++ b/tests/component/test_telegram_web_probe_correlation.sh
@@ -323,6 +323,52 @@ NODE
         test_fail "Quiet window should wait for late pre-send activity to settle before probe attribution starts"
     fi
 
+    test_start "component_telegram_web_probe_stabilizes_visible_baseline_before_quiet_window"
+    if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
+import process from "node:process";
+const { stabilizeVisibleBaselineWithCollector, waitForQuietWindowWithCollector } = await import(process.env.NODE_SCRIPT);
+
+const hydrationSnapshots = [
+  [],
+  [{ mid: 221721, direction: "in", text: "Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове." }],
+  [{ mid: 221721, direction: "in", text: "Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове." }],
+  [{ mid: 221721, direction: "in", text: "Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове." }],
+];
+let hydrationIndex = 0;
+const baseline = await stabilizeVisibleBaselineWithCollector({
+  collectMessagesFn: async () => hydrationSnapshots[Math.min(hydrationIndex++, hydrationSnapshots.length - 1)],
+  sleepFn: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  settleMs: 100,
+  maxWaitMs: 1000,
+  baselineMaxMid: 0,
+});
+if (!baseline.ok || baseline.baselineMaxMid !== 221721) {
+  throw new Error(`expected hydrated baseline to stabilize on historical bubble, got ${JSON.stringify(baseline)}`);
+}
+
+const quietSnapshots = [
+  [{ mid: 221721, direction: "in", text: "Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове." }],
+  [{ mid: 221721, direction: "in", text: "Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове." }],
+  [{ mid: 221721, direction: "in", text: "Не могу создать в этой сессии: create_skill сломан и возвращает missing 'name' даже при корректном вызове." }],
+];
+let quietIndex = 0;
+const quietWindow = await waitForQuietWindowWithCollector({
+  collectMessagesFn: async () => quietSnapshots[Math.min(quietIndex++, quietSnapshots.length - 1)],
+  sleepFn: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  quietMs: 120,
+  maxWaitMs: 900,
+  baselineMaxMid: baseline.baselineMaxMid,
+});
+if (!quietWindow.ok || quietWindow.lastActivity !== null) {
+  throw new Error(`expected quiet window to ignore hydrated historical bubble after baseline stabilization, got ${JSON.stringify(quietWindow)}`);
+}
+NODE
+    then
+        test_pass
+    else
+        test_fail "Probe must stabilize the visible baseline before quiet-window guards so historical hydrated bubbles do not trip pre-send invalid-activity fails"
+    fi
+
     test_start "component_telegram_web_probe_fails_when_chat_never_quiets"
     if NODE_SCRIPT="$NODE_SCRIPT" node --input-type=module <<'NODE'
 import process from "node:process";


### PR DESCRIPTION
## Summary
- stabilize the visible Telegram Web chat baseline before starting quiet-window invalid-activity guards
- add a regression test for historical bubble hydration that previously caused false pre-send failures
- record the RCA and refresh lessons learned

## Validation
- node --check scripts/telegram-web-user-probe.mjs
- bash tests/component/test_telegram_web_probe_correlation.sh