### PR TITLE
fix: harden telegram after-llm skill flows

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1,7 +1,7 @@
 # Lessons Learned (Auto-generated)
 
 **Generated**: 2026-04-24
-**Total Lessons**: 97
+**Total Lessons**: 98
 
 ---
 
@@ -14,12 +14,13 @@
 #### P0 (1 lessons)
 - [Unauthorized File Deletion Attempt](../docs/rca/2026-03-04-unauthorized-file-deletion-attempt.md)
 
-#### P1 (49 lessons)
+#### P1 (50 lessons)
 - [Telegram skill CRUD fastpath depended on JSON field order when extracting tool call names](../docs/rca/2026-04-24-telegram-tool-call-name-extraction-depended-on-json-field-order.md)
 - [Telegram sparse skill create could still go silent because empty LLM turns had no repo-owned recovery](../docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md)
 - [Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent](../docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md)
 - [Telegram sparse skill create replayed stale create-skill failure from contaminated history](../docs/rca/2026-04-24-telegram-sparse-create-history-replayed-stale-failure.md)
 - [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
+- [Telegram AfterLLM skill flow still depended on ephemeral chat metadata and heuristic visibility rewrites](../docs/rca/2026-04-24-telegram-after-llm-skill-flow-still-depended-on-ephemeral-chat-metadata-and-heuristic-visibility-rewrites.md)
 - [Telegram Web probe collapsed multiline /status replies before exact semantic review](../docs/rca/2026-04-23-telegram-web-probe-collapsed-multiline-status-contract.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
@@ -200,12 +201,13 @@
 - [Повторный запрос уже документированных секретов](../docs/rca/2026-03-07-context-discovery-before-user-questions.md)
 - [Token Bloat в инструкциях — повторяющаяся проблема](../docs/rca/2026-03-04-token-bloat-recurring.md)
 
-#### product (12 lessons)
+#### product (13 lessons)
 - [Telegram skill CRUD fastpath depended on JSON field order when extracting tool call names](../docs/rca/2026-04-24-telegram-tool-call-name-extraction-depended-on-json-field-order.md)
 - [Telegram sparse skill create could still go silent because empty LLM turns had no repo-owned recovery](../docs/rca/2026-04-24-telegram-sparse-skill-create-empty-turn-had-no-owned-recovery.md)
 - [Telegram sparse skill create recovery still depended on the current-turn user message instead of persisted CRUD intent](../docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md)
 - [Telegram sparse skill create replayed stale create-skill failure from contaminated history](../docs/rca/2026-04-24-telegram-sparse-create-history-replayed-stale-failure.md)
 - [Telegram skill CRUD still failed because live runtime did not authoritatively apply BeforeToolCall modify](../docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md)
+- [Telegram AfterLLM skill flow still depended on ephemeral chat metadata and heuristic visibility rewrites](../docs/rca/2026-04-24-telegram-after-llm-skill-flow-still-depended-on-ephemeral-chat-metadata-and-heuristic-visibility-rewrites.md)
 - [Telegram direct fastpath BeforeLLMCall block assumption was superseded by the official shell-hook contract](../docs/rca/2026-04-23-telegram-direct-fastpath-before-llm-must-block.md)
 - [Moltis tool argument envelope drift surfaced as missing required parameters](../docs/rca/2026-04-23-moltis-tool-argument-envelope-drift.md)
 - [Telegram-safe maintenance turns fell into upstream tool-boundary errors](../docs/rca/2026-04-20-telegram-safe-maintenance-turns-fell-into-upstream-tool-boundary-errors.md)
@@ -239,16 +241,16 @@
 
 ### Popular Tags
 
-- `rca` (42 lessons)
-- `telegram` (33 lessons)
+- `rca` (43 lessons)
+- `telegram` (34 lessons)
 - `moltis` (28 lessons)
+- `skills` (20 lessons)
 - `deploy` (20 lessons)
-- `skills` (19 lessons)
+- `hooks` (18 lessons)
 - `github-actions` (18 lessons)
-- `hooks` (17 lessons)
 - `gitops` (16 lessons)
 - `cicd` (16 lessons)
-- `runtime` (14 lessons)
+- `runtime` (15 lessons)
 
 
 ---
@@ -257,10 +259,10 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Lessons | 97 |
-| Critical (P0/P1) | 50 |
+| Total Lessons | 98 |
+| Critical (P0/P1) | 51 |
 | Categories | 9 |
-| Unique Tags | 190 |
+| Unique Tags | 192 |
 
 ---
 

--- a/docs/rca/2026-04-24-telegram-after-llm-skill-flow-still-depended-on-ephemeral-chat-metadata-and-heuristic-visibility-rewrites.md
+++ b/docs/rca/2026-04-24-telegram-after-llm-skill-flow-still-depended-on-ephemeral-chat-metadata-and-heuristic-visibility-rewrites.md
@@ -1,0 +1,101 @@
+---
+title: "Telegram AfterLLM skill flow still depended on ephemeral chat metadata and heuristic visibility rewrites"
+date: 2026-04-24
+severity: P1
+category: product
+tags: [telegram, skills, hooks, runtime, after-llm, chat-id, visibility, rca]
+root_cause: "The repo-owned AfterLLM skill path still relied on upstream payload metadata and heuristic text checks instead of persisting the Telegram chat_id per session and canonicalizing skill visibility replies from runtime truth."
+---
+
+# RCA: Telegram AfterLLM skill flow still depended on ephemeral chat metadata and heuristic visibility rewrites
+
+**Дата:** 2026-04-24
+**Статус:** Resolved
+**Влияние:** Live Telegram skill CRUD мог снова срываться на позднем `AfterLLMCall`, хотя tool call уже был корректным: deterministic repo-owned path не мог отправить финальный ответ пользователю из-за потерянного `chat_id`. Параллельно skill visibility всё ещё мог показать внутренний/чужой инвентарь навыков, если модель случайно упоминала хотя бы одно настоящее runtime-имя.
+**Контекст:** `scripts/telegram-safe-llm-guard.sh`, authoritative Telegram Remote UAT, production hook captures, user-facing Telegram skill CRUD / skill visibility flows.
+
+## Ошибка
+
+После предыдущих ремонтов было видно, что:
+
+- `create_skill`/`update_skill`/`delete_skill` уже исполняются в repo-owned direct CRUD path, а не через старый broken tool boundary;
+- `skill visibility` уже имел deterministic runtime snapshot;
+- локальные component tests на canonical payload shape проходили.
+
+Но live evidence показал ещё два остаточных разрыва:
+
+1. `AfterLLMCall` на production иногда приходил без `channel_chat_id` и вообще без chat metadata, хотя на более раннем hook phase этот `chat_id` уже был известен.
+2. Final rewrite для `skill visibility` всё ещё был завязан на эвристику `reply mentions any runtime skill`, поэтому overbroad reply с частично правильными именами мог пройти мимо deterministic canonicalization.
+
+Итог: root-owned execution path уже существовал, но всё ещё опирался на неавторитетные свойства upstream payload.
+
+## Проверка прошлых уроков
+
+Перед фиксом были повторно проверены:
+
+- `./scripts/query-lessons.sh --tag telegram`
+- `./scripts/query-lessons.sh --tag skills`
+- `docs/rca/2026-04-24-telegram-tool-call-name-extraction-depended-on-json-field-order.md`
+- `docs/rca/2026-04-24-telegram-sparse-create-recovery-needed-persisted-crud-intent.md`
+- `docs/rca/2026-04-24-telegram-skill-crud-before-tool-modify-was-not-authoritative.md`
+
+Релевантные уже закреплённые уроки:
+
+1. Для Telegram-safe critical paths нужно считать upstream hook payload shape нестабильным между фазами.
+2. Если repo уже владеет deterministic recovery, ему нужен собственный persisted execution context, а не повторная надежда на поля следующего payload.
+3. Skill visibility нельзя считать исправленным, пока ответ полностью опирается на runtime truth, а не на частичное совпадение текста модели с реальными skill names.
+
+Что было новым:
+
+- persisted CRUD context уже хранил intent и slug, но не хранил последний известный `chat_id` для позднего direct send;
+- visibility finalization была недостаточно строгой именно на поздних фазах delivery: хороший partial overlap с runtime names скрывал реальный leak лишних skill names.
+
+## Анализ 5 Почему
+
+| Уровень | Вопрос | Ответ | Evidence |
+|---|---|---|---|
+| 1 | Почему live Telegram create/update/delete всё ещё могли заканчиваться плохим user-facing результатом? | Потому что `AfterLLMCall` direct CRUD branch иногда не мог отправить clean summary пользователю. | Hermetic replay of the live capture showed `attempt_direct_skill_crud_after_llm_fastpath` returning early on empty `telegram_chat_id`. |
+| 2 | Почему `telegram_chat_id` оказывался пустым, хотя раньше он был известен? | Потому что поздний live `AfterLLMCall` payload мог не содержать `channel_chat_id`, `to`, или других Telegram chat fields. | Production hook capture and bash-trace replay of the saved payload showed only datetime/system content without chat metadata. |
+| 3 | Почему repo-owned path не восстановил этот `chat_id` из собственного состояния? | Потому что в session-owned persistence были `intent`, suppression и terminal markers, но не было persisted session chat binding. | `scripts/telegram-safe-llm-guard.sh` before fix had `.intent`, `.suppress`, `.terminal`, but no `.chat` sidecar. |
+| 4 | Почему skill visibility leak тоже оставался возможным после прошлых fixes? | Потому что final rewrite срабатывал только при false-negative/generic mismatch или полном отсутствии runtime skill names в reply. | Existing branch logic skipped override when model reply mentioned any one runtime skill, even if the rest of the inventory was overbroad or internal. |
+| 5 | Какой source fix был нужен на самом деле? | Нужно было сделать skill-flow fully repo-owned: persist/restore last known session `chat_id` for late direct sends and canonicalize skill visibility by comparing against exact runtime-derived final text instead of heuristic overlap. | New fix adds session-scoped `.chat` persistence, restores `current_chat_id` when live payload is sparse, and rewrites visibility whenever the final text deviates from the canonical runtime snapshot reply. |
+
+## Корневая причина
+
+Repo-owned Telegram skill flow был доведён только наполовину.
+
+Архитектура уже перенесла critical skill CRUD logic в deterministic `AfterLLMCall` layer, но сама эта ветка всё ещё зависела от ephemeral upstream chat metadata, которого live runtime не обязан сохранять до поздней фазы. Одновременно `skill visibility` ещё доверял частичному semantic overlap текста модели, вместо того чтобы жёстко опираться на exact canonical runtime reply.
+
+Иными словами: determinism был заявлен, но execution context и final output canonicalization оставались неполностью repo-owned.
+
+## Принятые меры
+
+1. Добавлен session-scoped persisted `chat_id` sidecar:
+   - `chat_id` сохраняется по `session_key`, когда он известен;
+   - поздние фазы могут восстановить его, если live payload уже sparse.
+2. `AfterLLMCall` direct skill CRUD теперь использует restored session `chat_id`, а не только текущий payload.
+3. `BeforeLLMCall` fastpath тоже использует `current_chat_id` fallback, если `system_chat_id` отсутствует.
+4. `skill visibility` final rewrite tightened:
+   - старый retired create intent всё ещё чистится на follow-up;
+   - rewrite происходит whenever final reply deviates from the exact runtime-derived canonical visibility text;
+   - уже корректный canonical final reply не переписывается повторно.
+5. Добавлены новые component regressions:
+   - live-shaped `AfterLLMCall` direct skill CRUD payload without chat metadata;
+   - overbroad skill visibility inventory that still mentions some real runtime skill names.
+
+## Уроки
+
+1. Если Telegram-safe turn требует late direct send, persisted execution context должен хранить не только intent/slug, но и routing metadata, без которого reply невозможно доставить.
+2. Для user-visible skill visibility correctness нельзя использовать эвристику вида “модель назвала хоть один правильный навык”; нужен exact runtime-owned canonical reply.
+3. Live payload sparsity и semantic overbreadth нужно покрывать отдельными regression fixtures, даже если canonical/local payloads уже проходят.
+
+## Regression Test
+
+**Test Files:** `tests/component/test_telegram_safe_llm_guard.sh`, `tests/component/test_telegram_remote_uat_contract.sh`
+
+**Test Status:**
+
+- [x] Live-shaped `AfterLLMCall` skill CRUD payload without chat metadata reproduced
+- [x] Overbroad skill visibility inventory reproduced
+- [x] Fix applied
+- [x] Relevant component suites pass

--- a/scripts/telegram-safe-llm-guard.sh
+++ b/scripts/telegram-safe-llm-guard.sh
@@ -1785,6 +1785,16 @@ terminal_file_path() {
 
     printf '%s/%s.terminal' "$INTENT_DIR" "$safe_key"
 }
+
+chat_file_path() {
+    local raw_key="${1:-}"
+    local safe_key=""
+
+    safe_key="$(sanitize_intent_key "$raw_key" || true)"
+    [[ -n "$safe_key" ]] || return 1
+
+    printf '%s/%s.chat' "$INTENT_DIR" "$safe_key"
+}
 persist_safe_lane_marker() {
     local raw_key="${1:-}"
     local lane_file=""
@@ -2235,6 +2245,55 @@ clear_turn_intent() {
     [[ -n "$intent_file" ]] || return 0
 
     rm -f "$intent_file" 2>/dev/null || true
+}
+
+persist_turn_chat_id() {
+    local raw_key="${1:-}"
+    local chat_id="${2:-}"
+    local chat_file=""
+
+    [[ -n "$raw_key" && -n "$chat_id" ]] || return 0
+
+    chat_file="$(chat_file_path "$raw_key" || true)"
+    [[ -n "$chat_file" ]] || return 0
+
+    if ! mkdir -p "$INTENT_DIR" 2>/dev/null; then
+        write_audit_line "chat_id_set_failed key=$(basename "$chat_file") chat_id=$chat_id reason=mkdir"
+        return 0
+    fi
+    if ! printf '%s\t%s\n' "$(date +%s)" "$chat_id" 2>/dev/null >"$chat_file"; then
+        rm -f "$chat_file" 2>/dev/null || true
+        write_audit_line "chat_id_set_failed key=$(basename "$chat_file") chat_id=$chat_id reason=write"
+        return 0
+    fi
+    write_audit_line "chat_id_set key=$(basename "$chat_file") chat_id=$chat_id"
+    return 0
+}
+
+load_turn_chat_id() {
+    local raw_key="${1:-}"
+    local chat_file=""
+    local stored_epoch=""
+    local stored_chat_id=""
+    local now_epoch=0
+    local age_sec=0
+
+    [[ -n "$raw_key" ]] || return 1
+
+    chat_file="$(chat_file_path "$raw_key" || true)"
+    [[ -n "$chat_file" && -f "$chat_file" ]] || return 1
+
+    IFS=$'\t' read -r stored_epoch stored_chat_id <"$chat_file" || return 1
+    [[ "$stored_epoch" =~ ^[0-9]+$ && -n "$stored_chat_id" ]] || return 1
+
+    now_epoch="$(date +%s)"
+    age_sec=$((now_epoch - stored_epoch))
+    if (( age_sec < 0 || age_sec > INTENT_TTL_SEC )); then
+        rm -f "$chat_file" 2>/dev/null || true
+        return 1
+    fi
+
+    printf '%s' "$stored_chat_id"
 }
 
 format_skill_native_crud_turn_intent() {
@@ -3634,7 +3693,7 @@ attempt_direct_skill_crud_after_llm_fastpath() {
 
     [[ -n "$direct_tool_calls_json" && "$direct_tool_calls_json" != "[]" ]] || return 1
 
-    telegram_chat_id="${system_chat_id:-${current_chat_id:-}}"
+    telegram_chat_id="${current_chat_id:-${system_chat_id:-${persisted_turn_chat_id:-}}}"
     [[ -n "$telegram_chat_id" ]] || return 1
 
     direct_skill_crud_result_json="$(execute_direct_skill_tool_calls_json "$direct_tool_calls_json" || true)"
@@ -4848,6 +4907,7 @@ persisted_turn_intent="$(load_turn_intent "${turn_session_key:-}" || true)"
 persisted_turn_fingerprint="$(load_turn_intent_fingerprint "${turn_session_key:-}" || true)"
 persisted_delivery_suppression="$(load_delivery_suppression "${turn_session_key:-}" || true)"
 persisted_terminal_marker="$(load_terminal_marker "${turn_session_key:-}" || true)"
+persisted_turn_chat_id="$(load_turn_chat_id "${turn_session_key:-}" || true)"
 loaded_persisted_codex_update_request=false
 loaded_persisted_codex_update_scheduler_request=false
 loaded_persisted_codex_update_context_request=false
@@ -4889,6 +4949,17 @@ if [[ -z "$delivery_chat_id" ]]; then
     delivery_chat_id="$(extract_first_number to || true)"
 fi
 current_chat_id="${delivery_chat_id:-${system_chat_id:-$channel_binding_chat_id}}"
+restored_session_chat_id=false
+if [[ -z "$current_chat_id" && -n "$persisted_turn_chat_id" ]]; then
+    current_chat_id="$persisted_turn_chat_id"
+    restored_session_chat_id=true
+fi
+if [[ -n "${turn_session_key:-}" && -n "$current_chat_id" ]]; then
+    persist_turn_chat_id "${turn_session_key:-}" "$current_chat_id"
+fi
+if [[ "$restored_session_chat_id" == true ]]; then
+    write_audit_line "chat_id_restored source=session key=${turn_session_key:-missing} event=$event chat_id=$current_chat_id"
+fi
 persisted_chat_delivery_suppression="$(load_delivery_suppression_for_chat "${current_chat_id:-}" || true)"
 effective_delivery_suppression="${persisted_delivery_suppression:-$persisted_chat_delivery_suppression}"
 has_current_user_turn=false
@@ -5485,7 +5556,7 @@ if [[ "$event" == "MessageReceived" ]]; then
 fi
 
 if [[ "$event" == "BeforeLLMCall" ]]; then
-    telegram_chat_id="${system_chat_id:-}"
+    telegram_chat_id="${system_chat_id:-${current_chat_id:-}}"
     next_turn_intent=""
     if [[ "$looks_like_status" == true ]]; then
         next_turn_intent="status"
@@ -5971,9 +6042,12 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
     if [[ "$looks_like_skill_visibility_request" == true || "$has_skill_visibility_generic_mismatch" == true ]]; then
         skill_snapshot_csv="$(discover_runtime_skill_names_csv || true)"
         if [[ -n "$skill_snapshot_csv" || "$has_skill_visibility_generic_mismatch" == true || "$looks_like_skill_visibility_request" == true ]]; then
-            if [[ "$has_skill_path_false_negative" == true || "$has_skill_visibility_generic_mismatch" == true ]] || \
-               ! reply_mentions_any_skill_from_csv "$response_text_flat" "$skill_snapshot_csv"; then
-                visibility_reply_text="$(build_skill_visibility_reply_text "$skill_snapshot_csv")"
+            visibility_reply_text="$(build_skill_visibility_reply_text "$skill_snapshot_csv")"
+            if [[ "$looks_like_skill_visibility_request" == true && -n "$persisted_skill_create_state" ]]; then
+                write_audit_line "intent_clear reason=skill_visibility_followup_consumed_create_intent skill=$requested_skill_name state=$persisted_skill_create_state"
+                clear_turn_intent "${turn_session_key:-}"
+            fi
+            if [[ "$has_skill_path_false_negative" == true || "$has_skill_visibility_generic_mismatch" == true || "${response_text:-}" != "$visibility_reply_text" ]]; then
                 write_audit_line "emit_modify event=$event reason=skill_visibility_reply_override snapshot_count=$(count_skill_names_csv "$skill_snapshot_csv") false_negative=$has_skill_path_false_negative generic_mismatch=$has_skill_visibility_generic_mismatch"
                 if [[ "$event" == "AfterLLMCall" ]]; then
                     emit_modified_payload "$visibility_reply_text" true
@@ -5981,10 +6055,6 @@ if [[ "$event" == "AfterLLMCall" || "$event" == "MessageSending" ]]; then
                     emit_modified_payload "$visibility_reply_text" false
                 fi
                 exit 0
-            fi
-            if [[ "$looks_like_skill_visibility_request" == true && -n "$persisted_skill_create_state" ]]; then
-                write_audit_line "intent_clear reason=skill_visibility_followup_consumed_create_intent skill=$requested_skill_name state=$persisted_skill_create_state"
-                clear_turn_intent "${turn_session_key:-}"
             fi
         fi
     fi

--- a/tests/component/test_telegram_safe_llm_guard.sh
+++ b/tests/component/test_telegram_safe_llm_guard.sh
@@ -3444,6 +3444,23 @@ EOF
         test_fail "AfterLLMCall guard must let the latest skill-visibility turn win over stale /status history and persisted status intent"
     fi
 
+    test_start "component_after_llm_guard_rewrites_overbroad_skill_visibility_inventory_even_when_model_mentions_real_runtime_skills"
+    local after_skill_visibility_overbroad_output
+    after_skill_visibility_overbroad_output="$(
+        env PATH="$MINIMAL_PATH" \
+            MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:skill-visibility-overbroad","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"base system"},{"role":"user","content":"Какие у тебя сейчас есть навыки?"}],"text":"Навыки: codex-update, telegram-learner, docker-expert, prompt-engineer, devops-guardian. Могу показать ещё скрытые системные навыки.","tool_calls":[]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_visibility_overbroad_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_skill_visibility_overbroad_output" && \
+       jq -e '.data.text == "Навыки (2): codex-update, telegram-learner."' >/dev/null 2>&1 <<<"$after_skill_visibility_overbroad_output"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall skill visibility override must ignore overbroad model inventories and always answer from the runtime skill snapshot"
+    fi
+
     test_start "component_after_llm_guard_preserves_allowlisted_skill_tool_calls_while_rewriting_progress_text"
     local after_skill_tool_output
     after_skill_tool_output="$(
@@ -3502,6 +3519,48 @@ EOF
         test_pass
     else
         test_fail "AfterLLMCall guard must directly execute Telegram-safe native skill CRUD, send one clean user-facing summary, and suppress the later raw tool tail"
+    fi
+
+    test_start "component_after_llm_guard_restores_session_chat_id_for_live_shaped_direct_skill_crud_payload"
+    local after_skill_crud_live_dir after_skill_crud_live_runtime after_skill_crud_live_send after_skill_crud_live_log after_skill_crud_live_output after_skill_crud_live_skill_file
+    after_skill_crud_live_dir="$(secure_temp_dir telegram-safe-after-skill-crud-live)"
+    after_skill_crud_live_runtime="$after_skill_crud_live_dir/runtime"
+    after_skill_crud_live_send="$after_skill_crud_live_dir/send.sh"
+    after_skill_crud_live_log="$after_skill_crud_live_dir/send.log"
+    after_skill_crud_live_skill_file="$after_skill_crud_live_runtime/moltis-live-shaped/SKILL.md"
+    cat >"$after_skill_crud_live_send" <<'EOF'
+#!/usr/bin/env bash
+printf 'send %s\n' "$*" >>"$FASTPATH_LOG"
+exit 0
+EOF
+    chmod +x "$after_skill_crud_live_send"
+    env PATH="$MINIMAL_PATH" \
+        MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_live_dir/intent" \
+        MOLTIS_TELEGRAM_SAFE_SKILL_SNAPSHOT_NAMES='codex-update,telegram-learner' \
+        bash "$HOOK_SCRIPT" <<'EOF' >/dev/null
+{"event":"BeforeLLMCall","data":{"session_key":"session:after-skill-crud-live","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"Host: host=test | channel_account=moltis-bot | channel_chat_id=262872984 | data_dir=/home/moltis/.moltis"},{"role":"user","content":"Создай навык moltis-live-shaped для проверки live-shaped AfterLLM payload."}],"tool_count":37,"iteration":1}}
+EOF
+    after_skill_crud_live_output="$(
+        env PATH="$MINIMAL_PATH:/usr/bin" \
+            FASTPATH_LOG="$after_skill_crud_live_log" \
+            MOLTIS_RUNTIME_SKILLS_ROOT="$after_skill_crud_live_runtime" \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_FASTPATH=true \
+            MOLTIS_TELEGRAM_SAFE_DIRECT_SEND_SCRIPT="$after_skill_crud_live_send" \
+            MOLTIS_TELEGRAM_SAFE_LLM_GUARD_INTENT_DIR="$after_skill_crud_live_dir/intent" \
+            bash "$HOOK_SCRIPT" <<'EOF'
+{"event":"AfterLLMCall","data":{"session_key":"session:after-skill-crud-live","provider":"openai-codex","model":"openai-codex::gpt-5.4","messages":[{"role":"system","content":"The current user datetime is 2026-04-24 06:07:59 MSK."}],"text":"Сначала создам навык, потом дам краткий итог.","tool_calls":[{"arguments":{"name":"moltis-live-shaped","body":"---\nname: moltis-live-shaped\ndescription: Проверка live-shaped AfterLLM payload.\n---\n# moltis-live-shaped\n"},"id":"call_live_shaped_create","name":"create_skill"}]}}
+EOF
+    )"
+    if jq -e '.action == "modify"' >/dev/null 2>&1 <<<"$after_skill_crud_live_output" && \
+       jq -e '.data.text == ""' >/dev/null 2>&1 <<<"$after_skill_crud_live_output" && \
+       jq -e '.data.tool_calls == []' >/dev/null 2>&1 <<<"$after_skill_crud_live_output" && \
+       [[ -f "$after_skill_crud_live_skill_file" ]] && \
+       grep -Fq 'name: moltis-live-shaped' "$after_skill_crud_live_skill_file" && \
+       grep -Fq -- '--chat-id 262872984' "$after_skill_crud_live_log" && \
+       grep -Fq 'Создал базовый шаблон навыка `moltis-live-shaped`.' "$after_skill_crud_live_log"; then
+        test_pass
+    else
+        test_fail "AfterLLMCall direct skill CRUD must restore the Telegram chat_id from persisted session state when the live-shaped payload omits chat metadata"
     fi
 
     test_start "component_after_llm_guard_recovers_sparse_skill_create_when_live_after_llm_payload_omits_user_message"


### PR DESCRIPTION
## Что меняется
- сохраняется session-scoped Telegram chat_id для позднего AfterLLM direct skill CRUD
- skill visibility финализируется по exact runtime snapshot, а не по частичному совпадению текста модели
- добавлен RCA и новые регрессии под live-shaped AfterLLM payload

## Проверки
- bash tests/component/test_telegram_safe_llm_guard.sh
- bash tests/component/test_telegram_remote_uat_contract.sh